### PR TITLE
Update test command in README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ To make a pull request, you will need a GitHub account; if you are unclear on th
 
 1. Create a feature branch off of `master` so that changes do not get mixed up.
 1. [Rebase](https://git-scm.com/book/en/Git-Branching-Rebasing) your local changes against the `master` branch.
-1. Run the full project test suite with the `go test ./...` (or equivalent) command and confirm that it passes.
+1. Run the full project test suite with the `go test $(glide novendor)` (or equivalent) command and confirm that it passes.
 1. Run `gofmt -s` (if the project is written in Go).
 1. Accept the Developer's Certificate of Origin on all commits (see above).
 1. Ensure that each commit has a subsystem prefix (ex: `controller: `).

--- a/README.md
+++ b/README.md
@@ -351,10 +351,10 @@ go get -d github.com/ory/fosite
 cd $GOPATH/src/github.com/ory/fosite
 git status
 git remote add myfork <url-to-your-fork>
-go test ./...
+go test $(glide novendor)
 ```
 
-Simple, right? Now you are ready to go! Make sure to run `go test ./...` often, detecting problems with your code
+Simple, right? Now you are ready to go! Make sure to run `go test $(glide novendor)` often, detecting problems with your code
 rather sooner than later. Please read [CONTRIBUTE.md] before creating pull requests and issues.
 
 ### Refresh mock objects


### PR DESCRIPTION
Running `go test ./...` fails, even with everything installed. Travis seems to be running the equivalent of `go test $(glide novendor)` and this is what Hydra is doing, so I'm assuming this is more correct.