### PR TITLE
Add Argon2 Hasher

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 2f6fa8dc5ade79bbc0ed0d47b16040420f96011fc2d84185f1a9754285f60b87
-updated: 2017-05-15T09:35:06.156922857+02:00
+hash: f7a62d30538f7380d83a36c84be4a3c01430f374e212db3e540e7b0c0500d69b
+updated: 2017-05-19T18:13:54.528981+12:00
 imports:
 - name: github.com/asaskevich/govalidator
   version: 7b3beb6df3c42abd3509abfc3bcacc0fbfb7c877
@@ -9,6 +9,8 @@ imports:
   version: bd3c8e81be01eef76d4b503f5e687d2d1354d2d9
   subpackages:
   - gomock
+- name: github.com/lhecker/argon2
+  version: b3ac3756bd9227d6d4d5f9dec8142b1cd9ca6ac5
 - name: github.com/ory/common
   version: b6357395e30805e2ad1f6d8fb759fa2b7146d8da
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -24,6 +24,8 @@ import:
 - package: github.com/ory/common
   subpackages:
   - pkg
+- package: github.com/lhecker/argon2
+  version: b3ac3756bd9227d6d4d5f9dec8142b1cd9ca6ac5
 testImport:
 - package: github.com/gorilla/mux
   version: ~1.1.0

--- a/hash_argon2.go
+++ b/hash_argon2.go
@@ -1,0 +1,50 @@
+package fosite
+
+import (
+	"github.com/lhecker/argon2"
+	"github.com/pkg/errors"
+)
+
+// Argon2 implements the Hasher interface by using github.com/lhecker/Argon2.
+//
+// Issues related to building and developing on Windows:
+//   For Argon2 Hasher to work on Windows you will require a compatible CGO environment.
+//   for 32-bit Windows:
+// 	* Install [MinGW for x86](https://sourceforge.net/projects/mingw/files/latest/download?source=files)
+//	* Add `C:\MinGW\bin` to path
+//	* Select and install `gcc-core`
+//	* Select and install `gcc-g++`
+//	* Build successfully!
+//   For 64-bit Windows:
+// 	* Install [Cygwin]()
+//	* Add `C:\cygwin64\bin` to path
+// 	* Select and Install `x86_64-w64-mingw32-gcc-core`
+// 	* Select and Install `x86_64-w64-mingw32-gcc-g++`
+//	* Change all file names in `C:\cygwin64\bin` by removing `x86_64-w64-mingw32-` which is prepended to all files we need to use..
+//	* Build successfully!
+type Argon2 struct {
+	Config argon2.Config
+}
+
+// Compare compares data with an Argon2 hash and returns an error
+// if the two do not match.
+func (a *Argon2) Compare(hash, data []byte) error {
+	ok, err := argon2.VerifyEncoded(data, hash)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	if !ok {
+		return ErrRequestUnauthorized
+	}
+	return nil
+}
+
+// Hash creates a Argon2 hash from data or returns an error.
+// The salt is automatically generated based on the length of the Salt as specified by Config.SaltLength
+func (a *Argon2) Hash(data []byte) ([]byte, error) {
+	s, err := a.Config.HashEncoded(data)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return s, nil
+}

--- a/hash_argon2_test.go
+++ b/hash_argon2_test.go
@@ -1,0 +1,74 @@
+package fosite
+
+import (
+	"testing"
+
+	"github.com/lhecker/argon2"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestArgon2Hash ensures that a hash is returned from the Argon2 Hasher
+func TestArgon2Hash(t *testing.T) {
+	h := &Argon2{
+		Config: argon2.DefaultConfig(),
+	}
+	password := []byte("foo")
+	hash, err := h.Hash(password)
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+	assert.NotEqual(t, hash, password)
+}
+
+// TestArgon2HashLibErr purposely causes the underlying argon2 lib to error to ensure it is reported up the stack
+func TestArgon2HashLibErr(t *testing.T) {
+	h := &Argon2{
+		Config: argon2.DefaultConfig(),
+	}
+	h.Config.MemoryCost = 1
+	password := []byte("foo")
+	hash, err := h.Hash(password)
+	assert.Empty(t, hash)
+	assert.NotNil(t, err)
+	assert.NotEqual(t, hash, password)
+}
+
+// TestArgon2CompareEquals ensures a password can be verified successfully when decoded
+func TestArgon2CompareEquals(t *testing.T) {
+	h := &Argon2{
+		Config: argon2.DefaultConfig(),
+	}
+	password := []byte("foo")
+	hash, err := h.Hash(password)
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+	err = h.Compare(hash, password)
+	assert.Nil(t, err)
+}
+
+// TestArgon2CompareEquals ensures a compare errors when a presented clear text password does not match the original
+func TestArgon2CompareDifferent(t *testing.T) {
+	h := &Argon2{
+		Config: argon2.DefaultConfig(),
+	}
+	password := []byte("foo")
+	hash, err := h.Hash(password)
+	assert.Nil(t, err)
+	assert.NotNil(t, hash)
+	err = h.Compare(hash, []byte(uuid.NewRandom()))
+	assert.NotNil(t, err)
+}
+
+// TestArgon2HashLibErr purposely causes the underlying argon2 lib to error to ensure it is reported up the stack
+func TestArgon2CompareLibErr(t *testing.T) {
+	h := &Argon2{
+		Config: argon2.DefaultConfig(),
+	}
+	h.Config.MemoryCost = 1
+	password := []byte("foo")
+	hash, err := h.Hash(password)
+	assert.Empty(t, hash)
+	assert.NotNil(t, err)
+	err = h.Compare(hash, []byte(uuid.NewRandom()))
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Implements an Argon2 based Hasher for fosite!

## Development Notes
Issues related to building and developing on Windows:
- **For Argon2 Hasher to work on Windows you will require a compatible CGO environment.**
### For Linux
- Install gcc

### For 32-bit Windows:
- Install [MinGW for x86](https://sourceforge.net/projects/mingw/files/latest/download?source=files)
- Add `C:\MinGW\bin` to path
- Select and install `gcc-core`
- Select and install `gcc-g++`
- Build successfully!

### For 64-bit Windows:
- Install [Cygwin]()
- Add `C:\cygwin64\bin` to path
- Select and Install `x86_64-w64-mingw32-gcc-core`
- Select and Install `x86_64-w64-mingw32-gcc-g++`
- Change all file names in `C:\cygwin64\bin` by removing `x86_64-w64-mingw32-` which is prepended to all files we need to use..
- Build successfully!