### PR TITLE
Add key id to header

### DIFF
--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -25,6 +25,8 @@ func (j *RS256JWTStrategy) Generate(claims jwt.Claims, header Mapper) (string, s
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	token.Header = assign(token.Header, header.ToMap())
+	// "public" is understood to be the most recent keyid
+	token.Header["kid"] = "public"
 
 	var sig, sstr string
 	var err error


### PR DESCRIPTION
Adding key id to the header of the id token, per https://github.com/ory/hydra/issues/433.

This implies that the most recent active key is always named 'public'.

Signed-off-by: pbarker <pbarker@datapipe.com>