### PR TITLE
openid: Adds errors for request and registration parameters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.9.x
 
 env:
-  - DEP_VERSION="0.3.2"
+  - DEP_VERSION="0.4.1"
 
 before_install:
   - curl -L -s https://github.com/golang/dep/releases/download/v${DEP_VERSION}/dep-linux-amd64 -o $GOPATH/bin/dep

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,7 +120,9 @@
   name = "golang.org/x/crypto"
   packages = [
     "bcrypt",
-    "blowfish"
+    "blowfish",
+    "ed25519",
+    "ed25519/internal/edwards25519"
   ]
   revision = "2509b142fb2b797aa7587dad548f113b2c0f20ce"
 
@@ -180,9 +182,19 @@
   revision = "150dc57a1b433e64154302bdc40b6bb8aefa313a"
   version = "v1.0.0"
 
+[[projects]]
+  name = "gopkg.in/square/go-jose.v2"
+  packages = [
+    ".",
+    "cipher",
+    "json"
+  ]
+  revision = "76dd09796242edb5b897103a75df2645c028c960"
+  version = "v2.1.6"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7463dc423c1ad2a7624a26768643791085b84c96a074410a344e2ee7437be6f4"
+  inputs-digest = "73363188a295445f2c12d95f9b294a26180dc56a6f5f9346a0814648f1e9f48e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -42,6 +42,10 @@
   name = "github.com/ory/go-convenience"
 
 [[constraint]]
+  version = "2.1.6"
+  name = "gopkg.in/square/go-jose.v2"
+
+[[constraint]]
   branch = "master"
   name = "github.com/gtank/cryptopasta"
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,7 +5,13 @@ bumps (`0.1.0` -> `0.2.0`).
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
 
