### PR TITLE
openid: Do not require id_token response type for auth_code

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -44,6 +44,35 @@ bumps (`0.1.0` -> `0.2.0`).
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 0.21.0
+
+This release improves compatibility with the OpenID Connect Dynamic Client Registration 1.0 specification.
+
+### Response Type `id_token` no longer required for authorize_code flow
+
+The `authorize_code` [does not require](https://openid.net/specs/openid-connect-registration-1_0.html#ClientMetadata)
+the `id_token` response type to be available when performing the OpenID Connect flow:
+
+> grant_types
+>      OPTIONAL. JSON array containing a list of the OAuth 2.0 Grant Types that the Client is declaring that it will restrict itself to using. The Grant Type values used by OpenID Connect are:
+>
+>          authorization_code: The Authorization Code Grant Type described in OAuth 2.0 Section 4.1.
+>          implicit: The Implicit Grant Type described in OAuth 2.0 Section 4.2.
+>          refresh_token: The Refresh Token Grant Type described in OAuth 2.0 Section 6.
+>
+>      The following table lists the correspondence between response_type values that the Client will use and grant_type values that MUST be included in the registered grant_types list:
+>
+>          code: authorization_code
+>          id_token: implicit
+>          token id_token: implicit
+>          code id_token: authorization_code, implicit
+>          code token: authorization_code, implicit
+>          code token id_token: authorization_code, implicit
+>
+>      If omitted, the default is that the Client will use only the authorization_code Grant Type.
+
+Before this patch, the `id_token` response type was required whenever an ID Token was requested. This patch changes that.
+
 ## 0.20.0
 
 This release implements an OAuth 2.0 Best Practice with regards to revoking already issued access and refresh tokens

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -49,9 +49,9 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return nil
 	}
 
-	if !ar.GetClient().GetResponseTypes().Has("id_token", "code") {
-		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("The client is not allowed to use response type id_token and code"))
-	}
+	//if !ar.GetClient().GetResponseTypes().Has("id_token", "code") {
+	//	return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("The client is not allowed to use response type id_token and code"))
+	//}
 
 	if len(resp.GetCode()) == 0 {
 		return errors.WithStack(fosite.ErrMisconfiguration.WithDebug("Authorization code has not been issued yet"))

--- a/handler/openid/flow_explicit_auth_test.go
+++ b/handler/openid/flow_explicit_auth_test.go
@@ -75,7 +75,7 @@ func TestExplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 			setup: func() {
 				areq.ResponseTypes = fosite.Arguments{"code"}
 				areq.Client = &fosite.DefaultClient{
-					ResponseTypes: fosite.Arguments{"code", "id_token"},
+					ResponseTypes: fosite.Arguments{"code"},
 				}
 				areq.Scopes = fosite.Arguments{""}
 			},

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -52,9 +52,12 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the authorization_code grant type"))
 	}
 
-	if !requester.GetClient().GetResponseTypes().Has("id_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
-	}
+	// The response type `id_token` is only required when performing the implicit or hybrid flow, see:
+	// https://openid.net/specs/openid-connect-registration-1_0.html
+	//
+	// if !requester.GetClient().GetResponseTypes().Has("id_token") {
+	// 	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
+	// }
 
 	return c.IssueExplicitIDToken(ctx, authorize, responder)
 }

--- a/handler/openid/flow_explicit_token_test.go
+++ b/handler/openid/flow_explicit_token_test.go
@@ -39,7 +39,7 @@ func TestHandleTokenEndpointRequest(t *testing.T) {
 	h := &OpenIDConnectExplicitHandler{}
 	areq := fosite.NewAccessRequest(nil)
 	areq.Client = &fosite.DefaultClient{
-		ResponseTypes: fosite.Arguments{"id_token"},
+		//ResponseTypes: fosite.Arguments{"id_token"},
 	}
 	assert.EqualError(t, h.HandleTokenEndpointRequest(nil, areq), fosite.ErrUnknownRequest.Error())
 }
