### PR TITLE
handler/oauth2: grant scopes before the access token is generated

### DIFF
--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -81,13 +81,13 @@ func (c *AuthorizeExplicitGrantHandler) PopulateTokenEndpointResponse(ctx contex
 		return errors.Wrap(fosite.ErrInvalidRequest, err.Error())
 	}
 
+	for _, scope := range authorizeRequest.GetGrantedScopes() {
+		requester.GrantScope(scope)
+	}
+
 	access, accessSignature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, requester)
 	if err != nil {
 		return errors.Wrap(fosite.ErrServerError, err.Error())
-	}
-
-	for _, scope := range authorizeRequest.GetGrantedScopes() {
-		requester.GrantScope(scope)
 	}
 
 	var refresh, refreshSignature string


### PR DESCRIPTION
Hi!
JWT access token does not contain any granted scopes in "scp" claim. This is because the access token is generated before the scopes are granted.