### PR TITLE
Regression fix for request ID in refresh token flow

### DIFF
--- a/request.go
+++ b/request.go
@@ -137,6 +137,7 @@ func (a *Request) Sanitize(allowedParameters []string) Requester {
 	}
 
 	*b = *a
+	b.ID = a.GetID()
 	b.Form = url.Values{}
 	for k := range a.Form {
 		if _, ok := allowed[k]; ok {

--- a/request_test.go
+++ b/request_test.go
@@ -99,3 +99,18 @@ func TestSanitizeRequest(t *testing.T) {
 	assert.Equal(t, "fasdf", a.GetRequestForm().Get("baz"))
 	assert.Equal(t, "fasdf", a.GetRequestForm().Get("foo"))
 }
+
+func TestIdentifyRequest(t *testing.T) {
+	a := &Request{
+		RequestedAt:   time.Now().UTC(),
+		Client:        &DefaultClient{},
+		Scopes:        Arguments{},
+		GrantedScopes: []string{},
+		Form:          url.Values{"foo": []string{"bar"}},
+		Session:       new(DefaultSession),
+	}
+
+	b := a.Sanitize([]string{})
+	b.GetID()
+	assert.Equal(t, a.ID, b.GetID())
+}


### PR DESCRIPTION
The sanitize request method introduced a change where the generated ID for an access token and refresh token are different for the same response.

This is due to the ID being generated on the sanitized request not being passed back to the handler e.g. https://github.com/ory/fosite/blob/master/handler/oauth2/flow_refresh.go#L110.

To mitigate this the request ID is pre-generated on the original requester. There may be a better approach that would also pass the test.