### PR TITLE
Set expires at for password credentials flow

### DIFF
--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"fmt"
+	"time"
 
 	"context"
 
@@ -50,6 +51,8 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 
 	// Credentials must not be passed around, potentially leaking to the database!
 	delete(request.GetRequestForm(), "password")
+
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().Add(c.AccessTokenLifespan))
 	return nil
 }
 

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -32,6 +32,7 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 		description string
 		setup       func()
 		expectErr   error
+		check       func(areq *fosite.AccessRequest)
 	}{
 		{
 			description: "should fail because not responsible",
@@ -64,12 +65,18 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 			setup: func() {
 				store.EXPECT().Authenticate(nil, "peter", "pan").Return(nil)
 			},
+			check: func(areq *fosite.AccessRequest) {
+				assert.NotEmpty(t, areq.GetSession().GetExpiresAt(fosite.AccessToken))
+			},
 		},
 	} {
 		c.setup()
 		err := h.HandleTokenEndpointRequest(nil, areq)
 		assert.True(t, errors.Cause(err) == c.expectErr, "(%d) %s\n%s\n%s", k, c.description, err, c.expectErr)
 		t.Logf("Passed test case %d", k)
+		if c.check != nil {
+			c.check(areq)
+		}
 	}
 }
 

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -17,7 +17,7 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 	store := internal.NewMockResourceOwnerPasswordCredentialsGrantStorage(ctrl)
 	defer ctrl.Finish()
 
-	areq := fosite.NewAccessRequest(nil)
+	areq := fosite.NewAccessRequest(new(fosite.DefaultSession))
 	areq.Form = url.Values{}
 
 	h := ResourceOwnerPasswordCredentialsGrantHandler{


### PR DESCRIPTION
Noticed that expires at is not set in the session by default unlike the authorize code, client credential and refresh flows.