### PR TITLE
Introspection: Decode of Basic Authorization username/password

### DIFF
--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -17,6 +17,7 @@ package fosite
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"fmt"
@@ -122,12 +123,21 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}
 	} else {
-		clientID, clientSecret, ok := r.BasicAuth()
+		id, secret, ok := r.BasicAuth()
 		if !ok {
+			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
+		}
+		clientID, err := url.QueryUnescape(id)
+		if err != nil {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}
 
 		client, err := f.Store.GetClient(ctx, clientID)
+		if err != nil {
+			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
+		}
+
+		clientSecret, err := url.QueryUnescape(secret)
 		if err != nil {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -127,17 +127,18 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 		if !ok {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}
+
 		clientID, err := url.QueryUnescape(id)
 		if err != nil {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}
 
-		client, err := f.Store.GetClient(ctx, clientID)
+		clientSecret, err := url.QueryUnescape(secret)
 		if err != nil {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}
 
-		clientSecret, err := url.QueryUnescape(secret)
+		client, err := f.Store.GetClient(ctx, clientID)
 		if err != nil {
 			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithDebug("HTTP Authorization header missing.WithDebug(malformed or credentials used are invalid"))
 		}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -65,6 +65,14 @@ func NewExampleStore() *MemoryStore {
 				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 				Scopes:        []string{"fosite", "openid", "photos", "offline"},
 			},
+			"encoded:client": {
+				ID:            "encoded:client",
+				Secret:        []byte(`$2a$10$A7M8b65dSSKGHF0H2sNkn.9Z0hT8U1Nv6OWPV3teUUaczXkVkxuDS`), // = "encoded&password"
+				RedirectURIs:  []string{"http://localhost:3846/callback"},
+				ResponseTypes: []string{"id_token", "code", "token"},
+				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+				Scopes:        []string{"fosite", "openid", "photos", "offline"},
+			},
 		},
 		Users: map[string]MemoryUserRelation{
 			"peter": {


### PR DESCRIPTION
Signed-off-by: Dmitry Dolbik <dolbik@gmail.com>

Introspection handler does not decode a valid encoded username and password on Basic Authorization process.
For example access_request_handler Basic Authorization parameters decoded properly

Basic Authorization behaviour of endpoints should be the same i think