+- [0.21.0](#0210)
+  - [Adds `private_key_jwt` client authentication method](#adds-private_key_jwt-client-authentication-method)
+  - [Response Type `id_token` no longer required for authorize_code flow](#response-type-id_token-no-longer-required-for-authorize_code-flow)
 - [0.20.0](#0200)
+- [Breaking Changes](#breaking-changes)
+  - [JWT Claims](#jwt-claims)
+  - [`AuthorizeCodeStorage`](#authorizecodestorage)
 - [0.19.0](#0190)
 - [0.18.0](#0180)
 - [0.17.0](#0170)
@@ -21,7 +27,7 @@ bumps (`0.1.0` -> `0.2.0`).
   - [Non-breaking changes](#non-breaking-changes)
     - [Storage adapter](#storage-adapter)
     - [Reducing use of gomock](#reducing-use-of-gomock)
-  - [Breaking Changes](#breaking-changes)
+  - [Breaking Changes](#breaking-changes-1)
     - [`fosite/handler/oauth2.AuthorizeCodeGrantStorage` was removed](#fositehandleroauth2authorizecodegrantstorage-was-removed)
     - [`fosite/handler/oauth2.RefreshTokenGrantStorage` was removed](#fositehandleroauth2refreshtokengrantstorage-was-removed)
     - [`fosite/handler/oauth2.AuthorizeCodeGrantStorage` was removed](#fositehandleroauth2authorizecodegrantstorage-was-removed-1)
@@ -47,6 +53,17 @@ bumps (`0.1.0` -> `0.2.0`).
 ## 0.21.0
 
 This release improves compatibility with the OpenID Connect Dynamic Client Registration 1.0 specification.
+
+### Adds `private_key_jwt` client authentication method
+
+This patch adds the ability to perform the [`private_key_jwt` client authentication method](http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)
+defined in the OpenID Connect specification. Please note that method `client_secret_jwt` is not supported because of the BCrypt hashing strategy.
+
+For this strategy to work, you must set the `TokenURL` field of the `compose.Config` object to the authorization server's
+Token URL.
+
+If you would like to support this authentication method, your `Client` implementation must also implement `fosite.DefaultOpenIDConnectClient`
+and then, for example, `GetTokenEndpointAuthMethod()` should return `private_key_jwt`.
 
 ### Response Type `id_token` no longer required for authorize_code flow
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -59,6 +59,12 @@ This release improves compatibility with the OpenID Connect Dynamic Client Regis
 
 Field `RS256JWTStrategy` was renamed to `JWTStrategy` and now relies on an interface instead of a concrete struct.
 
+### `oauth2.RS256JWTStrategy` was renamed and field name changed
+
+The strategy `oauth2.RS256JWTStrategy` was renamed to `oauth2.DefaultJWTStrategy` and now accepts an interface that
+implements `jwt.JWTStrategy` instead of directly relying on `jwt.RS256JWTStrategy`. For this reason,
+the field `RS256JWTStrategy` was renamed to `JWTStrategy`
+
 ### Adds `private_key_jwt` client authentication method
 
 This patch adds the ability to perform the [`private_key_jwt` client authentication method](http://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ bumps (`0.1.0` -> `0.2.0`).
 
 
 - [0.21.0](#0210)
+  - [`openid.DefaultStrategy` field name changed](#openiddefaultstrategy-field-name-changed)
   - [Adds `private_key_jwt` client authentication method](#adds-private_key_jwt-client-authentication-method)
   - [Response Type `id_token` no longer required for authorize_code flow](#response-type-id_token-no-longer-required-for-authorize_code-flow)
 - [0.20.0](#0200)
@@ -53,6 +54,10 @@ bumps (`0.1.0` -> `0.2.0`).
 ## 0.21.0
 
 This release improves compatibility with the OpenID Connect Dynamic Client Registration 1.0 specification.
+
+### `openid.DefaultStrategy` field name changed
+
+Field `RS256JWTStrategy` was renamed to `JWTStrategy` and now relies on an interface instead of a concrete struct.
 
 ### Adds `private_key_jwt` client authentication method
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -55,6 +55,16 @@ bumps (`0.1.0` -> `0.2.0`).
 
 This release improves compatibility with the OpenID Connect Dynamic Client Registration 1.0 specification.
 
+### Changes to parsing of OAuth 2.0 Client `response_types`
+
+Previously, when response types such as `code token id_token` were requested (OpenID Connect Hybrid Flow) it was enough
+for the client to have `response_types=["code", "token", "id_token"]`. This is however incompatible with the
+OpenID Connect Dynamic Client Registration 1.0 spec which dictates that the `response_types` have to match exactly.
+
+Assuming you are requesting `&response_types=code+token+id_token`, your client should have `response_types=["code token id_token"]`,
+if other response types are required (e.g. `&response_types=code`, `&response_types=token`) they too must be included:
+`response_types=["code", "token", "code token id_token"]`.
+
 ### `openid.DefaultStrategy` field name changed
 
 Field `RS256JWTStrategy` was renamed to `JWTStrategy` and now relies on an interface instead of a concrete struct.

--- a/access_error.go
+++ b/access_error.go
@@ -27,15 +27,15 @@ import (
 	"net/http"
 )
 
-func (c *Fosite) WriteAccessError(rw http.ResponseWriter, _ AccessRequester, err error) {
-	c.writeJsonError(rw, err)
+func (f *Fosite) WriteAccessError(rw http.ResponseWriter, _ AccessRequester, err error) {
+	f.writeJsonError(rw, err)
 }
 
-func (c *Fosite) writeJsonError(rw http.ResponseWriter, err error) {
+func (f *Fosite) writeJsonError(rw http.ResponseWriter, err error) {
 	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 
 	rfcerr := ErrorToRFC6749Error(err)
-	if !c.SendDebugMessagesToClients {
+	if !f.SendDebugMessagesToClients {
 		rfcerr.Debug = ""
 	}
 

--- a/access_write.go
+++ b/access_write.go
@@ -26,7 +26,7 @@ import (
 	"net/http"
 )
 
-func (c *Fosite) WriteAccessResponse(rw http.ResponseWriter, requester AccessRequester, responder AccessResponder) {
+func (f *Fosite) WriteAccessResponse(rw http.ResponseWriter, requester AccessRequester, responder AccessResponder) {
 	js, err := json.Marshal(responder.ToMap())
 	if err != nil {
 		http.Error(rw, err.Error(), http.StatusInternalServerError)

--- a/authorize_error.go
+++ b/authorize_error.go
@@ -61,7 +61,7 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 		query.Add("error_hint", rfcerr.Hint)
 	}
 
-	if !ar.GetResponseTypes().Exact("code") && errors.Cause(err) != ErrUnsupportedResponseType {
+	if !(len(ar.GetResponseTypes()) == 0 || ar.GetResponseTypes().Exact("code")) && errors.Cause(err) != ErrUnsupportedResponseType {
 		redirectURI.Fragment = query.Encode()
 	} else {
 		for key, values := range redirectURI.Query() {

--- a/authorize_error.go
+++ b/authorize_error.go
@@ -29,10 +29,10 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (c *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error) {
+func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error) {
 	rfcerr := ErrorToRFC6749Error(err)
 	if !ar.IsRedirectURIValid() {
-		if !c.SendDebugMessagesToClients {
+		if !f.SendDebugMessagesToClients {
 			rfcerr.Debug = ""
 		}
 
@@ -53,7 +53,7 @@ func (c *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 	query.Add("error", rfcerr.Name)
 	query.Add("error_description", rfcerr.Description)
 	query.Add("state", ar.GetState())
-	if c.SendDebugMessagesToClients && rfcerr.Debug != "" {
+	if f.SendDebugMessagesToClients && rfcerr.Debug != "" {
 		query.Add("error_debug", rfcerr.Debug)
 	}
 

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -196,6 +196,10 @@ func (f *Fosite) validateResponseTypes(r *http.Request, request *AuthorizeReques
 	// type "a b" is the same as "b a").  The meaning of such composite
 	// response types is defined by their respective specifications.
 	responseTypes := removeEmpty(stringsx.Splitx(r.Form.Get("response_type"), " "))
+	if len(responseTypes) == 0 {
+		return errors.WithStack(ErrInvalidRequest.WithDebug("The request is missing the response_type parameter"))
+	}
+
 	var found bool
 	for _, t := range request.GetClient().GetResponseTypes() {
 		if Arguments(responseTypes).Matches(removeEmpty(stringsx.Splitx(t, " "))...) {

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -92,6 +92,18 @@ func (c *Fosite) NewAuthorizeRequest(ctx context.Context, r *http.Request) (Auth
 	}
 	request.State = state
 
+	if len(request.Form.Get("request")) > 0 {
+		return request, errors.WithStack(ErrRequestNotSupported)
+	}
+
+	if len(request.Form.Get("request_uri")) > 0 {
+		return request, errors.WithStack(ErrRequestURINotSupported)
+	}
+
+	if len(request.Form.Get("registration")) > 0 {
+		return request, errors.WithStack(ErrRegistrationNotSupported)
+	}
+
 	// Remove empty items from arrays
 	request.SetRequestedScopes(scope)
 	return request, nil

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -197,7 +197,7 @@ func (f *Fosite) validateResponseTypes(r *http.Request, request *AuthorizeReques
 	// response types is defined by their respective specifications.
 	responseTypes := removeEmpty(stringsx.Splitx(r.Form.Get("response_type"), " "))
 	if len(responseTypes) == 0 {
-		return errors.WithStack(ErrInvalidRequest.WithDebug("The request is missing the response_type parameter"))
+		return errors.WithStack(ErrUnsupportedResponseType.WithDebug("The request is missing the response_type parameter"))
 	}
 
 	var found bool
@@ -209,7 +209,7 @@ func (f *Fosite) validateResponseTypes(r *http.Request, request *AuthorizeReques
 	}
 
 	if !found {
-		return errors.WithStack(ErrInvalidRequest.WithDebug(fmt.Sprintf("The client is not allowed to request response_type \"%s\"", r.Form.Get("response_type"))))
+		return errors.WithStack(ErrUnsupportedResponseType.WithDebug(fmt.Sprintf("The client is not allowed to request response_type \"%s\"", r.Form.Get("response_type"))))
 	}
 
 	request.ResponseTypes = responseTypes

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -1,0 +1,199 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+)
+
+func mustGenerateAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	tokenString, err := token.SignedString(key)
+	require.NoError(t, err)
+	return tokenString
+}
+
+func mustGenerateHSAssertion(t *testing.T, claims jwt.MapClaims) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("aaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccddddddddddddddddddddddd"))
+	require.NoError(t, err)
+	return tokenString
+}
+
+func mustGenerateNoneAssertion(t *testing.T, claims jwt.MapClaims) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	return tokenString
+}
+
+func TestAuthorizeRequestParametersFromOpenIDConnectRequest(t *testing.T) {
+
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic(err)
+	}
+	jwks := &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				KeyID: "kid-foo",
+				Use:   "sig",
+				Key:   &key.PublicKey,
+			},
+		},
+	}
+
+	validRequestObject := mustGenerateAssertion(t, jwt.MapClaims{"scope": "foo", "foo": "bar", "baz": "baz"}, key, "kid-foo")
+	validNoneRequestObject := mustGenerateNoneAssertion(t, jwt.MapClaims{"scope": "foo", "foo": "bar", "baz": "baz"})
+
+	var reqH http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
+		rw.Write([]byte(validRequestObject))
+	}
+	reqTS := httptest.NewServer(reqH)
+	defer reqTS.Close()
+
+	var hJWK http.HandlerFunc = func(rw http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewEncoder(rw).Encode(jwks))
+	}
+	reqJWK := httptest.NewServer(hJWK)
+	defer reqJWK.Close()
+
+	f := &Fosite{JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy()}
+	for k, tc := range []struct {
+		client Client
+		form   url.Values
+		d      string
+
+		expectErr  error
+		expectForm url.Values
+	}{
+		{
+			d:          "should pass because no request context given and not openid",
+			form:       url.Values{},
+			expectErr:  nil,
+			expectForm: url.Values{},
+		},
+		{
+			d:          "should pass because no request context given",
+			form:       url.Values{"scope": {"openid"}},
+			expectErr:  nil,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should pass because request context given but not openid",
+			form:       url.Values{"request": {"foo"}},
+			expectErr:  nil,
+			expectForm: url.Values{"request": {"foo"}},
+		},
+		{
+			d:          "should fail because not an OpenIDConnect compliant client",
+			form:       url.Values{"scope": {"openid"}, "request": {"foo"}},
+			expectErr:  ErrRequestNotSupported,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should fail because not an OpenIDConnect compliant client",
+			form:       url.Values{"scope": {"openid"}, "request_uri": {"foo"}},
+			expectErr:  ErrRequestURINotSupported,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should fail because token invalid an no keys set",
+			form:       url.Values{"scope": {"openid"}, "request_uri": {"foo"}},
+			client:     &DefaultOpenIDConnectClient{RequestObjectSigningAlgorithm: "RS256"},
+			expectErr:  ErrInvalidRequest,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should fail because token invalid",
+			form:       url.Values{"scope": {"openid"}, "request": {"foo"}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlgorithm: "RS256"},
+			expectErr:  ErrInvalidRequest,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should fail because kid does not exist",
+			form:       url.Values{"scope": {"openid"}, "request": {mustGenerateAssertion(t, jwt.MapClaims{}, key, "does-not-exists")}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlgorithm: "RS256"},
+			expectErr:  ErrInvalidRequest,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should fail because not RS256 token",
+			form:       url.Values{"scope": {"openid"}, "request": {mustGenerateHSAssertion(t, jwt.MapClaims{})}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlgorithm: "RS256"},
+			expectErr:  ErrInvalidRequest,
+			expectForm: url.Values{"scope": {"openid"}},
+		},
+		{
+			d:          "should pass and set request parameters properly",
+			form:       url.Values{"scope": {"openid"}, "request": {validRequestObject}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeys: jwks, RequestObjectSigningAlgorithm: "RS256"},
+			expectForm: url.Values{"scope": {"foo openid"}, "request": {validRequestObject}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			d:          "should pass and set request_uri parameters properly and also fetch jwk from remote",
+			form:       url.Values{"scope": {"openid"}, "request_uri": {reqTS.URL}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlgorithm: "RS256"},
+			expectForm: url.Values{"scope": {"foo openid"}, "request_uri": {reqTS.URL}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+		{
+			d:          "should pass when request object uses algorithm none",
+			form:       url.Values{"scope": {"openid"}, "request": {validNoneRequestObject}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlgorithm: "none"},
+			expectForm: url.Values{"scope": {"foo openid"}, "request": {validNoneRequestObject}, "foo": {"bar"}, "baz": {"baz"}},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
+			req := &AuthorizeRequest{
+				Request: Request{
+					Client: tc.client,
+					Form:   tc.form,
+				},
+			}
+
+			err := f.authorizeRequestParametersFromOpenIDConnectRequest(req)
+			if tc.expectErr != nil {
+				require.EqualError(t, err, tc.expectErr.Error(), "%+v", err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, len(tc.expectForm), len(req.Form))
+				for k, v := range tc.expectForm {
+					assert.EqualValues(t, v, req.Form[k])
+				}
+			}
+		})
+	}
+}

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -168,12 +168,12 @@ func TestAuthorizeRequestParametersFromOpenIDConnectRequest(t *testing.T) {
 			form:       url.Values{"scope": {"openid"}, "request_uri": {reqTS.URL}},
 			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlgorithm: "RS256"},
 			expectForm: url.Values{"scope": {"foo openid"}, "request_uri": {reqTS.URL}, "foo": {"bar"}, "baz": {"baz"}},
-			expectErr:ErrInvalidRequestURI,
+			expectErr:  ErrInvalidRequestURI,
 		},
 		{
 			d:          "should pass and set request_uri parameters properly and also fetch jwk from remote",
 			form:       url.Values{"scope": {"openid"}, "request_uri": {reqTS.URL}},
-			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlgorithm: "RS256", RequestURIs:[]string{reqTS.URL}},
+			client:     &DefaultOpenIDConnectClient{JSONWebKeysURI: reqJWK.URL, RequestObjectSigningAlgorithm: "RS256", RequestURIs: []string{reqTS.URL}},
 			expectForm: url.Values{"scope": {"foo openid"}, "request_uri": {reqTS.URL}, "foo": {"bar"}, "baz": {"baz"}},
 		},
 		{

--- a/authorize_request_handler_test.go
+++ b/authorize_request_handler_test.go
@@ -184,14 +184,14 @@ func TestNewAuthorizeRequest(t *testing.T) {
 				"scope":         {"foo bar"},
 			},
 			mock: func() {
-				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}}, nil)
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}}, nil)
 			},
 			expect: &AuthorizeRequest{
 				RedirectURI:   redir,
 				ResponseTypes: []string{"code", "token"},
 				State:         "strong-state",
 				Request: Request{
-					Client: &DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}},
+					Client: &DefaultClient{ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}},
 					Scopes: []string{"foo", "bar"},
 				},
 			},

--- a/authorize_response_writer.go
+++ b/authorize_response_writer.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (o *Fosite) NewAuthorizeResponse(ctx context.Context, ar AuthorizeRequester, session Session) (AuthorizeResponder, error) {
+func (f *Fosite) NewAuthorizeResponse(ctx context.Context, ar AuthorizeRequester, session Session) (AuthorizeResponder, error) {
 	var resp = &AuthorizeResponse{
 		Header:   http.Header{},
 		Query:    url.Values{},
@@ -38,7 +38,7 @@ func (o *Fosite) NewAuthorizeResponse(ctx context.Context, ar AuthorizeRequester
 	}
 
 	ar.SetSession(session)
-	for _, h := range o.AuthorizeEndpointHandlers {
+	for _, h := range f.AuthorizeEndpointHandlers {
 		if err := h.HandleAuthorizeEndpointRequest(ctx, ar, resp); err != nil {
 			return nil, err
 		}

--- a/authorize_validators_test.go
+++ b/authorize_validators_test.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/ory/go-convenience/stringsx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateResponseTypes(t *testing.T) {
+	f := &Fosite{}
+	for k, tc := range []struct {
+		rt        string
+		art       []string
+		expectErr bool
+	}{
+		{
+			rt:        "code",
+			art:       []string{"token"},
+			expectErr: true,
+		},
+		{
+			rt:  "token",
+			art: []string{"token"},
+		},
+		{
+			rt:        "code token",
+			art:       []string{"token", "code"},
+			expectErr: true,
+		},
+		{
+			rt:  "code token",
+			art: []string{"token", "token code"},
+		},
+		{
+			rt:  "code token",
+			art: []string{"token", "code token"},
+		},
+		{
+			rt:        "code token",
+			art:       []string{"token", "code token id_token"},
+			expectErr: true,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			r := &http.Request{Form: url.Values{"response_type": {tc.rt}}}
+			ar := NewAuthorizeRequest()
+			ar.Request.Client = &DefaultClient{ResponseTypes: tc.art}
+
+			err := f.validateResponseTypes(r, ar)
+			if tc.expectErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.EqualValues(t, stringsx.Splitx(tc.rt, " "), ar.GetResponseTypes())
+			}
+		})
+	}
+}

--- a/authorize_validators_test.go
+++ b/authorize_validators_test.go
@@ -49,6 +49,21 @@ func TestValidateResponseTypes(t *testing.T) {
 			art: []string{"token"},
 		},
 		{
+			rt:        "",
+			art:       []string{"token"},
+			expectErr: true,
+		},
+		{
+			rt:        "  ",
+			art:       []string{"token"},
+			expectErr: true,
+		},
+		{
+			rt:        "disable",
+			art:       []string{"token"},
+			expectErr: true,
+		},
+		{
 			rt:        "code token",
 			art:       []string{"token", "code"},
 			expectErr: true,
@@ -69,6 +84,9 @@ func TestValidateResponseTypes(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			r := &http.Request{Form: url.Values{"response_type": {tc.rt}}}
+			if tc.rt == "disable" {
+				r = &http.Request{Form: url.Values{}}
+			}
 			ar := NewAuthorizeRequest()
 			ar.Request.Client = &DefaultClient{ResponseTypes: tc.art}
 

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -31,7 +31,7 @@ var (
 	plusMatch = regexp.MustCompile("\\+")
 )
 
-func (c *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
+func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
 	redir := ar.GetRedirectURI()
 
 	// Explicit grants

--- a/client.go
+++ b/client.go
@@ -89,10 +89,11 @@ type DefaultClient struct {
 
 type DefaultOpenIDConnectClient struct {
 	*DefaultClient
-	JSONWebKeysURI          string              `json:"jwks_uri"`
-	JSONWebKeys             *jose.JSONWebKeySet `json:"jwks"`
-	TokenEndpointAuthMethod string              `json:"token_endpoint_auth_method"`
-	RequestURIs             []string            `json:"request_uris"`
+	JSONWebKeysURI                string              `json:"jwks_uri"`
+	JSONWebKeys                   *jose.JSONWebKeySet `json:"jwks"`
+	TokenEndpointAuthMethod       string              `json:"token_endpoint_auth_method"`
+	RequestURIs                   []string            `json:"request_uris"`
+	RequestObjectSigningAlgorithm string              `json:"request_object_signing_alg"`
 }
 
 func (c *DefaultClient) GetID() string {
@@ -152,7 +153,7 @@ func (c *DefaultOpenIDConnectClient) GetTokenEndpointAuthSigningAlgorithm() stri
 }
 
 func (c *DefaultOpenIDConnectClient) GetRequestObjectSigningAlgorithm() string {
-	return "RS256"
+	return c.RequestObjectSigningAlgorithm
 }
 
 func (c *DefaultOpenIDConnectClient) GetTokenEndpointAuthMethod() string {

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -1,0 +1,252 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite
+
+import (
+	"context"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/pkg/errors"
+	"gopkg.in/square/go-jose.v2"
+)
+
+const clientAssertionJWTBearerType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+func (f *Fosite) AuthenticateClient(ctx context.Context, r *http.Request, form url.Values) (Client, error) {
+	if assertionType := form.Get("client_assertion_type"); assertionType == clientAssertionJWTBearerType {
+		assertion := form.Get("client_assertion")
+		if len(assertion) == 0 {
+			return nil, errors.WithStack(ErrInvalidRequest.WithDebug(fmt.Sprintf("The client_assertion request parameter must be set when using client_assertion_type of \"%s\"", clientAssertionJWTBearerType)))
+		}
+
+		var clientID string
+		var client Client
+
+		token, err := jwt.ParseWithClaims(assertion, new(jwt.MapClaims), func(t *jwt.Token) (interface{}, error) {
+			var err error
+			clientID, _, err = clientCredentialsFromRequestBody(form, false)
+			if err != nil {
+				return nil, err
+			}
+
+			if clientID == "" {
+				if claims, ok := t.Claims.(*jwt.MapClaims); !ok {
+					return nil, errors.WithStack(ErrRequestUnauthorized.WithDebug("Unable to type assert claims from client_assertion"))
+				} else if sub, ok := (*claims)["sub"].(string); !ok {
+					return nil, errors.WithStack(ErrInvalidClient.WithDebug("Claim sub from client_assertion must be set"))
+				} else {
+					clientID = sub
+				}
+			}
+
+			client, err = f.Store.GetClient(ctx, clientID)
+			if err != nil {
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug(err.Error()))
+			}
+
+			oidcClient, ok := client.(OpenIDConnectClient)
+			if !ok {
+				return nil, errors.WithStack(ErrInvalidRequest.WithDebug("The server configuration does not support OpenID Connect specific authentication methods"))
+			}
+
+			switch oidcClient.GetTokenEndpointAuthMethod() {
+			case "client_secret_post":
+				fallthrough
+			case "client_secret_basic":
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The OAuth 2.0 Request uses the \"client_secret_jwt\" authentication method, but the OAuth 2.0 Client only support the \"%s\" client authentication method", oidcClient.GetTokenEndpointAuthMethod())))
+			case "client_secret_jwt":
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug("This requested OAuth 2.0 client only supports client authentication method \"client_secret_jwt\", however that method is not supported by this server"))
+			case "private_key_jwt":
+			}
+
+			if oidcClient.GetTokenEndpointAuthSigningAlgorithm() != "RS256" {
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The OAuth 2.0 Client only supports the \"%s\" signing algorithm which this authorization server does not support", oidcClient.GetTokenEndpointAuthSigningAlgorithm())))
+			}
+
+			if _, ok := t.Method.(*jwt.SigningMethodRSA); ok {
+				if set := oidcClient.GetJSONWebKeys(); set != nil {
+					return findPublicKey(t, set)
+				}
+
+				if location := oidcClient.GetJSONWebKeysURI(); len(location) > 0 {
+					keys, err := f.JWKSFetcherStrategy.Resolve(location, false)
+					if err != nil {
+						return nil, err
+					}
+
+					if key, err := findPublicKey(t, keys); err == nil {
+						return key, nil
+					}
+
+					keys, err = f.JWKSFetcherStrategy.Resolve(location, true)
+					if err != nil {
+						return nil, err
+					}
+
+					return findPublicKey(t, keys)
+				}
+
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug("The OAuth 2.0 Client has no JSON Web Keys set, thus client authentication method \"private_key_jwt\" failed"))
+			} else if _, ok := t.Method.(*jwt.SigningMethodHMAC); ok {
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug("This authorization server does not support client authentication method \"client_secret_jwt\""))
+			}
+
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The client_assertion request parameter uses unsupported signing algorithm \"%s\"", t.Header["alg"])))
+		})
+		if err != nil {
+			// Do not re-process already enhanced errors
+			if e, ok := errors.Cause(err).(*jwt.ValidationError); ok {
+				if e.Inner != nil {
+					return nil, e.Inner
+				}
+				errors.WithStack(ErrInvalidClient.WithDebug(err.Error()))
+			}
+			return nil, err
+		} else if err := token.Claims.Valid(); err != nil {
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug(err.Error()))
+		}
+
+		claims, ok := token.Claims.(*jwt.MapClaims)
+		if !ok {
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug("Unable to type assert claims from client_assertion"))
+		}
+
+		if !claims.VerifyIssuer(clientID, true) {
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug("Claim issuer from client_assertion must match the client_id of the OAuth 2.0 Client"))
+		} else if f.TokenURL == "" {
+			return nil, errors.WithStack(ErrMisconfiguration.WithDebug("The authorization server's token endpoint URL has not been set"))
+		} else if sub, ok := (*claims)["sub"].(string); !ok || sub != clientID {
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug("Claim sub from client_assertion must match the client_id of the OAuth 2.0 Client"))
+		} else if jti, ok := (*claims)["jti"].(string); !ok || len(jti) == 0 {
+			return nil, errors.WithStack(ErrInvalidClient.WithDebug("Claim jti from client_assertion must be set but is not"))
+		}
+
+		if auds, ok := (*claims)["aud"].([]interface{}); !ok {
+			if !claims.VerifyAudience(f.TokenURL, true) {
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("Claim audience from client_assertion must match the authorization server's token endpoint \"%s\"", f.TokenURL)))
+			}
+		} else {
+			var found bool
+			for _, aud := range auds {
+				if a, ok := aud.(string); ok && a == f.TokenURL {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("Claim audience from client_assertion must match the authorization server's token endpoint \"%s\"", f.TokenURL)))
+			}
+		}
+
+		return client, nil
+	} else if len(assertionType) > 0 {
+		return nil, errors.WithStack(ErrInvalidRequest.WithDebug(fmt.Sprintf("Unknown client_assertion_type \"%s\"", assertionType)))
+	}
+
+	clientID, clientSecret, err := clientCredentialsFromRequest(r, form)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := f.Store.GetClient(ctx, clientID)
+	if err != nil {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(err.Error()))
+	}
+
+	if oidcClient, ok := client.(OpenIDConnectClient); !ok {
+		// If this isn't an OpenID Connect client then we actually don't care about any of this, just continue!
+	} else if ok && form.Get("client_id") != "" && form.Get("client_secret") != "" && oidcClient.GetTokenEndpointAuthMethod() != "client_secret_post" {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The OAuth 2.0 Client supports client authentication method \"%s\", but method \"client_secret_post\" was requested", oidcClient.GetTokenEndpointAuthMethod())))
+	} else if _, _, basicOk := r.BasicAuth(); basicOk && ok && oidcClient.GetTokenEndpointAuthMethod() != "client_secret_basic" {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The OAuth 2.0 Client supports client authentication method \"%s\", but method \"client_secret_basic\" was requested", oidcClient.GetTokenEndpointAuthMethod())))
+	} else if ok && oidcClient.GetTokenEndpointAuthMethod() != "none" && client.IsPublic() {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("The OAuth 2.0 Client supports client authentication method \"%s\", but method \"none\" was requested", oidcClient.GetTokenEndpointAuthMethod())))
+	}
+
+	if client.IsPublic() {
+		return client, nil
+	}
+
+	// Enforce client authentication
+	if err := f.Hasher.Compare(client.GetHashedSecret(), []byte(clientSecret)); err != nil {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(err.Error()))
+	}
+
+	return client, nil
+}
+
+func findPublicKey(t *jwt.Token, set *jose.JSONWebKeySet) (*rsa.PublicKey, error) {
+	kid, ok := t.Header["kid"].(string)
+	if !ok {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug("The JSON Web Token from the client_assertion request parameter must contain a kid header value but did not"))
+	}
+
+	keys := set.Key(kid)
+	if len(keys) == 0 {
+		return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("Unable to find signing key for kid \"%s\"", kid)))
+	}
+
+	for _, key := range keys {
+		if key.Use != "sig" {
+			continue
+		}
+		if k, ok := key.Key.(*rsa.PublicKey); ok {
+			return k, nil
+		}
+	}
+
+	return nil, errors.WithStack(ErrInvalidClient.WithDebug(fmt.Sprintf("Unable to find RSA public key with use=\"sig\" for kid \"%s\" in JSON Web Key Set", kid)))
+}
+
+func clientCredentialsFromRequest(r *http.Request, form url.Values) (clientID, clientSecret string, err error) {
+	if id, secret, ok := r.BasicAuth(); !ok {
+		return clientCredentialsFromRequestBody(form, true)
+	} else if clientID, err = url.QueryUnescape(id); err != nil {
+		return "", "", errors.WithStack(ErrInvalidRequest.WithDebug(`The client id in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded"`))
+	} else if clientSecret, err = url.QueryUnescape(secret); err != nil {
+		return "", "", errors.WithStack(ErrInvalidRequest.WithDebug(`The client secret in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded"`))
+	}
+
+	return clientID, clientSecret, nil
+}
+
+func clientCredentialsFromRequestBody(form url.Values, forceID bool) (clientID, clientSecret string, err error) {
+	clientID = form.Get("client_id")
+	clientSecret = form.Get("client_secret")
+
+	if clientID == "" && forceID {
+		return "", "", errors.WithStack(ErrInvalidRequest.WithDebug("Client credentials missing or malformed in both HTTP Authorization header and HTTP POST body"))
+	}
+
+	if clientID, err = url.QueryUnescape(clientID); err != nil {
+		return "", "", errors.WithStack(ErrInvalidRequest.WithDebug(`The client id in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded"`))
+	} else if clientSecret, err = url.QueryUnescape(clientSecret); err != nil {
+		return "", "", errors.WithStack(ErrInvalidRequest.WithDebug(`The client secret in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded"`))
+	}
+
+	return clientID, clientSecret, nil
+}

