### PR TITLE
handler/oauth2: set expiration time before the access token is generated

### DIFF
--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -55,13 +55,14 @@ func (c *AuthorizeImplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx c
 }
 
 func (c *AuthorizeImplicitGrantTypeHandler) IssueImplicitAccessToken(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
+	ar.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().Add(c.AccessTokenLifespan))
+
 	// Generate the code
 	token, signature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, ar)
 	if err != nil {
 		return errors.Wrap(fosite.ErrServerError, err.Error())
 	}
 
-	ar.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().Add(c.AccessTokenLifespan))
 	if err := c.AccessTokenStorage.CreateAccessTokenSession(ctx, signature, ar); err != nil {
 		return errors.Wrap(fosite.ErrServerError, err.Error())
 	}


### PR DESCRIPTION
Hi!
JWT access token has invalid value in "exp" claim if implicit flow is used. This is because the token is generated before it is assigned an expiration time.