### PR TITLE
introspection: Adds missing http header to response writer

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -54,7 +54,7 @@ func (f *Fosite) WriteIntrospectionError(rw http.ResponseWriter, err error) {
 		return
 	}
 
-	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	rw.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(rw).Encode(struct {
 		Active bool `json:"active"`
 	}{Active: false})
@@ -195,6 +195,7 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		return
 	}
 
+	rw.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(rw).Encode(struct {
 		Active    bool    `json:"active"`
 		ClientID  string  `json:"client_id,omitempty"`


### PR DESCRIPTION
The introspection response writer was missing `application/json`
in header `Content-Type`. This patch fixes that.

Closes #209