### PR TITLE
Enable fosite composing with custom hashers.

### DIFF
--- a/integration/authorize_code_grant_test.go
+++ b/integration/authorize_code_grant_test.go
@@ -22,7 +22,7 @@ func TestAuthorizeCodeFlow(t *testing.T) {
 }
 
 func runAuthorizeCodeGrantTest(t *testing.T, strategy interface{}) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2AuthorizeExplicitFactory, compose.OAuth2TokenIntrospectionFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2AuthorizeExplicitFactory, compose.OAuth2TokenIntrospectionFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 

--- a/integration/authorize_implicit_grant_test.go
+++ b/integration/authorize_implicit_grant_test.go
@@ -26,7 +26,7 @@ func TestAuthorizeImplicitFlow(t *testing.T) {
 }
 
 func runTestAuthorizeImplicitGrant(t *testing.T, strategy interface{}) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2AuthorizeImplicitFactory, compose.OAuth2TokenIntrospectionFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2AuthorizeImplicitFactory, compose.OAuth2TokenIntrospectionFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 

--- a/integration/client_credentials_grant_test.go
+++ b/integration/client_credentials_grant_test.go
@@ -20,7 +20,7 @@ func TestClientCredentialsFlow(t *testing.T) {
 }
 
 func runClientCredentialsGrantTest(t *testing.T, strategy oauth2.AccessTokenStrategy) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2ClientCredentialsGrantFactory, compose.OAuth2TokenIntrospectionFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2ClientCredentialsGrantFactory, compose.OAuth2TokenIntrospectionFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 

--- a/integration/introspect_token_test.go
+++ b/integration/introspect_token_test.go
@@ -42,7 +42,7 @@ func TestIntrospectToken(t *testing.T) {
 }
 
 func runIntrospectTokenTest(t *testing.T, strategy oauth2.AccessTokenStrategy, introspectionFactory compose.Factory) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2ClientCredentialsGrantFactory, introspectionFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2ClientCredentialsGrantFactory, introspectionFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 

--- a/integration/refresh_token_grant_test.go
+++ b/integration/refresh_token_grant_test.go
@@ -27,6 +27,7 @@ func runRefreshTokenGrantTest(t *testing.T, strategy interface{}) {
 		new(compose.Config),
 		fositeStore,
 		strategy,
+		nil,
 		compose.OAuth2AuthorizeExplicitFactory,
 		compose.OAuth2RefreshTokenGrantFactory,
 		compose.OAuth2TokenIntrospectionFactory,

--- a/integration/resource_owner_password_credentials_grant_test.go
+++ b/integration/resource_owner_password_credentials_grant_test.go
@@ -20,7 +20,7 @@ func TestResourceOwnerPasswordCredentialsFlow(t *testing.T) {
 }
 
 func runResourceOwnerPasswordCredentialsGrantTest(t *testing.T, strategy hst.AccessTokenStrategy) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2ResourceOwnerPasswordCredentialsFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2ResourceOwnerPasswordCredentialsFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 

--- a/integration/revoke_token_test.go
+++ b/integration/revoke_token_test.go
@@ -23,7 +23,7 @@ func TestRevokeToken(t *testing.T) {
 }
 
 func runRevokeTokenTest(t *testing.T, strategy oauth2.AccessTokenStrategy) {
-	f := compose.Compose(new(compose.Config), fositeStore, strategy, compose.OAuth2ClientCredentialsGrantFactory, compose.OAuth2TokenIntrospectionFactory, compose.OAuth2TokenRevocationFactory)
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2ClientCredentialsGrantFactory, compose.OAuth2TokenIntrospectionFactory, compose.OAuth2TokenRevocationFactory)
 	ts := mockServer(t, f, &fosite.DefaultSession{})
 	defer ts.Close()
 


### PR DESCRIPTION
Makes it a little easier for composing, plus follows the same conventions as storage. Seeks to keep compatibility by setting BCrypt as the default hasher if one isn't set.

Signed-off-by: Matthew Hartstonge <matt@mykro.co.nz>