### PR TITLE
Configure core validator with access only option

### DIFF
--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -81,10 +81,10 @@ func OAuth2TokenRevocationFactory(config *Config, storage interface{}, strategy 
 // an access token and refresh token validator.
 func OAuth2TokenIntrospectionFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.CoreValidator{
-		CoreStrategy:  strategy.(oauth2.CoreStrategy),
-		CoreStorage:   storage.(oauth2.CoreStorage),
-		AccessOnly:    config.GetAccessOnly(),
-		ScopeStrategy: config.GetScopeStrategy(),
+		CoreStrategy:                  strategy.(oauth2.CoreStrategy),
+		CoreStorage:                   storage.(oauth2.CoreStorage),
+		ScopeStrategy:                 config.GetScopeStrategy(),
+		DisableRefreshTokenValidation: config.DisableRefreshTokenValidation,
 	}
 }
 

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -83,6 +83,7 @@ func OAuth2TokenIntrospectionFactory(config *Config, storage interface{}, strate
 	return &oauth2.CoreValidator{
 		CoreStrategy:  strategy.(oauth2.CoreStrategy),
 		CoreStorage:   storage.(oauth2.CoreStorage),
+		AccessOnly:    config.GetAccessOnly(),
 		ScopeStrategy: config.GetScopeStrategy(),
 	}
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -19,8 +19,8 @@ type Config struct {
 	// HashCost sets the cost of the password hashing cost. Defaults to 12.
 	HashCost int
 
-	// AccessOnly sets whether the introspection endpoint only validates access tokens.
-	AccessOnly bool
+	// DisableRefreshTokenValidation sets the introspection endpoint to disable refresh token validation.
+	DisableRefreshTokenValidation bool
 
 	ScopeStrategy fosite.ScopeStrategy
 }
@@ -63,9 +63,4 @@ func (c *Config) GetHashCost() int {
 		return 12
 	}
 	return c.HashCost
-}
-
-// GetAccessOnly returns whether the introspection endpoint only validates access tokens.
-func (c *Config) GetAccessOnly() bool {
-	return c.AccessOnly
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	// HashCost sets the cost of the password hashing cost. Defaults to 12.
 	HashCost int
 
+	// AccessOnly sets whether the introspection endpoint only validates access tokens.
+	AccessOnly bool
+
 	ScopeStrategy fosite.ScopeStrategy
 }
 
@@ -60,4 +63,9 @@ func (c *Config) GetHashCost() int {
 		return 12
 	}
 	return c.HashCost
+}
+
+// GetAccessOnly returns whether the introspection endpoint only validates access tokens.
+func (c *Config) GetAccessOnly() bool {
+	return c.AccessOnly
 }

--- a/handler/oauth2/introspector.go
+++ b/handler/oauth2/introspector.go
@@ -10,10 +10,19 @@ import (
 type CoreValidator struct {
 	CoreStrategy
 	CoreStorage
+	AccessOnly    bool
 	ScopeStrategy fosite.ScopeStrategy
 }
 
 func (c *CoreValidator) IntrospectToken(ctx context.Context, token string, tokenType fosite.TokenType, accessRequest fosite.AccessRequester, scopes []string) (err error) {
+	if c.AccessOnly {
+		if err = c.introspectAccessToken(ctx, token, accessRequest, scopes); err == nil {
+			return nil
+		}
+
+		return err
+	}
+
 	switch tokenType {
 	case fosite.RefreshToken:
 		if err = c.introspectRefreshToken(ctx, token, accessRequest, scopes); err == nil {

--- a/handler/oauth2/introspector.go
+++ b/handler/oauth2/introspector.go
@@ -10,17 +10,13 @@ import (
 type CoreValidator struct {
 	CoreStrategy
 	CoreStorage
-	AccessOnly    bool
-	ScopeStrategy fosite.ScopeStrategy
+	ScopeStrategy                 fosite.ScopeStrategy
+	DisableRefreshTokenValidation bool
 }
 
 func (c *CoreValidator) IntrospectToken(ctx context.Context, token string, tokenType fosite.TokenType, accessRequest fosite.AccessRequester, scopes []string) (err error) {
-	if c.AccessOnly {
-		if err = c.introspectAccessToken(ctx, token, accessRequest, scopes); err == nil {
-			return nil
-		}
-
-		return err
+	if c.DisableRefreshTokenValidation {
+		return c.introspectAccessToken(ctx, token, accessRequest, scopes)
 	}
 
 	switch tokenType {

--- a/handler/oauth2/introspector_test.go
+++ b/handler/oauth2/introspector_test.go
@@ -62,6 +62,14 @@ func TestIntrospectToken(t *testing.T) {
 			expectErr: fosite.ErrTokenExpired,
 		},
 		{
+			description: "should fail because access token invalid",
+			setup: func() {
+				v.DisableRefreshTokenValidation = true
+				chgen.EXPECT().ValidateAccessToken(nil, areq, "1234").Return(errors.WithStack(fosite.ErrInvalidTokenFormat))
+			},
+			expectErr: fosite.ErrInvalidTokenFormat,
+		},
+		{
 			description: "should pass",
 			setup: func() {
 				chgen.EXPECT().ValidateAccessToken(nil, areq, "1234").Return(nil)


### PR DESCRIPTION
My attempt to make the core validator configurable refer to #207. If you agree on the direction I'll write tests for the case that `AccessOnly` is turned on.