--- a/client_authentication_jwks_strategy.go
+++ b/client_authentication_jwks_strategy.go
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite
+
+import "sync"
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"gopkg.in/square/go-jose.v2"
+)
+
+// JWKSFetcherStrategy is a strategy which pulls (optionally caches) JSON Web Key Sets from a location,
+// typically a client's jwks_uri.
+type JWKSFetcherStrategy interface {
+	// Resolve returns the JSON Web Key Set, or an error if something went wrong. The forceRefresh, if true, forces
+	// the strategy to fetch the keys from the remote. If forceRefresh is false, the strategy may use a caching strategy
+	// to fetch the key.
+	Resolve(location string, forceRefresh bool) (*jose.JSONWebKeySet, error)
+}
+
+type DefaultJWKSFetcherStrategy struct {
+	client *http.Client
+	keys   map[string]jose.JSONWebKeySet
+	sync.Mutex
+}
+
+func NewDefaultJWKSFetcherStrategy() JWKSFetcherStrategy {
+	return &DefaultJWKSFetcherStrategy{
+		keys:   make(map[string]jose.JSONWebKeySet),
+		client: http.DefaultClient,
+	}
+}
+
+func (s *DefaultJWKSFetcherStrategy) Resolve(location string, forceRefresh bool) (*jose.JSONWebKeySet, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	keys, ok := s.keys[location]
+	if !ok || forceRefresh {
+		response, err := s.client.Get(location)
+		if err != nil {
+			return nil, errors.WithStack(ErrServerError.WithDebug(err.Error()))
+		}
+		defer response.Body.Close()
+
+		if response.StatusCode < 200 || response.StatusCode >= 400 {
+			return nil, errors.WithStack(ErrServerError.WithDebug(fmt.Sprintf("Expected successful status code from OAuth 2.0 Client's jwks_uri remote, but received code %d", response.StatusCode)))
+		}
+
+		var set jose.JSONWebKeySet
+		if err := json.NewDecoder(response.Body).Decode(&set); err != nil {
+			return nil, errors.WithStack(ErrServerError.WithDebug(fmt.Sprintf("Unable to decode JSON Web Keys from OAuth 2.0 Client's jwks_uri remote because %s", err)))
+		}
+
+		s.keys[location] = set
+		return &set, nil
+	}
+
+	return &keys, nil
+}

