### PR TITLE
Return ErrLoginRequired error when `prompt=none` and session doesn't have a subject

### DIFF
--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -102,6 +102,9 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(req fosite.AuthorizeReque
 
 	claims := session.IDTokenClaims()
 	if claims.Subject == "" {
+		if stringslice.Has(prompt, "none") {
+			return errors.WithStack(fosite.ErrLoginRequired.WithDebug("Cannot authenticate user silently because user's session has expired or it has never been authenticated."))
+		}
 		return errors.WithStack(fosite.ErrServerError.WithDebug("Failed to validate OpenID Connect request because session subject is empty."))
 	}
 


### PR DESCRIPTION
Return ErrLoginRequired error when `prompt=none` and session doesn't have a subject

This would happen if one hits the auth endpoint and the auth endpoint has no information/session about current user. Right now the generic 400 error is returned.
By the standard:

> The Authorization Server MUST NOT display any authentication or consent user interface pages. An error is returned if an End-User is not already authenticated or the Client does not have pre-configured consent for the requested Claims or does not fulfill other conditions for processing the request. The error code will typically be login_required, interaction_required, or another code defined in Section 3.1.2.6. This can be used as a method to check for existing authentication and/or consent. 