### PR TITLE
handler: Adds PKCE implementation for none and S256

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 Ory GmbH & Aeneas Rekkas
+   Copyright 2016 - 2018 Ory GmbH & Aeneas Rekkas
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ includes all flows: code, implicit, hybrid.
 This library considered and implemented:
 * [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
 * [OAuth 2.0 Multiple Response Type Encoding Practices](https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html)
-* [OAuth 2.0 Threat Model and Security Considerations](https://tools.ietf.org/html/rfc6819) (partially)
-* [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html) (partially)
+* [OAuth 2.0 Threat Model and Security Considerations](https://tools.ietf.org/html/rfc6819)
+* [Proof Key for Code Exchange by OAuth Public Clients](https://tools.ietf.org/html/rfc7636)
+* [OAuth 2.0 for Native Apps](https://tools.ietf.org/html/rfc8252)
+* [OpenID Connect Core 1.0](https://openid.net/specs/openid-connect-core-1_0.html)
 
 OAuth2 and OpenID Connect are difficult protocols. If you want quick wins, we strongly encourage you to look at [Hydra](https://github.com/ory-am/hydra).
 Hydra is a secure, high performance, cloud native OAuth2 and OpenID Connect service that integrates with every authentication method

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -95,6 +95,8 @@ func ComposeAllEnabled(config *Config, storage interface{}, secret []byte, key *
 		OAuth2RefreshTokenGrantFactory,
 		OAuth2ResourceOwnerPasswordCredentialsFactory,
 
+		OAuth2PKCEFactory,
+
 		OpenIDConnectExplicitFactory,
 		OpenIDConnectImplicitFactory,
 		OpenIDConnectHybridFactory,

--- a/compose/compose_pkce.go
+++ b/compose/compose_pkce.go
@@ -10,7 +10,7 @@ func OAuth2PKCEFactory(config *Config, storage interface{}, strategy interface{}
 	return &pkce.Handler{
 		AuthorizeCodeStrategy: strategy.(oauth2.AuthorizeCodeStrategy),
 		CoreStorage:           storage.(oauth2.CoreStorage),
-		Force:                 !config.AllowPublicAuthCodeFlowWithoutPKCE,
-		EnablePlainChallengeMethod: !config.EnablePKCEPlainChallengeMethod,
+		Force:                 config.EnforcePKCE,
+		EnablePlainChallengeMethod: config.EnablePKCEPlainChallengeMethod,
 	}
 }

--- a/compose/compose_pkce.go
+++ b/compose/compose_pkce.go
@@ -1,0 +1,16 @@
+package compose
+
+import (
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/handler/pkce"
+)
+
+// OAuth2PKCEFactory creates a PKCE handler.
+func OAuth2PKCEFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
+	return &pkce.Handler{
+		AuthorizeCodeStrategy: strategy.(oauth2.AuthorizeCodeStrategy),
+		CoreStorage:           storage.(oauth2.CoreStorage),
+		Force:                 !config.AllowPublicAuthCodeFlowWithoutPKCE,
+		EnablePlainChallengeMethod: !config.EnablePKCEPlainChallengeMethod,
+	}
+}

--- a/compose/config.go
+++ b/compose/config.go
@@ -44,8 +44,8 @@ type Config struct {
 	// ScopeStrategy sets the scope strategy that should be supported, for example fosite.WildcardScopeStrategy.
 	ScopeStrategy fosite.ScopeStrategy
 
-	// AllowPublicAuthCodeFlowWithoutPKCE, if set to true, allows public clients to perform authorize code flows without PKCE. Defaults to false.
-	AllowPublicAuthCodeFlowWithoutPKCE bool
+	// EnforcePKCE, if set to true, requires public clients to perform authorize code flows with PKCE. Defaults to false.
+	EnforcePKCE bool
 
 	// EnablePKCEPlainChallengeMethod sets whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged). Defaults to false.
 	EnablePKCEPlainChallengeMethod bool

--- a/compose/config.go
+++ b/compose/config.go
@@ -43,6 +43,12 @@ type Config struct {
 
 	// ScopeStrategy sets the scope strategy that should be supported, for example fosite.WildcardScopeStrategy.
 	ScopeStrategy fosite.ScopeStrategy
+
+	// AllowPublicAuthCodeFlowWithoutPKCE, if set to true, allows public clients to perform authorize code flows without PKCE. Defaults to false.
+	AllowPublicAuthCodeFlowWithoutPKCE bool
+
+	// EnablePKCEPlainChallengeMethod sets whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged). Defaults to false.
+	EnablePKCEPlainChallengeMethod bool
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.

--- a/errors.go
+++ b/errors.go
@@ -252,3 +252,9 @@ func (e *RFC6749Error) WithDebug(debug string) *RFC6749Error {
 	err.Debug = debug
 	return &err
 }
+
+func (e *RFC6749Error) WithDescription(description string) *RFC6749Error {
+	err := *e
+	err.Description = description
+	return &err
+}

--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -1,0 +1,176 @@
+package pkce
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/pkg/errors"
+)
+
+type Handler struct {
+	// If set to true, public clients must use PKCE.
+	Force bool
+
+	// Whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged).
+	EnablePlainChallengeMethod bool
+
+	AuthorizeCodeStrategy oauth2.AuthorizeCodeStrategy
+	CoreStorage           oauth2.CoreStorage
+}
+
+func (c *Handler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
+	// This let's us define multiple response types, for example open id connect's id_token
+	if !ar.GetResponseTypes().Exact("code") {
+		return nil
+	}
+
+	if !ar.GetClient().IsPublic() {
+		return nil
+	}
+
+	challenge := ar.GetRequestForm().Get("code_challenge")
+	method := ar.GetRequestForm().Get("code_challenge_method")
+	return c.validate(challenge, method)
+}
+
+func (c *Handler) validate(challenge, method string) error {
+	if c.Force && challenge == "" {
+		//If the server requires Proof Key for Code Exchange (PKCE) by OAuth
+		//public clients and the client does not send the "code_challenge" in
+		//the request, the authorization endpoint MUST return the authorization
+		//error response with the "error" value set to "invalid_request".  The
+		//"error_description" or the response of "error_uri" SHOULD explain the
+		//nature of error, e.g., code challenge required.
+
+		return errors.WithStack(fosite.ErrInvalidRequest.
+			WithDescription("Public clients must include a code_challenge when performing the authorize code flow, but it is missing.").
+			WithDebug("The server is configured in a way that enforces PKCE for public clients."))
+	}
+
+	if !c.Force && challenge == "" {
+		return nil
+	}
+
+	//If the server supporting PKCE does not support the requested
+	//transformation, the authorization endpoint MUST return the
+	//authorization error response with "error" value set to
+	//"invalid_request".  The "error_description" or the response of
+	//"error_uri" SHOULD explain the nature of error, e.g., transform
+	//algorithm not supported.
+	switch method {
+	case "S256":
+		break
+	case "plain":
+		fallthrough
+	case "":
+		if !c.EnablePlainChallengeMethod {
+			return errors.WithStack(fosite.ErrInvalidRequest.
+				WithDescription("Public clients must use code_challenge_method=S256, plain is not allowed.").
+				WithDebug("The server is configured in a way that enforces PKCE S256 as challenge method for public clients."))
+		}
+		break
+	default:
+		return errors.WithStack(fosite.ErrInvalidRequest.
+			WithDescription("The code_challenge_method is not supported, use S256 instead."))
+	}
+	return nil
+}
+
+func (c *Handler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
+	// This let's us define multiple response types, for example open id connect's id_token
+	if !request.GetGrantTypes().Exact("authorization_code") {
+		return errors.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	if !request.GetClient().IsPublic() {
+		return errors.WithStack(fosite.ErrUnknownRequest)
+	}
+
+	code := request.GetRequestForm().Get("code")
+	signature := c.AuthorizeCodeStrategy.AuthorizeCodeSignature(code)
+	authorizeRequest, err := c.CoreStorage.GetAuthorizeCodeSession(ctx, signature, request.GetSession())
+	if err != nil {
+		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+	}
+
+	//code_verifier
+	//REQUIRED.  Code verifier
+	//
+	//The "code_challenge_method" is bound to the Authorization Code when
+	//the Authorization Code is issued.  That is the method that the token
+	//endpoint MUST use to verify the "code_verifier".
+	verifier := request.GetRequestForm().Get("code_verifier")
+	challenge := authorizeRequest.GetRequestForm().Get("code_challenge")
+	method := authorizeRequest.GetRequestForm().Get("code_challenge_method")
+	if err := c.validate(challenge, method); err != nil {
+		return err
+	}
+
+	if !c.Force && challenge == "" && verifier == "" {
+		return nil
+	}
+
+	//Upon receipt of the request at the token endpoint, the server
+	//verifies it by calculating the code challenge from the received
+	//"code_verifier" and comparing it with the previously associated
+	//"code_challenge", after first transforming it according to the
+	//"code_challenge_method" method specified by the client.
+	//
+	//	If the "code_challenge_method" from Section 4.3 was "S256", the
+	//received "code_verifier" is hashed by SHA-256, base64url-encoded, and
+	//then compared to the "code_challenge", i.e.:
+	//
+	//BASE64URL-ENCODE(SHA256(ASCII(code_verifier))) == code_challenge
+	//
+	//If the "code_challenge_method" from Section 4.3 was "plain", they are
+	//compared directly, i.e.:
+	//
+	//code_verifier == code_challenge.
+	//
+	//	If the values are equal, the token endpoint MUST continue processing
+	//as normal (as defined by OAuth 2.0 [RFC6749]).  If the values are not
+	//equal, an error response indicating "invalid_grant" as described in
+	//Section 5.2 of [RFC6749] MUST be returned.
+	switch method {
+	case "S256":
+		verifierLength := base64.RawURLEncoding.DecodedLen(len(verifier))
+
+		// NOTE: The code verifier SHOULD have enough entropy to make it
+		//	impractical to guess the value.  It is RECOMMENDED that the output of
+		//	a suitable random number generator be used to create a 32-octet
+		//	sequence.  The octet sequence is then base64url-encoded to produce a
+		//	43-octet URL safe string to use as the code verifier.
+		if verifierLength < 32 {
+			return errors.WithStack(fosite.ErrInsufficientEntropy.
+				WithDebug("The PKCE code verifier must contain at least 32 octets."))
+		}
+
+		verifierBytes := make([]byte, verifierLength)
+		if _, err := base64.RawURLEncoding.Decode(verifierBytes, []byte(verifier)); err != nil {
+			return errors.WithStack(fosite.ErrInvalidGrant.WithDescription("Unable to decode code_verifier using base64 url decoding without padding.").WithDebug(err.Error()))
+		}
+
+		hash := sha256.New()
+		if _, err := hash.Write([]byte(verifier)); err != nil {
+			return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		}
+
+		if base64.RawURLEncoding.EncodeToString(hash.Sum([]byte{})) != challenge {
+			return errors.WithStack(fosite.ErrInvalidGrant.
+				WithDebug("The PKCE code challenge did not match the code verifier."))
+		}
+		break
+	case "plain":
+		fallthrough
+	default:
+		if verifier != challenge {
+			return errors.WithStack(fosite.ErrInvalidGrant.
+				WithDebug("The PKCE code challenge did not match the code verifier."))
+		}
+	}
+
+	return nil
+}

--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -174,3 +174,7 @@ func (c *Handler) HandleTokenEndpointRequest(ctx context.Context, request fosite
 
 	return nil
 }
+
+func (c *Handler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
+	return nil
+}

--- a/handler/pkce/handler_test.go
+++ b/handler/pkce/handler_test.go
@@ -1,0 +1,282 @@
+package pkce
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"testing"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCodeStrategy struct {
+	signature string
+}
+
+func (m *mockCodeStrategy) AuthorizeCodeSignature(token string) string {
+	return m.signature
+}
+
+func (m *mockCodeStrategy) GenerateAuthorizeCode(ctx context.Context, requester fosite.Requester) (token string, signature string, err error) {
+	return "", "", nil
+}
+
+func (m *mockCodeStrategy) ValidateAuthorizeCode(ctx context.Context, requester fosite.Requester, token string) (err error) {
+	return nil
+}
+
+func TestPKCEHandleAuthorizeEndpointRequest(t *testing.T) {
+	h := &Handler{}
+	w := fosite.NewAuthorizeResponse()
+	r := fosite.NewAuthorizeRequest()
+	c := &fosite.DefaultClient{}
+	r.Client = c
+
+	r.Form.Add("code_challenge", "challenge")
+	r.Form.Add("code_challenge_method", "plain")
+
+	r.ResponseTypes = fosite.Arguments{}
+	require.NoError(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+
+	r.ResponseTypes = fosite.Arguments{"code"}
+	require.NoError(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+
+	c.Public = true
+	h.EnablePlainChallengeMethod = true
+	require.NoError(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+
+	h.EnablePlainChallengeMethod = false
+	require.Error(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+
+	r.Form.Set("code_challenge_method", "S256")
+	r.Form.Set("code_challenge", "")
+	h.Force = true
+	require.Error(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+
+	r.Form.Set("code_challenge", "challenge")
+	require.NoError(t, h.HandleAuthorizeEndpointRequest(context.Background(), r, w))
+}
+
+func TestPKCEHandlerValidate(t *testing.T) {
+	s := storage.NewMemoryStore()
+	ms := &mockCodeStrategy{}
+	h := &Handler{
+		CoreStorage: s, AuthorizeCodeStrategy: ms,
+	}
+	pc := &fosite.DefaultClient{Public: true}
+
+	s256verifier := "11111111111111111111111111111111111111111111111111111111111111111111"
+	hash := sha256.New()
+	hash.Write([]byte(s256verifier))
+	s256challenge := base64.RawURLEncoding.EncodeToString(hash.Sum([]byte{}))
+
+	for k, tc := range []struct {
+		d           string
+		grant       string
+		force       bool
+		enablePlain bool
+		challenge   string
+		method      string
+		verifier    string
+		code        string
+		expectErr   error
+		client      *fosite.DefaultClient
+	}{
+		{
+			d:         "fails because not auth code flow",
+			grant:     "not_authorization_code",
+			expectErr: fosite.ErrUnknownRequest,
+		},
+		{
+			d:         "fails because not auth code flow",
+			grant:     "not_authorization_code",
+			expectErr: fosite.ErrUnknownRequest,
+			client:    &fosite.DefaultClient{Public: false},
+		},
+		{
+			d:         "fails because invalid code",
+			grant:     "authorization_code",
+			expectErr: fosite.ErrServerError,
+			client:    pc,
+			code:      "invalid-code-2",
+		},
+		{
+			d:      "passes because auth code flow but pkce is not forced and no challenge given",
+			grant:  "authorization_code",
+			client: pc,
+			code:   "valid-code-3",
+		},
+		{
+			d:         "fails because auth code flow and pkce challenge given but plain is disabled",
+			grant:     "authorization_code",
+			challenge: "foo",
+			client:    pc,
+			expectErr: fosite.ErrInvalidRequest,
+			code:      "valid-code-4",
+		},
+		{
+			d:           "passes",
+			grant:       "authorization_code",
+			challenge:   "foo",
+			verifier:    "foo",
+			client:      pc,
+			enablePlain: true,
+			force:       true,
+			code:        "valid-code-5",
+		},
+		{
+			d:           "passes",
+			grant:       "authorization_code",
+			challenge:   "foo",
+			verifier:    "foo",
+			method:      "plain",
+			client:      pc,
+			enablePlain: true,
+			force:       true,
+			code:        "valid-code-6",
+		},
+		{
+			d:           "fails because challenge and verifier do not match",
+			grant:       "authorization_code",
+			challenge:   "not-foo",
+			verifier:    "foo",
+			method:      "plain",
+			client:      pc,
+			enablePlain: true,
+			code:        "valid-code-7",
+			expectErr:   fosite.ErrInvalidGrant,
+		},
+		{
+			d:           "fails because challenge and verifier do not match",
+			grant:       "authorization_code",
+			challenge:   "not-foo",
+			verifier:    "foo",
+			client:      pc,
+			enablePlain: true,
+			code:        "valid-code-8",
+			expectErr:   fosite.ErrInvalidGrant,
+		},
+		{
+			d:         "fails because verifier has low entropy",
+			grant:     "authorization_code",
+			challenge: "foo",
+			verifier:  "foo",
+			method:    "S256",
+			client:    pc,
+			force:     true,
+			code:      "valid-code-9",
+			expectErr: fosite.ErrInsufficientEntropy,
+		},
+		{
+			d:         "fails because challenge and verifier do not match",
+			grant:     "authorization_code",
+			challenge: "Zm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9v",
+			verifier:  "Zm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9vZm9v",
+			method:    "S256",
+			client:    pc,
+			force:     true,
+			code:      "valid-code-10",
+			expectErr: fosite.ErrInvalidGrant,
+		},
+		{
+			d:         "passes because challenge and verifier match",
+			grant:     "authorization_code",
+			challenge: s256challenge,
+			verifier:  s256verifier,
+			method:    "S256",
+			client:    pc,
+			force:     true,
+			code:      "valid-code-11",
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
+			h.EnablePlainChallengeMethod = tc.enablePlain
+			h.Force = tc.force
+			ms.signature = tc.code
+			ar := fosite.NewAuthorizeRequest()
+			ar.Form.Add("code_challenge", tc.challenge)
+			ar.Form.Add("code_challenge_method", tc.method)
+			require.NoError(t, s.CreateAuthorizeCodeSession(nil, fmt.Sprintf("valid-code-%d", k), ar))
+
+			r := fosite.NewAccessRequest(nil)
+			r.Client = tc.client
+			r.GrantTypes = fosite.Arguments{tc.grant}
+			r.Form.Add("code_verifier", tc.verifier)
+			if tc.expectErr == nil {
+				require.NoError(t, h.HandleTokenEndpointRequest(context.Background(), r))
+			} else {
+				require.EqualError(t, h.HandleTokenEndpointRequest(context.Background(), r), tc.expectErr.Error())
+			}
+		})
+	}
+}
+
+func TestPKCEHandleTokenEndpointRequest(t *testing.T) {
+	for k, tc := range []struct {
+		d           string
+		force       bool
+		enablePlain bool
+		challenge   string
+		method      string
+		expectErr   bool
+	}{
+		{
+			d: "should pass because pkce is not enforced",
+		},
+		{
+			d:         "should fail because plain is not enabled and method is empty which defaults to plain",
+			expectErr: true,
+			force:     true,
+		},
+		{
+			d:           "should fail because force is enabled and no challenge was given",
+			force:       true,
+			enablePlain: true,
+			expectErr:   true,
+			method:      "S256",
+		},
+		{
+			d:         "should fail because although force is enabled and a challenge was given, plain is disabled",
+			force:     true,
+			expectErr: true,
+			method:    "plain",
+			challenge: "challenge",
+		},
+		{
+			d:         "should fail because although force is enabled and a challenge was given, plain is disabled and method is empty",
+			force:     true,
+			expectErr: true,
+			challenge: "challenge",
+		},
+		{
+			d:         "should fail because invalid challenge method",
+			force:     true,
+			expectErr: true,
+			method:    "invalid",
+			challenge: "challenge",
+		},
+		{
+			d:         "should pass because force is enabled with challenge given and method is S256",
+			force:     true,
+			method:    "S256",
+			challenge: "challenge",
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
+			h := &Handler{
+				Force: tc.force,
+				EnablePlainChallengeMethod: tc.enablePlain,
+			}
+
+			if tc.expectErr {
+				assert.Error(t, h.validate(tc.challenge, tc.method))
+			} else {
+				assert.NoError(t, h.validate(tc.challenge, tc.method))
+			}
+		})
+	}
+}

--- a/integration/authorize_code_grant_public_client_pkce_test.go
+++ b/integration/authorize_code_grant_public_client_pkce_test.go
@@ -1,0 +1,116 @@
+// Copyright © 2017 Aeneas Rekkas <aeneas+oss@aeneas.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"testing"
+
+	"net/http"
+
+	"fmt"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/compose"
+	"github.com/ory/fosite/handler/oauth2"
+	//"github.com/stretchr/testify/assert"
+	"encoding/json"
+	"net/url"
+
+	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/require"
+	goauth "golang.org/x/oauth2"
+)
+
+func TestAuthorizeCodeFlowWithPublicClientAndPKCE(t *testing.T) {
+	for _, strategy := range []oauth2.AccessTokenStrategy{
+		hmacStrategy,
+	} {
+		runAuthorizeCodeGrantWithPublicClientAndPKCETest(t, strategy)
+	}
+}
+
+func runAuthorizeCodeGrantWithPublicClientAndPKCETest(t *testing.T, strategy interface{}) {
+	c := new(compose.Config)
+	c.EnforcePKCE = true
+	c.EnablePKCEPlainChallengeMethod = true
+	f := compose.Compose(c, fositeStore, strategy, nil, compose.OAuth2AuthorizeExplicitFactory, compose.OAuth2PKCEFactory, compose.OAuth2TokenIntrospectionFactory)
+	ts := mockServer(t, f, &fosite.DefaultSession{})
+	defer ts.Close()
+
+	oauthClient := newOAuth2Client(ts)
+	oauthClient.ClientSecret = ""
+	oauthClient.ClientID = "public-client"
+	fositeStore.Clients["public-client"].RedirectURIs[0] = ts.URL + "/callback"
+
+	var authCodeUrl string
+	var verifier string
+	for k, c := range []struct {
+		description    string
+		setup          func()
+		authStatusCode int
+	}{
+		{
+			description: "should fail because no challenge was given",
+			setup: func() {
+				authCodeUrl = oauthClient.AuthCodeURL("12345678901234567890")
+			},
+			authStatusCode: http.StatusNotAcceptable,
+		},
+		{
+			description: "should pass",
+			setup: func() {
+				verifier = "somechallenge"
+				authCodeUrl = oauthClient.AuthCodeURL("12345678901234567890") + "&code_challenge=somechallenge"
+			},
+			authStatusCode: http.StatusOK,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, c.description), func(t *testing.T) {
+			c.setup()
+
+			t.Logf("Got url: %s", authCodeUrl)
+
+			resp, err := http.Get(authCodeUrl)
+			require.NoError(t, err)
+			require.Equal(t, c.authStatusCode, resp.StatusCode)
+
+			if resp.StatusCode == http.StatusOK {
+				// This should fail because no verifier was given
+				_, err := oauthClient.Exchange(goauth.NoContext, resp.Request.URL.Query().Get("code"))
+				require.Error(t, err)
+				//require.Empty(t, token.AccessToken)
+
+				resp, err := http.PostForm(ts.URL+"/token", url.Values{
+					"code":          {resp.Request.URL.Query().Get("code")},
+					"grant_type":    {"authorization_code"},
+					"client_id":     {"public-client"},
+					"redirect_uri":  {ts.URL + "/callback"},
+					"code_verifier": {verifier},
+				})
+				require.NoError(t, err)
+				defer resp.Body.Close()
+
+				assert.Equal(t, resp.StatusCode, http.StatusOK)
+				token := goauth.Token{}
+				require.NoError(t, json.NewDecoder(resp.Body).Decode(&token))
+
+				httpClient := oauthClient.Client(goauth.NoContext, &token)
+				resp, err = httpClient.Get(ts.URL + "/info")
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/integration/authorize_code_grant_public_client_test.go
+++ b/integration/authorize_code_grant_public_client_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2017 Aeneas Rekkas <aeneas+oss@aeneas.io>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package integration_test
+
+import (
+	"testing"
+
+	"net/http"
+
+	"fmt"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/compose"
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	goauth "golang.org/x/oauth2"
+)
+
+func TestAuthorizeCodeFlowWithPublicClient(t *testing.T) {
+	for _, strategy := range []oauth2.AccessTokenStrategy{
+		hmacStrategy,
+	} {
+		runAuthorizeCodeGrantWithPublicClientTest(t, strategy)
+	}
+}
+
+func runAuthorizeCodeGrantWithPublicClientTest(t *testing.T, strategy interface{}) {
+	f := compose.Compose(new(compose.Config), fositeStore, strategy, nil, compose.OAuth2AuthorizeExplicitFactory, compose.OAuth2TokenIntrospectionFactory)
+	ts := mockServer(t, f, &fosite.DefaultSession{})
+	defer ts.Close()
+
+	oauthClient := newOAuth2Client(ts)
+	oauthClient.ClientSecret = ""
+	oauthClient.ClientID = "public-client"
+	fositeStore.Clients["public-client"].RedirectURIs[0] = ts.URL + "/callback"
+
+	var state string
+	for k, c := range []struct {
+		description    string
+		setup          func()
+		authStatusCode int
+	}{
+		{
+			description: "should pass",
+			setup: func() {
+				state = "12345678901234567890"
+			},
+			authStatusCode: http.StatusOK,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, c.description), func(t *testing.T) {
+			c.setup()
+
+			resp, err := http.Get(oauthClient.AuthCodeURL(state))
+			require.NoError(t, err)
+			require.Equal(t, c.authStatusCode, resp.StatusCode)
+
+			if resp.StatusCode == http.StatusOK {
+				token, err := oauthClient.Exchange(goauth.NoContext, resp.Request.URL.Query().Get("code"))
+				require.NoError(t, err)
+				require.NotEmpty(t, token.AccessToken)
+
+				httpClient := oauthClient.Client(goauth.NoContext, token)
+				resp, err := httpClient.Get(ts.URL + "/info")
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+			}
+		})
+	}
+}

--- a/integration/helper_endpoints_test.go
+++ b/integration/helper_endpoints_test.go
@@ -97,9 +97,10 @@ func authEndpointHandler(t *testing.T, oauth2 fosite.OAuth2Provider, session fos
 
 		response, err := oauth2.NewAuthorizeResponse(ctx, ar, session)
 		if err != nil {
-			t.Logf("Access request failed because %s.", err.Error())
+			ca := errors.Cause(err).(*fosite.RFC6749Error)
+			t.Logf("Access request failed because %s - %s - %s.", err, ca.Description, ca.Debug)
 			t.Logf("Request: %s.", ar)
-			// t.Logf("Stack: %s.", err.(stackTracer).StackTrace())
+			t.Logf("Stack: %+v.", err.(stackTracer).StackTrace())
 			oauth2.WriteAuthorizeError(rw, ar, err)
 			return
 		}

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -41,6 +41,15 @@ var fositeStore = &storage.MemoryStore{
 			GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 			Scopes:        []string{"fosite", "offline", "openid"},
 		},
+		"public-client": {
+			ID:            "public-client",
+			Secret:        []byte{},
+			Public:        true,
+			RedirectURIs:  []string{"http://localhost:3846/callback"},
+			ResponseTypes: []string{"id_token", "code"},
+			GrantTypes:    []string{"refresh_token", "authorization_code"},
+			Scopes:        []string{"fosite", "offline", "openid"},
+		},
 	},
 	Users: map[string]storage.MemoryUserRelation{
 		"peter": {


### PR DESCRIPTION
This change adds [PKCE](https://tools.ietf.org/html/rfc7636) support for methods none and S256 and adds it per default to the composer with forced PKCE and method none disallowed. These settings can be configured using `compose.Config.AllowPublicAuthCodeFlowWithoutPKCE` and `compose.Config.EnablePKCEPlainChallengeMethod`.

Closes #213

To do:

* [x] Add integration tests for public clients using PKCE
* [x] Add integration tests for pbulic clients without PKCE