### PR TITLE
Get the token from the access_token query parameter

### DIFF
--- a/introspect.go
+++ b/introspect.go
@@ -13,10 +13,20 @@ type TokenIntrospector interface {
 }
 
 func AccessTokenFromRequest(req *http.Request) string {
+	// Acording to https://tools.ietf.org/html/rfc6750 you can pass tokens through:
+	// - Form-Encoded Body Parameter. Recomended, more likely to appear. e.g.: Authorization: Bearer mytoken123
+	// - URI Query Parameter e.g. access_token=mytoken123
+
 	auth := req.Header.Get("Authorization")
 	split := strings.SplitN(auth, " ", 2)
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {
-		return ""
+		// Nothing in Authorization header, try access_token
+		// Empty string returned if there's no such parameter
+		err := req.ParseForm()
+		if err != nil {
+			return ""
+		}
+		return req.Form.Get("access_token")
 	}
 
 	return split[1]


### PR DESCRIPTION
As discussed on Gitter some time ago - fosite needs to use _access_token_ query param. (https://tools.ietf.org/html/rfc6750)