### PR TITLE
Treat posted data as multipart

### DIFF
--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -62,7 +62,7 @@ func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session 
 
 	if r.Method != "POST" {
 		return accessRequest, errors.WithStack(ErrInvalidRequest.WithDebug("HTTP method is not POST"))
-	} else if err := r.ParseForm(); err != nil {
+	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
 		return accessRequest, errors.WithStack(ErrInvalidRequest.WithDebug(err.Error()))
 	}
 

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -39,7 +39,7 @@ func (c *Fosite) NewAuthorizeRequest(ctx context.Context, r *http.Request) (Auth
 		Request:              *NewRequest(),
 	}
 
-	if err := r.ParseForm(); err != nil {
+	if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
 		return request, errors.WithStack(ErrInvalidRequest.WithDebug(err.Error()))
 	}
 

--- a/integration/helper_endpoints_test.go
+++ b/integration/helper_endpoints_test.go
@@ -132,7 +132,7 @@ func authCallbackHandler(t *testing.T) func(rw http.ResponseWriter, req *http.Re
 
 func tokenEndpointHandler(t *testing.T, provider fosite.OAuth2Provider) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
-		req.ParseForm()
+		req.ParseMultipartForm(1 << 20)
 		ctx := fosite.NewContext()
 
 		accessRequest, err := provider.NewAccessRequest(ctx, req, &oauth2.JWTSession{})

--- a/introspect.go
+++ b/introspect.go
@@ -44,8 +44,7 @@ func AccessTokenFromRequest(req *http.Request) string {
 	if len(split) != 2 || !strings.EqualFold(split[0], "bearer") {
 		// Nothing in Authorization header, try access_token
 		// Empty string returned if there's no such parameter
-		err := req.ParseForm()
-		if err != nil {
+		if err := req.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
 			return ""
 		}
 		return req.Form.Get("access_token")

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -114,8 +114,11 @@ import (
 func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, session Session) (IntrospectionResponder, error) {
 	if r.Method != "POST" {
 		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithDebug("HTTP method is not POST"))
-	} else if err := r.ParseForm(); err != nil {
+	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
 		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithDebug(err.Error()))
+	}
+	if len(r.PostForm) == 0 {
+		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithDebug("missing form body"))
 	}
 
 	token := r.PostForm.Get("token")

--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -51,8 +51,11 @@ import (
 func (f *Fosite) NewRevocationRequest(ctx context.Context, r *http.Request) error {
 	if r.Method != "POST" {
 		return errors.WithStack(ErrInvalidRequest.WithDebug("HTTP method is not POST"))
-	} else if err := r.ParseForm(); err != nil {
+	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
 		return errors.WithStack(ErrInvalidRequest.WithDebug(err.Error()))
+	}
+	if len(r.PostForm) == 0 {
+		return errors.WithStack(ErrInvalidRequest.WithDebug("missing form body"))
 	}
 
 	clientID, clientSecret, ok := r.BasicAuth()


### PR DESCRIPTION
Use Multipart form parse function as some client implementations use it to send form data.
e.g All of our native clients which use CURL