--- a/client_authentication_jwks_strategy_test.go
+++ b/client_authentication_jwks_strategy_test.go
@@ -1,0 +1,108 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/ory/fosite"
+	"github.com/ory/fosite/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+)
+
+func TestDefaultJWKSFetcherStrategy(t *testing.T) {
+	var h http.HandlerFunc
+
+	s := NewDefaultJWKSFetcherStrategy()
+	t.Run("case=fetching", func(t *testing.T) {
+		var set *jose.JSONWebKeySet
+		h = func(w http.ResponseWriter, r *http.Request) {
+			require.NoError(t, json.NewEncoder(w).Encode(set))
+		}
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+
+		set = &jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
+				{
+					KeyID: "foo",
+					Use:   "sig",
+					Key:   &internal.MustRSAKey().PublicKey,
+				},
+			},
+		}
+
+		keys, err := s.Resolve(ts.URL, false)
+		require.NoError(t, err)
+		assert.True(t, len(keys.Key("foo")) == 1)
+
+		set = &jose.JSONWebKeySet{
+			Keys: []jose.JSONWebKey{
+				{
+					KeyID: "bar",
+					Use:   "sig",
+					Key:   &internal.MustRSAKey().PublicKey,
+				},
+			},
+		}
+
+		keys, err = s.Resolve(ts.URL, false)
+		require.NoError(t, err)
+		assert.True(t, len(keys.Key("foo")) == 1)
+		assert.True(t, len(keys.Key("bar")) == 0)
+
+		keys, err = s.Resolve(ts.URL, true)
+		require.NoError(t, err)
+		assert.True(t, len(keys.Key("foo")) == 0)
+		assert.True(t, len(keys.Key("bar")) == 1)
+	})
+
+	t.Run("case=error_network", func(t *testing.T) {
+		h = func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(400)
+		}
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+
+		_, err := s.Resolve(ts.URL, true)
+		require.Error(t, err)
+
+		_, err = s.Resolve("$%/19", true)
+		require.Error(t, err)
+	})
+
+	t.Run("case=error_encoding", func(t *testing.T) {
+		h = func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("[]"))
+		}
+		ts := httptest.NewServer(h)
+		defer ts.Close()
+
+		_, err := s.Resolve(ts.URL, true)
+		require.Error(t, err)
+	})
+}

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -1,0 +1,385 @@
+/*
+ * Copyright © 2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @Copyright 	2017-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite_test
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+	. "github.com/ory/fosite"
+	"github.com/ory/fosite/internal"
+	"github.com/ory/fosite/storage"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+)
+
+func mustGenerateAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = kid
+	tokenString, err := token.SignedString(key)
+	require.NoError(t, err)
+	return tokenString
+}
+
+func mustGenerateHSAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	tokenString, err := token.SignedString([]byte("aaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccddddddddddddddddddddddd"))
+	require.NoError(t, err)
+	return tokenString
+}
+
+func mustGenerateNoneAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
+	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
+	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
+	require.NoError(t, err)
+	return tokenString
+}
+
+func TestAuthenticateClient(t *testing.T) {
+	const at = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+
+	hasher := &BCrypt{WorkFactor: 6}
+	f := &Fosite{
+		JWKSFetcherStrategy: NewDefaultJWKSFetcherStrategy(),
+		Store:               storage.NewMemoryStore(),
+		Hasher:              hasher,
+		TokenURL:            "token-url",
+	}
+
+	barSecret, err := hasher.Hash([]byte("bar"))
+	require.NoError(t, err)
+
+	key := internal.MustRSAKey()
+	jwks := &jose.JSONWebKeySet{
+		Keys: []jose.JSONWebKey{
+			{
+				KeyID: "kid-foo",
+				Use:   "sig",
+				Key:   &key.PublicKey,
+			},
+		},
+	}
+
+	var h http.HandlerFunc
+	h = func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(jwks))
+	}
+	ts := httptest.NewServer(h)
+	defer ts.Close()
+
+	for k, tc := range []struct {
+		d             string
+		client        *DefaultOpenIDConnectClient
+		assertionType string
+		assertion     string
+		r             *http.Request
+		form          url.Values
+		expectErr     error
+	}{
+		{
+			d:         "should fail because authentication can not be determined",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo"}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         new(http.Request),
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			d:         "should fail because client does not exist",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "none"},
+			form:      url.Values{"client_id": []string{"bar"}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass because client is public and authentication requirements are met",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "none"},
+			form:   url.Values{"client_id": []string{"foo"}},
+			r:      new(http.Request),
+		},
+		{
+			d:         "should fail because auth method is not none",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{"client_id": []string{"foo"}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass because client is confidential and id and secret match in post body",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:   url.Values{"client_id": []string{"foo"}, "client_secret": []string{"bar"}},
+			r:      new(http.Request),
+		},
+		{
+			d:         "should fail because client is confidential and secret does not match in post body",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:      url.Values{"client_id": []string{"foo"}, "client_secret": []string{"baz"}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:         "should fail because client is confidential and id does not exist in post body",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:      url.Values{"client_id": []string{"foo"}, "client_secret": []string{"bar"}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass because client is confidential and id and secret match in header",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:   url.Values{},
+			r:      &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
+		},
+		{
+			d:         "should fail because auth method is not client_secret_basic",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:      url.Values{},
+			r:         &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:         "should fail because client is confidential and secret does not match in header",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:baz"))}}},
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:         "should fail because client id is not encoded using application/x-www-form-urlencoded",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("%%%%%%:foo"))}}},
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			d:         "should fail because client secret is not encoded using application/x-www-form-urlencoded",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:%%%%%%%"))}}},
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			d:         "should fail because client is confidential and id does not exist in header",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte("foo:bar"))}}},
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:         "should fail because client_assertion but client_assertion is missing",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "private_key_jwt"},
+			form:      url.Values{"client_id": []string{"foo"}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			d:         "should fail because client_assertion_type is unknown",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Secret: barSecret}, TokenEndpointAuthMethod: "private_key_jwt"},
+			form:      url.Values{"client_id": []string{"foo"}, "client_assertion_type": []string{"foobar"}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			d:      "should pass with proper assertion when JWKs are set within the client and client_id is not set in the request",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r: new(http.Request),
+		},
+		{
+			d:      "should fail because token auth method is not private_key_jwt",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "client_secret_jwt"},
+			form: url.Values{"client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass with proper assertion when JWKs are set within the client and client_id is not set in the request (aud is array)",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": []string{"token-url-2", "token-url"},
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r: new(http.Request),
+		},
+		{
+			d:      "should fail because audience (array) does not match token url",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": []string{"token-url-1", "token-url-2"},
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass with proper assertion when JWKs are set within the client",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r: new(http.Request),
+		},
+		{
+			d:      "should fail because JWT algorithm is HS256",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateHSAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should fail because JWT algorithm is none",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateNoneAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should pass with proper assertion when JWKs URI is set",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeysURI: ts.URL, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r: new(http.Request),
+		},
+		{
+			d:      "should fail because client_assertion sub does not match client",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "not-bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should fail because client_assertion iss does not match client",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "not-bar",
+				"jti": "12345",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should fail because client_assertion jti is not set",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"aud": "token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+		{
+			d:      "should fail because client_assertion aud is not set",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: jwks, TokenEndpointAuthMethod: "private_key_jwt"},
+			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour),
+				"iss": "bar",
+				"jti": "12345",
+				"aud": "not-token-url",
+			}, key, "kid-foo")}, "client_assertion_type": []string{at}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
+			store := storage.NewMemoryStore()
+			store.Clients[tc.client.ID] = tc.client
+			f.Store = store
+
+			c, err := f.AuthenticateClient(nil, tc.r, tc.form)
+			if tc.expectErr != nil {
+				require.EqualError(t, err, tc.expectErr.Error())
+				return
+			}
+
+			if err != nil {
+				switch e := errors.Cause(err).(type) {
+				case *jwt.ValidationError:
+					t.Logf("Error is: %s", e.Inner)
+				case *RFC6749Error:
+					t.Logf("Debug is: %s", e.Debug)
+				}
+			}
+			require.NoError(t, err)
+			assert.EqualValues(t, tc.client, c)
+		})
+	}
+}

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -56,6 +56,7 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 	if hasher == nil {
 		hasher = &fosite.BCrypt{WorkFactor: config.GetHashCost()}
 	}
+
 	f := &fosite.Fosite{
 		Store: storage.(fosite.Storage),
 		AuthorizeEndpointHandlers:  fosite.AuthorizeEndpointHandlers{},
@@ -65,6 +66,8 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 		Hasher:                     hasher,
 		ScopeStrategy:              config.GetScopeStrategy(),
 		SendDebugMessagesToClients: config.SendDebugMessagesToClients,
+		TokenURL:                   config.TokenURL,
+		JWKSFetcherStrategy:        config.GetJWKSFetcherStrategy(),
 	}
 
 	for _, factory := range factories {

--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -46,9 +46,9 @@ func NewOAuth2HMACStrategy(config *Config, secret []byte) *oauth2.HMACSHAStrateg
 	}
 }
 
-func NewOAuth2JWTStrategy(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy) *oauth2.RS256JWTStrategy {
-	return &oauth2.RS256JWTStrategy{
-		RS256JWTStrategy: &jwt.RS256JWTStrategy{
+func NewOAuth2JWTStrategy(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy) *oauth2.DefaultJWTStrategy {
+	return &oauth2.DefaultJWTStrategy{
+		JWTStrategy: &jwt.RS256JWTStrategy{
 			PrivateKey: key,
 		},
 		HMACSHAStrategy: strategy,

--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -57,7 +57,7 @@ func NewOAuth2JWTStrategy(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy)
 
 func NewOpenIDConnectStrategy(key *rsa.PrivateKey) *openid.DefaultStrategy {
 	return &openid.DefaultStrategy{
-		RS256JWTStrategy: &jwt.RS256JWTStrategy{
+		JWTStrategy: &jwt.RS256JWTStrategy{
 			PrivateKey: key,
 		},
 	}

--- a/compose/config.go
+++ b/compose/config.go
@@ -59,6 +59,15 @@ type Config struct {
 
 	// AllowedPromptValues sets which OpenID Connect prompt values the server supports. Defaults to []string{"login", "none", "consent", "select_account"}.
 	AllowedPromptValues []string
+
+	// TokenURL is the the URL of the Authorization Server's Token Endpoint. If the authorization server is intended
+	// to be compatible with the private_key_jwt client authentication method (see http://openid.net/specs/openid-connect-core-1_0.html#CodeFlowAuth),
+	// this value MUST be set.
+	TokenURL string
+
+	// JWKSFetcherStrategy is responsible for fetching JSON Web Keys from remote URLs. This is required when the private_key_jwt
+	// client authentication method is used. Defaults to fosite.DefaultJWKSFetcherStrategy.
+	JWKSFetcher fosite.JWKSFetcherStrategy
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.
@@ -99,4 +108,12 @@ func (c *Config) GetHashCost() int {
 		return 12
 	}
 	return c.HashCost
+}
+
+// GetJWKSFetcherStrategy returns the JWKSFetcherStrategy.
+func (c *Config) GetJWKSFetcherStrategy() fosite.JWKSFetcherStrategy {
+	if c.JWKSFetcher == nil {
+		c.JWKSFetcher = fosite.NewDefaultJWKSFetcherStrategy()
+	}
+	return c.JWKSFetcher
 }

--- a/errors.go
+++ b/errors.go
@@ -193,9 +193,21 @@ var (
 		Name:        errRegistrationNotSupportedName,
 		Code:        http.StatusBadRequest,
 	}
+	ErrInvalidRequestURI = &RFC6749Error{
+		Description: "The request_uri in the Authorization Request returns an error or contains invalid data. ",
+		Name:        errInvalidRequestURI,
+		Code:        http.StatusBadRequest,
+	}
+	ErrInvalidRequestObject = &RFC6749Error{
+		Description: "The request parameter contains an invalid Request Object. ",
+		Name:        errInvalidRequestObject,
+		Code:        http.StatusBadRequest,
+	}
 )
 
 const (
+	errInvalidRequestURI              = "invalid_request_uri"
+	errInvalidRequestObject              = "invalid_request_object"
 	errConsentRequired              = "consent_required"
 	errInteractionRequired          = "interaction_required"
 	errLoginRequired                = "login_required"

--- a/errors.go
+++ b/errors.go
@@ -178,6 +178,21 @@ var (
 		Name:        errConsentRequired,
 		Code:        http.StatusBadRequest,
 	}
+	ErrRequestNotSupported = &RFC6749Error{
+		Description: "The OP does not support use of the request parameter",
+		Name:        errRequestNotSupportedName,
+		Code:        http.StatusBadRequest,
+	}
+	ErrRequestURINotSupported = &RFC6749Error{
+		Description: "The OP does not support use of the request_uri parameter",
+		Name:        errRequestURINotSupportedName,
+		Code:        http.StatusBadRequest,
+	}
+	ErrRegistrationNotSupported = &RFC6749Error{
+		Description: "The OP does not support use of the registration parameter",
+		Name:        errRegistrationNotSupportedName,
+		Code:        http.StatusBadRequest,
+	}
 )
 
 const (
@@ -209,6 +224,9 @@ const (
 	errAuthorizaionCodeInactiveName = "authorization_code_inactive"
 	errUnknownErrorName             = "error"
 	errRevokationClientMismatchName = "revokation_client_mismatch"
+	errRequestNotSupportedName      = "request_not_supported"
+	errRequestURINotSupportedName   = "request_uri_not_supported"
+	errRegistrationNotSupportedName = "registration_not_supported"
 )
 
 func ErrorToRFC6749Error(err error) *RFC6749Error {

--- a/errors.go
+++ b/errors.go
@@ -206,8 +206,8 @@ var (
 )
 
 const (
-	errInvalidRequestURI              = "invalid_request_uri"
-	errInvalidRequestObject              = "invalid_request_object"
+	errInvalidRequestURI            = "invalid_request_uri"
+	errInvalidRequestObject         = "invalid_request_object"
 	errConsentRequired              = "consent_required"
 	errInteractionRequired          = "interaction_required"
 	errLoginRequired                = "login_required"

--- a/errors.go
+++ b/errors.go
@@ -275,6 +275,12 @@ func (e *RFC6749Error) StatusCode() int {
 	return e.Code
 }
 
+func (e *RFC6749Error) WithHint(hin string) *RFC6749Error {
+	err := *e
+	err.Hint = hin
+	return &err
+}
+
 func (e *RFC6749Error) WithDebug(debug string) *RFC6749Error {
 	err := *e
 	err.Debug = debug

--- a/fosite.go
+++ b/fosite.go
@@ -90,6 +90,10 @@ type Fosite struct {
 	RevocationHandlers         RevocationHandlers
 	Hasher                     Hasher
 	ScopeStrategy              ScopeStrategy
+	JWKSFetcherStrategy        JWKSFetcherStrategy
+
+	// TokenURL is the the URL of the Authorization Server's Token Endpoint.
+	TokenURL string
 
 	// SendDebugMessagesToClients if set to true, includes error debug messages in response payloads. Be aware that sensitive
 	// data may be exposed, depending on your implementation of Fosite. Such sensitive data might include database error

--- a/fosite.go
+++ b/fosite.go
@@ -22,6 +22,7 @@
 package fosite
 
 import (
+	"net/http"
 	"reflect"
 )
 
@@ -91,6 +92,7 @@ type Fosite struct {
 	Hasher                     Hasher
 	ScopeStrategy              ScopeStrategy
 	JWKSFetcherStrategy        JWKSFetcherStrategy
+	HTTPClient                 *http.Client
 
 	// TokenURL is the the URL of the Authorization Server's Token Endpoint.
 	TokenURL string

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -63,9 +63,10 @@ func (c *AuthorizeExplicitGrantHandler) HandleAuthorizeEndpointRequest(ctx conte
 		return nil
 	}
 
-	if !ar.GetClient().GetResponseTypes().Has("code") {
-		return errors.WithStack(fosite.ErrInvalidGrant)
-	}
+	// Disabled because this is already handled at the authorize_request_handler
+	// if !ar.GetClient().GetResponseTypes().Has("code") {
+	// 	 return errors.WithStack(fosite.ErrInvalidGrant)
+	// }
 
 	if !fosite.IsRedirectURISecure(ar.GetRedirectURI()) {
 		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("Redirect URL is using an insecure protocol, http is only allowed for hosts with suffix `localhost`, for example: http://myapp.localhost/"))

--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -54,9 +54,10 @@ func (c *AuthorizeImplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx c
 		return nil
 	}
 
-	if !ar.GetClient().GetResponseTypes().Has("token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type token"))
-	}
+	// Disabled because this is already handled at the authorize_request_handler
+	// if !ar.GetClient().GetResponseTypes().Has("token") {
+	// 	 return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type token"))
+	// }
 
 	if !ar.GetClient().GetGrantTypes().Has("implicit") {
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use grant type implicit"))

--- a/handler/oauth2/introspector_jwt_test.go
+++ b/handler/oauth2/introspector_jwt_test.go
@@ -36,8 +36,8 @@ import (
 )
 
 func TestIntrospectJWT(t *testing.T) {
-	strat := &RS256JWTStrategy{
-		RS256JWTStrategy: &jwt.RS256JWTStrategy{
+	strat := &DefaultJWTStrategy{
+		JWTStrategy: &jwt.RS256JWTStrategy{
 			PrivateKey: internal.MustRSAKey(),
 		},
 	}
@@ -129,8 +129,8 @@ func TestIntrospectJWT(t *testing.T) {
 }
 
 func BenchmarkIntrospectJWT(b *testing.B) {
-	strat := &RS256JWTStrategy{
-		RS256JWTStrategy: &jwt.RS256JWTStrategy{
+	strat := &DefaultJWTStrategy{
+		JWTStrategy: &jwt.RS256JWTStrategy{
 			PrivateKey: internal.MustRSAKey(),
 		},
 	}

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -33,14 +33,14 @@ import (
 	"github.com/pkg/errors"
 )
 
-// RS256JWTStrategy is a JWT RS256 strategy.
-type RS256JWTStrategy struct {
-	*jwt.RS256JWTStrategy
+// DefaultJWTStrategy is a JWT RS256 strategy.
+type DefaultJWTStrategy struct {
+	jwt.JWTStrategy
 	HMACSHAStrategy *HMACSHAStrategy
 	Issuer          string
 }
 
-func (h RS256JWTStrategy) signature(token string) string {
+func (h DefaultJWTStrategy) signature(token string) string {
 	split := strings.Split(token, ".")
 	if len(split) != 3 {
 		return ""
@@ -49,20 +49,20 @@ func (h RS256JWTStrategy) signature(token string) string {
 	return split[2]
 }
 
-func (h RS256JWTStrategy) AccessTokenSignature(token string) string {
+func (h DefaultJWTStrategy) AccessTokenSignature(token string) string {
 	return h.signature(token)
 }
 
-func (h *RS256JWTStrategy) GenerateAccessToken(_ context.Context, requester fosite.Requester) (token string, signature string, err error) {
+func (h *DefaultJWTStrategy) GenerateAccessToken(_ context.Context, requester fosite.Requester) (token string, signature string, err error) {
 	return h.generate(fosite.AccessToken, requester)
 }
 
-func (h *RS256JWTStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, token string) error {
+func (h *DefaultJWTStrategy) ValidateAccessToken(_ context.Context, _ fosite.Requester, token string) error {
 	_, err := h.validate(token)
 	return err
 }
 
-func (h *RS256JWTStrategy) ValidateJWT(tokenType fosite.TokenType, token string) (requester fosite.Requester, err error) {
+func (h *DefaultJWTStrategy) ValidateJWT(tokenType fosite.TokenType, token string) (requester fosite.Requester, err error) {
 	t, err := h.validate(token)
 	if err != nil {
 		return nil, err
@@ -91,32 +91,32 @@ func (h *RS256JWTStrategy) ValidateJWT(tokenType fosite.TokenType, token string)
 	return
 }
 
-func (h RS256JWTStrategy) RefreshTokenSignature(token string) string {
+func (h DefaultJWTStrategy) RefreshTokenSignature(token string) string {
 	return h.HMACSHAStrategy.RefreshTokenSignature(token)
 }
 
-func (h RS256JWTStrategy) AuthorizeCodeSignature(token string) string {
+func (h DefaultJWTStrategy) AuthorizeCodeSignature(token string) string {
 	return h.HMACSHAStrategy.AuthorizeCodeSignature(token)
 }
 
-func (h *RS256JWTStrategy) GenerateRefreshToken(ctx context.Context, req fosite.Requester) (token string, signature string, err error) {
+func (h *DefaultJWTStrategy) GenerateRefreshToken(ctx context.Context, req fosite.Requester) (token string, signature string, err error) {
 	return h.HMACSHAStrategy.GenerateRefreshToken(ctx, req)
 }
 
-func (h *RS256JWTStrategy) ValidateRefreshToken(ctx context.Context, req fosite.Requester, token string) error {
+func (h *DefaultJWTStrategy) ValidateRefreshToken(ctx context.Context, req fosite.Requester, token string) error {
 	return h.HMACSHAStrategy.ValidateRefreshToken(ctx, req, token)
 }
 
-func (h *RS256JWTStrategy) GenerateAuthorizeCode(ctx context.Context, req fosite.Requester) (token string, signature string, err error) {
+func (h *DefaultJWTStrategy) GenerateAuthorizeCode(ctx context.Context, req fosite.Requester) (token string, signature string, err error) {
 	return h.HMACSHAStrategy.GenerateAuthorizeCode(ctx, req)
 }
 
-func (h *RS256JWTStrategy) ValidateAuthorizeCode(ctx context.Context, req fosite.Requester, token string) error {
+func (h *DefaultJWTStrategy) ValidateAuthorizeCode(ctx context.Context, req fosite.Requester, token string) error {
 	return h.HMACSHAStrategy.ValidateAuthorizeCode(ctx, req, token)
 }
 
-func (h *RS256JWTStrategy) validate(token string) (t *jwtx.Token, err error) {
-	t, err = h.RS256JWTStrategy.Decode(token)
+func (h *DefaultJWTStrategy) validate(token string) (t *jwtx.Token, err error) {
+	t, err = h.JWTStrategy.Decode(token)
 
 	if err == nil {
 		err = t.Claims.Valid()
@@ -154,7 +154,7 @@ func (h *RS256JWTStrategy) validate(token string) (t *jwtx.Token, err error) {
 	return
 }
 
-func (h *RS256JWTStrategy) generate(tokenType fosite.TokenType, requester fosite.Requester) (string, string, error) {
+func (h *DefaultJWTStrategy) generate(tokenType fosite.TokenType, requester fosite.Requester) (string, string, error) {
 	if jwtSession, ok := requester.GetSession().(JWTSessionContainer); !ok {
 		return "", "", errors.New("Session must be of type JWTSessionContainer")
 	} else if jwtSession.GetJWTClaims() == nil {
@@ -173,6 +173,6 @@ func (h *RS256JWTStrategy) generate(tokenType fosite.TokenType, requester fosite
 
 		claims.Scope = requester.GetGrantedScopes()
 
-		return h.RS256JWTStrategy.Generate(claims.ToMapClaims(), jwtSession.GetJWTHeader())
+		return h.JWTStrategy.Generate(claims.ToMapClaims(), jwtSession.GetJWTHeader())
 	}
 }

--- a/handler/oauth2/strategy_jwt_test.go
+++ b/handler/oauth2/strategy_jwt_test.go
@@ -34,8 +34,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var j = &RS256JWTStrategy{
-	RS256JWTStrategy: &jwt.RS256JWTStrategy{
+var j = &DefaultJWTStrategy{
+	JWTStrategy: &jwt.RS256JWTStrategy{
 		PrivateKey: internal.MustRSAKey(),
 	},
 }

--- a/handler/openid/flow_explicit_auth_test.go
+++ b/handler/openid/flow_explicit_auth_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 var j = &DefaultStrategy{
-	RS256JWTStrategy: &jwt.RS256JWTStrategy{
+	JWTStrategy: &jwt.RS256JWTStrategy{
 		PrivateKey: internal.MustRSAKey(),
 	},
 }
@@ -57,7 +57,7 @@ func TestExplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 		IDTokenHandleHelper: &IDTokenHandleHelper{
 			IDTokenStrategy: j,
 		},
-		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.RS256JWTStrategy),
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.JWTStrategy),
 	}
 	for k, c := range []struct {
 		description string

--- a/handler/openid/flow_hybrid.go
+++ b/handler/openid/flow_hybrid.go
@@ -53,13 +53,14 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 		return nil
 	}
 
-	if ar.GetResponseTypes().Matches("token") && !ar.GetClient().GetResponseTypes().Has("token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the token response type"))
-	} else if ar.GetResponseTypes().Matches("code") && !ar.GetClient().GetResponseTypes().Has("code") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the code response type"))
-	} else if ar.GetResponseTypes().Matches("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the id_token response type"))
-	}
+	// Disabled because this is already handled at the authorize_request_handler
+	//if ar.GetResponseTypes().Matches("token") && !ar.GetClient().GetResponseTypes().Has("token") {
+	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the token response type"))
+	//} else if ar.GetResponseTypes().Matches("code") && !ar.GetClient().GetResponseTypes().Has("code") {
+	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the code response type"))
+	//} else if ar.GetResponseTypes().Matches("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
+	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the id_token response type"))
+	//}
 
 	if nonce := ar.GetRequestForm().Get("nonce"); len(nonce) == 0 {
 		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("Parameter nonce must be set when using the hybrid flow"))

--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -41,7 +41,7 @@ import (
 )
 
 var idStrategy = &DefaultStrategy{
-	RS256JWTStrategy: &jwt.RS256JWTStrategy{
+	JWTStrategy: &jwt.RS256JWTStrategy{
 		PrivateKey: internal.MustRSAKey(),
 	},
 }
@@ -95,7 +95,7 @@ func TestHybrid_HandleAuthorizeEndpointRequest(t *testing.T) {
 			IDTokenStrategy: idStrategy,
 		},
 		ScopeStrategy:                 fosite.HierarchicScopeStrategy,
-		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.RS256JWTStrategy),
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.JWTStrategy),
 		OpenIDConnectRequestStorage:   storage.NewMemoryStore(),
 	}
 

--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -54,11 +54,12 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use implicit grant type"))
 	}
 
-	if ar.GetResponseTypes().Exact("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
-	} else if ar.GetResponseTypes().Matches("token", "id_token") && !ar.GetClient().GetResponseTypes().Has("token", "id_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type token and id_token"))
-	}
+	// Disabled because this is already handled at the authorize_request_handler
+	//if ar.GetResponseTypes().Exact("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
+	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
+	//} else if ar.GetResponseTypes().Matches("token", "id_token") && !ar.GetClient().GetResponseTypes().Has("token", "id_token") {
+	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type token and id_token"))
+	//}
 
 	if nonce := ar.GetRequestForm().Get("nonce"); len(nonce) == 0 {
 		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug("Parameter nonce must be set when using the implicit flow"))

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -101,28 +101,29 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 			},
 			expectErr: fosite.ErrInvalidGrant,
 		},
-		{
-			description: "should not do anything because request requirements are not met",
-			setup: func() {
-				areq.ResponseTypes = fosite.Arguments{"token", "id_token"}
-				areq.Scopes = fosite.Arguments{"openid"}
-				areq.Client = &fosite.DefaultClient{
-					GrantTypes:    fosite.Arguments{"implicit"},
-					ResponseTypes: fosite.Arguments{},
-					Scopes:        []string{"openid", "fosite"},
-				}
-			},
-			expectErr: fosite.ErrInvalidGrant,
-		},
+		// Disabled because this is already handled at the authorize_request_handler
+		//{
+		//	description: "should not do anything because request requirements are not met",
+		//	setup: func() {
+		//		areq.ResponseTypes = fosite.Arguments{"token", "id_token"}
+		//		areq.Scopes = fosite.Arguments{"openid"}
+		//		areq.Client = &fosite.DefaultClient{
+		//			GrantTypes:    fosite.Arguments{"implicit"},
+		//			ResponseTypes: fosite.Arguments{},
+		//			Scopes:        []string{"openid", "fosite"},
+		//		}
+		//	},
+		//	expectErr: fosite.ErrInvalidGrant,
+		//},
 		{
 			description: "should not do anything because request requirements are not met",
 			setup: func() {
 				areq.ResponseTypes = fosite.Arguments{"id_token"}
 				areq.Scopes = fosite.Arguments{"openid"}
 				areq.Client = &fosite.DefaultClient{
-					GrantTypes:    fosite.Arguments{"implicit"},
-					ResponseTypes: fosite.Arguments{"token", "id_token"},
-					Scopes:        []string{"openid", "fosite"},
+					GrantTypes: fosite.Arguments{"implicit"},
+					//ResponseTypes: fosite.Arguments{"token", "id_token"},
+					Scopes: []string{"openid", "fosite"},
 				}
 			},
 			expectErr: fosite.ErrInvalidRequest,

--- a/handler/openid/flow_implicit_test.go
+++ b/handler/openid/flow_implicit_test.go
@@ -55,7 +55,7 @@ func TestImplicit_HandleAuthorizeEndpointRequest(t *testing.T) {
 			IDTokenStrategy: idStrategy,
 		},
 		ScopeStrategy:                 fosite.HierarchicScopeStrategy,
-		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.RS256JWTStrategy),
+		OpenIDConnectRequestValidator: NewOpenIDConnectRequestValidator(nil, j.JWTStrategy),
 	}
 
 	for k, c := range []struct {

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -77,9 +77,10 @@ func (c *OpenIDConnectRefreshHandler) PopulateTokenEndpointResponse(ctx context.
 		return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use the authorization_code grant type"))
 	}
 
-	if !requester.GetClient().GetResponseTypes().Has("id_token") {
-		return errors.WithStack(fosite.ErrUnknownRequest.WithDebug("The client is not allowed to use response type id_token"))
-	}
+	// Disabled because this is already handled at the authorize_request_handler
+	// if !requester.GetClient().GetResponseTypes().Has("id_token") {
+	// 	 return errors.WithStack(fosite.ErrUnknownRequest.WithDebug("The client is not allowed to use response type id_token"))
+	// }
 
 	return c.IssueExplicitIDToken(ctx, requester, responder)
 }

--- a/handler/openid/flow_refresh_token_test.go
+++ b/handler/openid/flow_refresh_token_test.go
@@ -121,19 +121,20 @@ func TestOpenIDConnectRefreshHandler_PopulateTokenEndpointResponse(t *testing.T)
 			},
 			expectedErr: fosite.ErrUnknownRequest,
 		},
-		{
-			description: "should not pass because client may not ask for id_token",
-			areq: &fosite.AccessRequest{
-				GrantTypes: []string{"refresh_token"},
-				Request: fosite.Request{
-					GrantedScopes: []string{"openid"},
-					Client: &fosite.DefaultClient{
-						GrantTypes: []string{"refresh_token"},
-					},
-				},
-			},
-			expectedErr: fosite.ErrUnknownRequest,
-		},
+		// Disabled because this is already handled at the authorize_request_handler
+		//{
+		//	description: "should not pass because client may not ask for id_token",
+		//	areq: &fosite.AccessRequest{
+		//		GrantTypes: []string{"refresh_token"},
+		//		Request: fosite.Request{
+		//			GrantedScopes: []string{"openid"},
+		//			Client: &fosite.DefaultClient{
+		//				GrantTypes: []string{"refresh_token"},
+		//			},
+		//		},
+		//	},
+		//	expectedErr: fosite.ErrUnknownRequest,
+		//},
 		{
 			description: "should pass",
 			areq: &fosite.AccessRequest{
@@ -141,8 +142,8 @@ func TestOpenIDConnectRefreshHandler_PopulateTokenEndpointResponse(t *testing.T)
 				Request: fosite.Request{
 					GrantedScopes: []string{"openid"},
 					Client: &fosite.DefaultClient{
-						GrantTypes:    []string{"refresh_token"},
-						ResponseTypes: []string{"id_token"},
+						GrantTypes: []string{"refresh_token"},
+						//ResponseTypes: []string{"id_token"},
 					},
 					Session: &DefaultSession{
 						Subject: "foo",

--- a/handler/openid/helper_test.go
+++ b/handler/openid/helper_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 var strat = &DefaultStrategy{
-	RS256JWTStrategy: &jwt.RS256JWTStrategy{
+	JWTStrategy: &jwt.RS256JWTStrategy{
 		PrivateKey: internal.MustRSAKey(),
 	},
 }

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -119,7 +119,7 @@ func (s *DefaultSession) IDTokenClaims() *jwt.IDTokenClaims {
 }
 
 type DefaultStrategy struct {
-	*jwt.RS256JWTStrategy
+	jwt.JWTStrategy
 
 	Expiry time.Duration
 	Issuer string
@@ -188,7 +188,7 @@ func (h DefaultStrategy) GenerateIDToken(_ context.Context, requester fosite.Req
 		}
 
 		if tokenHintString := requester.GetRequestForm().Get("id_token_hint"); tokenHintString != "" {
-			tokenHint, err := h.RS256JWTStrategy.Decode(tokenHintString)
+			tokenHint, err := h.JWTStrategy.Decode(tokenHintString)
 			if err != nil {
 				return "", errors.WithStack(fosite.ErrServerError.WithDebug(fmt.Sprintf("Unable to decode id token from id_token_hint parameter because %s", err.Error())))
 			}
@@ -231,6 +231,6 @@ func (h DefaultStrategy) GenerateIDToken(_ context.Context, requester fosite.Req
 	claims.Audience = stringsx.Unique(append(claims.Audience, requester.GetClient().GetID()))
 	claims.IssuedAt = time.Now().UTC()
 
-	token, _, err = h.RS256JWTStrategy.Generate(claims.ToMapClaims(), sess.IDTokenHeaders())
+	token, _, err = h.JWTStrategy.Generate(claims.ToMapClaims(), sess.IDTokenHeaders())
 	return token, err
 }

--- a/integration/authorize_code_grant_public_client_pkce_test.go
+++ b/integration/authorize_code_grant_public_client_pkce_test.go
@@ -61,7 +61,7 @@ func runAuthorizeCodeGrantWithPublicClientAndPKCETest(t *testing.T, strategy int
 	oauthClient := newOAuth2Client(ts)
 	oauthClient.ClientSecret = ""
 	oauthClient.ClientID = "public-client"
-	fositeStore.Clients["public-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["public-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	var authCodeUrl string
 	var verifier string

--- a/integration/authorize_code_grant_public_client_test.go
+++ b/integration/authorize_code_grant_public_client_test.go
@@ -52,7 +52,7 @@ func runAuthorizeCodeGrantWithPublicClientTest(t *testing.T, strategy interface{
 	oauthClient := newOAuth2Client(ts)
 	oauthClient.ClientSecret = ""
 	oauthClient.ClientID = "public-client"
-	fositeStore.Clients["public-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["public-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	var state string
 	for k, c := range []struct {

--- a/integration/authorize_code_grant_test.go
+++ b/integration/authorize_code_grant_test.go
@@ -57,7 +57,7 @@ func runAuthorizeCodeGrantTest(t *testing.T, strategy interface{}) {
 	defer ts.Close()
 
 	oauthClient := newOAuth2Client(ts)
-	fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	var state string
 	for k, c := range []struct {
@@ -101,7 +101,7 @@ func runAuthorizeCodeGrantDupeCodeTest(t *testing.T, strategy interface{}) {
 	defer ts.Close()
 
 	oauthClient := newOAuth2Client(ts)
-	fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	oauthClient = newOAuth2Client(ts)
 	state := "12345678901234567890"

--- a/integration/authorize_implicit_grant_test.go
+++ b/integration/authorize_implicit_grant_test.go
@@ -54,7 +54,7 @@ func runTestAuthorizeImplicitGrant(t *testing.T, strategy interface{}) {
 	defer ts.Close()
 
 	oauthClient := newOAuth2Client(ts)
-	fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	var state string
 	for k, c := range []struct {

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -44,7 +44,7 @@ var fositeStore = &storage.MemoryStore{
 			ID:            "my-client",
 			Secret:        []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`), // = "foobar"
 			RedirectURIs:  []string{"http://localhost:3846/callback"},
-			ResponseTypes: []string{"id_token", "code", "token"},
+			ResponseTypes: []string{"id_token", "code", "token", "token code", "id_token code", "token id_token", "token code id_token"},
 			GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 			Scopes:        []string{"fosite", "offline", "openid"},
 		},
@@ -53,7 +53,7 @@ var fositeStore = &storage.MemoryStore{
 			Secret:        []byte{},
 			Public:        true,
 			RedirectURIs:  []string{"http://localhost:3846/callback"},
-			ResponseTypes: []string{"id_token", "code"},
+			ResponseTypes: []string{"id_token", "code", "code id_token"},
 			GrantTypes:    []string{"refresh_token", "authorization_code"},
 			Scopes:        []string{"fosite", "offline", "openid"},
 		},

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -112,8 +112,8 @@ var hmacStrategy = &oauth2.HMACSHAStrategy{
 	AuthorizeCodeLifespan: authCodeLifespan,
 }
 
-var jwtStrategy = &oauth2.RS256JWTStrategy{
-	RS256JWTStrategy: &jwt.RS256JWTStrategy{
+var jwtStrategy = &oauth2.DefaultJWTStrategy{
+	JWTStrategy: &jwt.RS256JWTStrategy{
 		PrivateKey: internal.MustRSAKey(),
 	},
 	HMACSHAStrategy: hmacStrategy,

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -39,8 +39,8 @@ import (
 )
 
 var fositeStore = &storage.MemoryStore{
-	Clients: map[string]*fosite.DefaultClient{
-		"my-client": {
+	Clients: map[string]fosite.Client{
+		"my-client": &fosite.DefaultClient{
 			ID:            "my-client",
 			Secret:        []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`), // = "foobar"
 			RedirectURIs:  []string{"http://localhost:3846/callback"},
@@ -48,7 +48,7 @@ var fositeStore = &storage.MemoryStore{
 			GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 			Scopes:        []string{"fosite", "offline", "openid"},
 		},
-		"public-client": {
+		"public-client": &fosite.DefaultClient{
 			ID:            "public-client",
 			Secret:        []byte{},
 			Public:        true,

--- a/integration/oidc_explicit_test.go
+++ b/integration/oidc_explicit_test.go
@@ -31,6 +31,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/internal"
@@ -137,7 +138,7 @@ func TestOpenIDConnectExplicitFlow(t *testing.T) {
 			defer ts.Close()
 
 			oauthClient := newOAuth2Client(ts)
-			fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+			fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 			resp, err := http.Get(c.setup(oauthClient))
 			require.NoError(t, err)

--- a/integration/oidc_implicit_hybrid_test.go
+++ b/integration/oidc_implicit_hybrid_test.go
@@ -36,6 +36,7 @@ import (
 
 	"fmt"
 
+	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/internal"
@@ -56,7 +57,7 @@ func TestOIDCImplicitFlow(t *testing.T) {
 	defer ts.Close()
 
 	oauthClient := newOAuth2Client(ts)
-	fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 
 	var state = "12345678901234567890"
 	for k, c := range []struct {

--- a/integration/refresh_token_grant_test.go
+++ b/integration/refresh_token_grant_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/internal"
@@ -50,7 +51,7 @@ func TestRefreshTokenFlow(t *testing.T) {
 
 	oauthClient := newOAuth2Client(ts)
 	state := "1234567890"
-	fositeStore.Clients["my-client"].RedirectURIs[0] = ts.URL + "/callback"
+	fositeStore.Clients["my-client"].(*fosite.DefaultClient).RedirectURIs[0] = ts.URL + "/callback"
 	for _, c := range []struct {
 		description string
 		setup       func()

--- a/internal/client.go
+++ b/internal/client.go
@@ -6,6 +6,7 @@ package internal
 import (
 	gomock "github.com/golang/mock/gomock"
 	fosite "github.com/ory/fosite"
+	go_jose "gopkg.in/square/go-jose.v2"
 )
 
 // Mock of Client interface
@@ -57,6 +58,26 @@ func (_m *MockClient) GetID() string {
 
 func (_mr *_MockClientRecorder) GetID() *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetID")
+}
+
+func (_m *MockClient) GetJSONWebKeys() *go_jose.JSONWebKeySet {
+	ret := _m.ctrl.Call(_m, "GetJSONWebKeys")
+	ret0, _ := ret[0].(*go_jose.JSONWebKeySet)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) GetJSONWebKeys() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetJSONWebKeys")
+}
+
+func (_m *MockClient) GetJSONWebKeysURI() string {
+	ret := _m.ctrl.Call(_m, "GetJSONWebKeysURI")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+func (_mr *_MockClientRecorder) GetJSONWebKeysURI() *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "GetJSONWebKeysURI")
 }
 
 func (_m *MockClient) GetRedirectURIs() []string {

--- a/revoke_handler_test.go
+++ b/revoke_handler_test.go
@@ -38,11 +38,11 @@ import (
 func TestNewRevocationRequest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	store := internal.NewMockStorage(ctrl)
-	client := internal.NewMockClient(ctrl)
 	handler := internal.NewMockRevocationHandler(ctrl)
 	hasher := internal.NewMockHasher(ctrl)
 	defer ctrl.Finish()
 
+	client := &DefaultClient{}
 	fosite := &Fosite{Store: store, Hasher: hasher}
 	for k, c := range []struct {
 		header    http.Header
@@ -98,8 +98,8 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: ErrInvalidClient,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().GetHashedSecret().Return([]byte("foo"))
-				client.EXPECT().IsPublic().Return(false)
+				client.Secret = []byte("foo")
+				client.Public = false
 				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(errors.New(""))
 			},
 		},
@@ -114,8 +114,8 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: nil,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().GetHashedSecret().Return([]byte("foo"))
-				client.EXPECT().IsPublic().Return(false)
+				client.Secret = []byte("foo")
+				client.Public = false
 				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
 				handler.EXPECT().RevokeToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
@@ -133,8 +133,8 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: nil,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().GetHashedSecret().Return([]byte("foo"))
-				client.EXPECT().IsPublic().Return(false)
+				client.Secret = []byte("foo")
+				client.Public = false
 				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
 				handler.EXPECT().RevokeToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
@@ -152,8 +152,7 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: nil,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().IsPublic().Return(true)
-				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
+				client.Public = true
 				handler.EXPECT().RevokeToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			handlers: RevocationHandlers{handler},
@@ -170,8 +169,9 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: nil,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().GetHashedSecret().Return([]byte("foo"))
-				client.EXPECT().IsPublic().Return(false)
+				client.Secret = []byte("foo")
+				client.Public = false
+				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
 				handler.EXPECT().RevokeToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},
 			handlers: RevocationHandlers{handler},
@@ -188,8 +188,8 @@ func TestNewRevocationRequest(t *testing.T) {
 			expectErr: nil,
 			mock: func() {
 				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
-				client.EXPECT().GetHashedSecret().Return([]byte("foo"))
-				client.EXPECT().IsPublic().Return(false)
+				client.Secret = []byte("foo")
+				client.Public = false
 				hasher.EXPECT().Compare(gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
 				handler.EXPECT().RevokeToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 			},

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -34,7 +34,7 @@ type MemoryUserRelation struct {
 }
 
 type MemoryStore struct {
-	Clients        map[string]*fosite.DefaultClient
+	Clients        map[string]fosite.Client
 	AuthorizeCodes map[string]StoreAuthorizeCode
 	IDSessions     map[string]fosite.Requester
 	AccessTokens   map[string]fosite.Requester
@@ -49,7 +49,7 @@ type MemoryStore struct {
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		Clients:        make(map[string]*fosite.DefaultClient),
+		Clients:        make(map[string]fosite.Client),
 		AuthorizeCodes: make(map[string]StoreAuthorizeCode),
 		IDSessions:     make(map[string]fosite.Requester),
 		AccessTokens:   make(map[string]fosite.Requester),
@@ -70,8 +70,8 @@ type StoreAuthorizeCode struct {
 func NewExampleStore() *MemoryStore {
 	return &MemoryStore{
 		IDSessions: make(map[string]fosite.Requester),
-		Clients: map[string]*fosite.DefaultClient{
-			"my-client": {
+		Clients: map[string]fosite.Client{
+			"my-client": &fosite.DefaultClient{
 				ID:            "my-client",
 				Secret:        []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`), // = "foobar"
 				RedirectURIs:  []string{"http://localhost:3846/callback"},
@@ -79,7 +79,7 @@ func NewExampleStore() *MemoryStore {
 				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 				Scopes:        []string{"fosite", "openid", "photos", "offline"},
 			},
-			"encoded:client": {
+			"encoded:client": &fosite.DefaultClient{
 				ID:            "encoded:client",
 				Secret:        []byte(`$2a$10$A7M8b65dSSKGHF0H2sNkn.9Z0hT8U1Nv6OWPV3teUUaczXkVkxuDS`), // = "encoded&password"
 				RedirectURIs:  []string{"http://localhost:3846/callback"},


### PR DESCRIPTION
To do:

- [x] Support `token_endpoint_auth_method`
- [x] Support `token_endpoint_auth_signing_alg`

For request/request_uri:

- [x] ~Support `request_object_encryption_enc`~
- [x] Support `request_object_encryption_alg`
- [x] Support `request_object_signing_alg` -> should be `RS256`
   - [x] Should also support the `none` algorithm.

Changelog:
- [x] Add notice to breaking changes wrt client interface

Internal API:
- [x] #252 + docs