### PR TITLE
Removes RevokeHandler from JWT Introspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ imaginable and is built on top of Fosite.
     - [Code Examples](#code-examples)
     - [Exemplary Storage Implementation](#exemplary-storage-implementation)
     - [Extensible handlers](#extensible-handlers)
+    - [JWT Introspection](#jwt-introspection)
   - [Contribute](#contribute)
     - [Refresh mock objects](#refresh-mock-objects)
   - [Hall of Fame](#hall-of-fame)
@@ -335,6 +336,9 @@ Of course, fosite ships handlers for all OAuth2 and OpenID Connect flows.
  [Authentication using the Implicit Flow](http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth),
  [Authentication using the Hybrid Flow](http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth)
  
+### JWT Introspection
+
+Please note that when using the OAuth2StatelessJWTIntrospectionFactory access token revocation is not possible.
 
 This section is missing documentation and we welcome any contributions in that direction.
 

--- a/README.md
+++ b/README.md
@@ -335,12 +335,12 @@ Of course, fosite ships handlers for all OAuth2 and OpenID Connect flows.
  [Authentication using the Authorization Code Flow](http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth),
  [Authentication using the Implicit Flow](http://openid.net/specs/openid-connect-core-1_0.html#ImplicitFlowAuth),
  [Authentication using the Hybrid Flow](http://openid.net/specs/openid-connect-core-1_0.html#HybridFlowAuth)
+
+This section is missing documentation and we welcome any contributions in that direction.
  
 ### JWT Introspection
 
 Please note that when using the OAuth2StatelessJWTIntrospectionFactory access token revocation is not possible.
-
-This section is missing documentation and we welcome any contributions in that direction.
 
 ## Contribute
 

--- a/handler/oauth2/introspector_jwt.go
+++ b/handler/oauth2/introspector_jwt.go
@@ -35,9 +35,3 @@ func (v *StatelessJWTValidator) IntrospectToken(ctx context.Context, token strin
 	accessRequest.Merge(or)
 	return nil
 }
-
-// Revocation is not supported with the stateless validator. If you need revocation, use the
-// CoreValidator struct instead.
-func (v *StatelessJWTValidator) RevokeToken(ctx context.Context, token string, tokenType fosite.TokenType) error {
-	return errors.Wrap(fosite.ErrMisconfiguration, "Token revocation is not supported")
-}


### PR DESCRIPTION
RevokeHandler has been removed because it conflicts with Stateless JWT
accesstokens and revocable hmac refresh tokens. The readme has been
updated to warn users about possible misconfiguration.

Closes [154](https://github.com/ory/fosite/issues/154)