### PR TITLE
openid: Adds a validator used to validate OIDC parameters

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,6 +50,12 @@
   revision = "1f550f6f2f69009f6ae57347c188e0a67cd4e500"
 
 [[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["assert"]
+  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
+  version = "v1.7.6"
+
+[[projects]]
   branch = "master"
   name = "github.com/mohae/deepcopy"
   packages = ["."]
@@ -66,6 +72,15 @@
   packages = ["."]
   revision = "2b6ec3da648e3e834dc41bad8d9ed7f2dc6a9496"
   version = "v1.0.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/ory/go-convenience"
+  packages = [
+    "stringslice",
+    "stringsx"
+  ]
+  revision = "5f0c7c5dccfb8021c6de1f316a54afe530cdef63"
 
 [[projects]]
   name = "github.com/parnurzeal/gorequest"
@@ -93,43 +108,81 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","require"]
+  packages = [
+    "assert",
+    "require"
+  ]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["bcrypt","blowfish"]
+  packages = [
+    "bcrypt",
+    "blowfish"
+  ]
   revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["context","context/ctxhttp","idna","publicsuffix"]
+  packages = [
+    "context",
+    "context/ctxhttp",
+    "idna",
+    "publicsuffix"
+  ]
   revision = "4b14673ba32bee7f5ac0f990a48f033919fd418b"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/oauth2"
-  packages = [".","clientcredentials","internal"]
+  packages = [
+    ".",
+    "clientcredentials",
+    "internal"
+  ]
   revision = "bb50c06baba3d0c76f9d125c0719093e315b5b44"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/text"
-  packages = ["collate","collate/build","internal/colltab","internal/gen","internal/tag","internal/triegen","internal/ucd","language","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
+  packages = [
+    "collate",
+    "collate/build",
+    "internal/colltab",
+    "internal/gen",
+    "internal/tag",
+    "internal/triegen",
+    "internal/ucd",
+    "language",
+    "secure/bidirule",
+    "transform",
+    "unicode/bidi",
+    "unicode/cldr",
+    "unicode/norm",
+    "unicode/rangetable"
+  ]
   revision = "6eab0e8f74e86c598ec3b6fad4888e0c11482d48"
 
 [[projects]]
   name = "google.golang.org/appengine"
-  packages = ["internal","internal/base","internal/datastore","internal/log","internal/remote_api","internal/urlfetch","urlfetch"]
+  packages = [
+    "internal",
+    "internal/base",
+    "internal/datastore",
+    "internal/log",
+    "internal/remote_api",
+    "internal/urlfetch",
+    "urlfetch"
+  ]
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ec88100ce674d2223851185b8712fcf94ba459b7b891314b79849ad95916938"
+  inputs-digest = "e321698ec771b2713753c3157127216f1271e4e1611ccd4d949be02b64183971"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/compose/compose_openid.go
+++ b/compose/compose_openid.go
@@ -35,6 +35,7 @@ func OpenIDConnectExplicitFactory(config *Config, storage interface{}, strategy 
 		IDTokenHandleHelper: &openid.IDTokenHandleHelper{
 			IDTokenStrategy: strategy.(openid.OpenIDConnectTokenStrategy),
 		},
+		OpenIDConnectRequestValidator: openid.NewOpenIDConnectRequestValidator(config.AllowedPromptValues),
 	}
 }
 
@@ -63,6 +64,7 @@ func OpenIDConnectImplicitFactory(config *Config, storage interface{}, strategy 
 		IDTokenHandleHelper: &openid.IDTokenHandleHelper{
 			IDTokenStrategy: strategy.(openid.OpenIDConnectTokenStrategy),
 		},
+		OpenIDConnectRequestValidator: openid.NewOpenIDConnectRequestValidator(config.AllowedPromptValues),
 	}
 }
 
@@ -88,5 +90,6 @@ func OpenIDConnectHybridFactory(config *Config, storage interface{}, strategy in
 		IDTokenHandleHelper: &openid.IDTokenHandleHelper{
 			IDTokenStrategy: strategy.(openid.OpenIDConnectTokenStrategy),
 		},
+		OpenIDConnectRequestValidator: openid.NewOpenIDConnectRequestValidator(config.AllowedPromptValues),
 	}
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -56,6 +56,9 @@ type Config struct {
 
 	// EnablePKCEPlainChallengeMethod sets whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged). Defaults to false.
 	EnablePKCEPlainChallengeMethod bool
+
+	// AllowedPromptValues sets which OpenID Connect prompt values the server supports. Defaults to []string{"login", "none", "consent", "select_account"}.
+	AllowedPromptValues []string
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -30,7 +30,8 @@ import (
 
 type OpenIDConnectExplicitHandler struct {
 	// OpenIDConnectRequestStorage is the storage for open id connect sessions.
-	OpenIDConnectRequestStorage OpenIDConnectRequestStorage
+	OpenIDConnectRequestStorage   OpenIDConnectRequestStorage
+	OpenIDConnectRequestValidator *OpenIDConnectRequestValidator
 
 	*IDTokenHandleHelper
 }
@@ -54,6 +55,10 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 
 	if len(resp.GetCode()) == 0 {
 		return errors.WithStack(fosite.ErrMisconfiguration.WithDebug("Authorization code has not been issued yet"))
+	}
+
+	if err := c.OpenIDConnectRequestValidator.ValidatePrompt(ar); err != nil {
+		return err
 	}
 
 	if err := c.OpenIDConnectRequestStorage.CreateOpenIDConnectSession(ctx, resp.GetCode(), ar.Sanitize(oidcParameters)); err != nil {

--- a/handler/openid/flow_explicit_auth_test.go
+++ b/handler/openid/flow_explicit_auth_test.go
@@ -53,6 +53,7 @@ func TestExplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		IDTokenHandleHelper: &IDTokenHandleHelper{
 			IDTokenStrategy: j,
 		},
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil),
 	}
 	for k, c := range []struct {
 		description string

--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -92,7 +92,8 @@ func TestHybrid_HandleAuthorizeEndpointRequest(t *testing.T) {
 		IDTokenHandleHelper: &IDTokenHandleHelper{
 			IDTokenStrategy: idStrategy,
 		},
-		ScopeStrategy: fosite.HierarchicScopeStrategy,
+		ScopeStrategy:                 fosite.HierarchicScopeStrategy,
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil),
 	}
 	for k, c := range []struct {
 		description string

--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -36,7 +36,8 @@ import (
 type OpenIDConnectImplicitHandler struct {
 	AuthorizeImplicitGrantTypeHandler *oauth2.AuthorizeImplicitGrantTypeHandler
 	*IDTokenHandleHelper
-	ScopeStrategy fosite.ScopeStrategy
+	ScopeStrategy                 fosite.ScopeStrategy
+	OpenIDConnectRequestValidator *OpenIDConnectRequestValidator
 
 	RS256JWTStrategy *jwt.RS256JWTStrategy
 }
@@ -51,6 +52,10 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 
 	if !ar.GetClient().GetGrantTypes().Has("implicit") {
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use implicit grant type"))
+	}
+
+	if err := c.OpenIDConnectRequestValidator.ValidatePrompt(ar); err != nil {
+		return err
 	}
 
 	if ar.GetResponseTypes().Exact("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -52,7 +52,8 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		IDTokenHandleHelper: &IDTokenHandleHelper{
 			IDTokenStrategy: idStrategy,
 		},
-		ScopeStrategy: fosite.HierarchicScopeStrategy,
+		ScopeStrategy:                 fosite.HierarchicScopeStrategy,
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil),
 	}
 	for k, c := range []struct {
 		description string

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package openid
+
+import (
+	"fmt"
+
+	"github.com/ory/fosite"
+	"github.com/ory/go-convenience/stringslice"
+	"github.com/ory/go-convenience/stringsx"
+	"github.com/pkg/errors"
+)
+
+type OpenIDConnectRequestValidator struct {
+	AllowedPrompt []string
+}
+
+func NewOpenIDConnectRequestValidator(prompt []string) *OpenIDConnectRequestValidator {
+	if len(prompt) == 0 {
+		prompt = []string{"login", "none", "consent", "select_account"}
+	}
+
+	return &OpenIDConnectRequestValidator{
+		AllowedPrompt: prompt,
+	}
+}
+
+func (v *OpenIDConnectRequestValidator) ValidatePrompt(req fosite.AuthorizeRequester) error {
+	// prompt is case sensitive!
+	prompt := stringsx.Splitx(req.GetRequestForm().Get("prompt"), " ")
+
+	if req.GetClient().IsPublic() {
+		// Threat: Malicious Client Obtains Existing Authorization by Fraud
+		// https://tools.ietf.org/html/rfc6819#section-4.2.3
+		//
+		//  Authorization servers should not automatically process repeat
+		//  authorizations to public clients unless the client is validated
+		//  using a pre-registered redirect URI
+
+		// Client Impersonation
+		// https://tools.ietf.org/html/rfc8252#section-8.6#
+		//
+		//  As stated in Section 10.2 of OAuth 2.0 [RFC6749], the authorization
+		//  server SHOULD NOT process authorization requests automatically
+		//  without user consent or interaction, except when the identity of the
+		//  client can be assured.  This includes the case where the user has
+		//  previously approved an authorization request for a given client id --
+		//  unless the identity of the client can be proven, the request SHOULD
+		//  be processed as if no previous request had been approved.
+
+		// To make sure that we are not vulnerable to this type of attack, we will always require consent for public
+		// clients.
+
+		// If prompt is none - meaning that no consent should be requested, we must terminate with an error.
+		if stringslice.Has(prompt, "none") {
+			return errors.WithStack(fosite.ErrConsentRequired.WithDebug("OAuth 2.0 Client is marked public and requires end-user consent, but prompt=none was requested"))
+		}
+	}
+
+	if !isWhitelisted(prompt, v.AllowedPrompt) {
+		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(fmt.Sprintf(`Used unknown value "%s" for prompt parameter`, prompt)))
+	}
+
+	if stringslice.Has(prompt, "none") && len(prompt) > 1 {
+		// If this parameter contains none with any other value, an error is returned.
+		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("Parameter prompt was set to none, but contains other values as well which is not allowed"))
+	}
+
+	return nil
+}
+
+func isWhitelisted(items []string, whiteList []string) bool {
+	for _, item := range items {
+		if !stringslice.Has(whiteList, item) {
+			return false
+		}
+	}
+	return true
+}

--- a/handler/openid/validator_test.go
+++ b/handler/openid/validator_test.go
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package openid
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/ory/fosite"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePrompt(t *testing.T) {
+	v := NewOpenIDConnectRequestValidator(nil)
+
+	for k, tc := range []struct {
+		prompt    string
+		isPublic  bool
+		expectErr bool
+	}{
+		{
+			prompt:    "none",
+			isPublic:  true,
+			expectErr: true,
+		},
+		{
+			prompt:    "none",
+			isPublic:  false,
+			expectErr: false,
+		},
+		{
+			prompt:    "none login",
+			isPublic:  false,
+			expectErr: true,
+		},
+		{
+			prompt:    "foo",
+			isPublic:  false,
+			expectErr: true,
+		},
+		{
+			prompt:    "login consent",
+			isPublic:  true,
+			expectErr: false,
+		},
+		{
+			prompt:    "login consent",
+			isPublic:  false,
+			expectErr: false,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			err := v.ValidatePrompt(&fosite.AuthorizeRequest{
+				Request: fosite.Request{
+					Form:   url.Values{"prompt": {tc.prompt}},
+					Client: &fosite.DefaultClient{Public: tc.isPublic},
+				},
+			})
+			if tc.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/handler/pkce/storage.go
+++ b/handler/pkce/storage.go
@@ -23,6 +23,7 @@ package pkce
 
 import (
 	"context"
+
 	"github.com/ory/fosite"
 )
 

--- a/integration/authorize_code_grant_public_client_pkce_test.go
+++ b/integration/authorize_code_grant_public_client_pkce_test.go
@@ -35,10 +35,11 @@ import (
 	"encoding/json"
 	"net/url"
 
+	"io/ioutil"
+
 	"github.com/magiconair/properties/assert"
 	"github.com/stretchr/testify/require"
 	goauth "golang.org/x/oauth2"
-	"io/ioutil"
 )
 
 func TestAuthorizeCodeFlowWithPublicClientAndPKCE(t *testing.T) {


### PR DESCRIPTION
The validator, for now, validates the prompt parameter of OIDC requests.