### PR TITLE
oauth2/introspector: remove auth code, refresh scopes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -19,6 +19,11 @@ bumps (`0.1.0` -> `0.2.0`).
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 0.10.0
+
+It is no longer possible to introspect authorize codes, and passing scopes to the introspector now also checks
+refresh token scopes.
+
 ## 0.9.0
 
 This patch adds the ability to pass a custom hasher to `compose.Compose`, which is a breaking change. You can pass nil for the fosite default hasher:

--- a/handler/oauth2/introspector_test.go
+++ b/handler/oauth2/introspector_test.go
@@ -37,8 +37,6 @@ func TestIntrospectToken(t *testing.T) {
 				store.EXPECT().GetAccessTokenSession(nil, "", nil).Return(nil, errors.New(""))
 				chgen.EXPECT().RefreshTokenSignature("").Return("")
 				store.EXPECT().GetRefreshTokenSession(nil, "", nil).Return(nil, errors.New(""))
-				chgen.EXPECT().AuthorizeCodeSignature("").Return("")
-				store.EXPECT().GetAuthorizeCodeSession(nil, "", nil).Return(nil, errors.New(""))
 			},
 			expectErr: fosite.ErrRequestUnauthorized,
 		},
@@ -50,8 +48,6 @@ func TestIntrospectToken(t *testing.T) {
 				store.EXPECT().GetAccessTokenSession(nil, "asdf", nil).Return(nil, errors.New(""))
 				chgen.EXPECT().RefreshTokenSignature("1234").Return("asdf")
 				store.EXPECT().GetRefreshTokenSession(nil, "asdf", nil).Return(nil, errors.New(""))
-				chgen.EXPECT().AuthorizeCodeSignature("1234").Return("asdf")
-				store.EXPECT().GetAuthorizeCodeSession(nil, "asdf", nil).Return(nil, errors.New(""))
 			},
 			expectErr: fosite.ErrRequestUnauthorized,
 		},
@@ -62,8 +58,6 @@ func TestIntrospectToken(t *testing.T) {
 				chgen.EXPECT().ValidateAccessToken(nil, areq, "1234").Return(errors.WithStack(fosite.ErrTokenExpired))
 				chgen.EXPECT().RefreshTokenSignature("1234").Return("asdf")
 				store.EXPECT().GetRefreshTokenSession(nil, "asdf", nil).Return(nil, errors.New(""))
-				chgen.EXPECT().AuthorizeCodeSignature("1234").Return("asdf")
-				store.EXPECT().GetAuthorizeCodeSession(nil, "asdf", nil).Return(nil, errors.New(""))
 			},
 			expectErr: fosite.ErrTokenExpired,
 		},


### PR DESCRIPTION
Removes authorize code introspection in the HMAC-based strategy and now checks scopes of refresh tokens as well.