### PR TITLE
authorize code expire time isset after persist

### DIFF
--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -62,11 +62,11 @@ func (c *AuthorizeExplicitGrantHandler) IssueAuthorizeCode(ctx context.Context, 
 		return errors.Wrap(fosite.ErrServerError, err.Error())
 	}
 
+	ar.GetSession().SetExpiresAt(fosite.AuthorizeCode, time.Now().Add(c.AuthCodeLifespan))
 	if err := c.AuthorizeCodeGrantStorage.CreateAuthorizeCodeSession(ctx, signature, ar); err != nil {
 		return errors.Wrap(fosite.ErrServerError, err.Error())
 	}
 
-	ar.GetSession().SetExpiresAt(fosite.AuthorizeCode, time.Now().Add(c.AuthCodeLifespan))
 	resp.AddQuery("code", code)
 	resp.AddQuery("state", ar.GetState())
 	resp.AddQuery("scope", strings.Join(ar.GetGrantedScopes(), " "))


### PR DESCRIPTION
Authorize code expire time is set after the calling CreateAuthorizeCodeSession.
This way i cannot store the expire time in the database.

This is the same kinda issue as with the implicit code session expire time (other PR)