@@ -80,7 +80,7 @@ func TestExplicit_PopulateTokenEndpointResponse(t *testing.T) {
 				areq.GrantTypes = fosite.Arguments{"authorization_code"}
 				areq.Client = &fosite.DefaultClient{
 					GrantTypes:    fosite.Arguments{"authorization_code"},
-					ResponseTypes: fosite.Arguments{"id_token"},
+					//ResponseTypes: fosite.Arguments{"id_token"},
 				}
 				areq.Form.Set("code", "foobar")
 				store.EXPECT().GetOpenIDConnectSession(nil, "foobar", areq).Return(nil, ErrNoSessionFound)

--- a/handler/openid/flow_explicit_token_test.go
+++ b/handler/openid/flow_explicit_token_test.go
@@ -39,7 +39,7 @@ func TestHandleTokenEndpointRequest(t *testing.T) {
 	h := &OpenIDConnectExplicitHandler{}
 	areq := fosite.NewAccessRequest(nil)
 	areq.Client = &fosite.DefaultClient{
-		//ResponseTypes: fosite.Arguments{"id_token"},
+	//ResponseTypes: fosite.Arguments{"id_token"},
 	}
 	assert.EqualError(t, h.HandleTokenEndpointRequest(nil, areq), fosite.ErrUnknownRequest.Error())
 }
@@ -79,7 +79,7 @@ func TestExplicit_PopulateTokenEndpointResponse(t *testing.T) {
 			setup: func() {
 				areq.GrantTypes = fosite.Arguments{"authorization_code"}
 				areq.Client = &fosite.DefaultClient{
-					GrantTypes:    fosite.Arguments{"authorization_code"},
+					GrantTypes: fosite.Arguments{"authorization_code"},
 					//ResponseTypes: fosite.Arguments{"id_token"},
 				}
 				areq.Form.Set("code", "foobar")

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -46,9 +46,12 @@ func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Con
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the authorization_code grant type"))
 	}
 
-	if !request.GetClient().GetResponseTypes().Has("id_token") {
-		return errors.WithStack(fosite.ErrUnknownRequest.WithDebug("The client is not allowed to use response type id_token"))
-	}
+	// Refresh tokens can only be issued by an authorize_code which in turn disables the need to check if the id_token
+	// response type is enabled by the client.
+	//
+	// if !request.GetClient().GetResponseTypes().Has("id_token") {
+	// 	return errors.WithStack(fosite.ErrUnknownRequest.WithDebug("The client is not allowed to use response type id_token"))
+	// }
 
 	sess, ok := request.GetSession().(Session)
 	if !ok {

--- a/handler/openid/flow_refresh_token_test.go
+++ b/handler/openid/flow_refresh_token_test.go
@@ -67,27 +67,14 @@ func TestOpenIDConnectRefreshHandler_HandleTokenEndpointRequest(t *testing.T) {
 			expectedErr: fosite.ErrInvalidGrant,
 		},
 		{
-			description: "should not pass because client may not ask for id_token",
-			areq: &fosite.AccessRequest{
-				GrantTypes: []string{"refresh_token"},
-				Request: fosite.Request{
-					GrantedScopes: []string{"openid"},
-					Client: &fosite.DefaultClient{
-						GrantTypes: []string{"refresh_token"},
-					},
-				},
-			},
-			expectedErr: fosite.ErrUnknownRequest,
-		},
-		{
 			description: "should pass",
 			areq: &fosite.AccessRequest{
 				GrantTypes: []string{"refresh_token"},
 				Request: fosite.Request{
 					GrantedScopes: []string{"openid"},
 					Client: &fosite.DefaultClient{
-						GrantTypes:    []string{"refresh_token"},
-						ResponseTypes: []string{"id_token"},
+						GrantTypes: []string{"refresh_token"},
+						//ResponseTypes: []string{"id_token"},
 					},
 					Session: &DefaultSession{},
 				},


### PR DESCRIPTION
Before this patch, the `id_token` response type was required whenever an ID Token was requested. This patch changes that.