### PR TITLE
Remove forced nonce

### DIFF
--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -2,6 +2,7 @@ package openid
 
 import (
 	"encoding/gob"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -143,10 +144,9 @@ func (h DefaultStrategy) GenerateIDToken(_ context.Context, _ *http.Request, req
 
 	nonce := requester.GetRequestForm().Get("nonce")
 	// OPTIONAL. String value used to associate a Client session with an ID Token, and to mitigate replay attacks.
-	// Although optional, this is considered good practice and therefore enforced.
 	if len(nonce) < fosite.MinParameterEntropy {
 		// We're assuming that using less then 8 characters for the state can not be considered "unguessable"
-		return "", errors.WithStack(fosite.ErrInsufficientEntropy)
+		fmt.Println("WARNING: nonce token is missing or contains insufficient entropy")
 	}
 
 	claims.Nonce = nonce


### PR DESCRIPTION
Hey @arekkas, as you know I'm working on integrating Hydra with Kubernetes' RBAC system. Both Kubernetes and Dex aren't using a nonce when requesting an ID token. I know thats the recommended way of doing it, but its not required and may be substantially more difficult to push these things through upstream.

With this piece unblocked Hydra would be fully compatible with Kubernetes!

Signed-off-by: pbarker <pbarker@datapipe.com>