### PR TITLE
compose: Pass ID Token configuration to strategy

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -96,7 +96,7 @@ func ComposeAllEnabled(config *Config, storage interface{}, secret []byte, key *
 		storage,
 		&CommonStrategy{
 			CoreStrategy:               NewOAuth2HMACStrategy(config, secret),
-			OpenIDConnectTokenStrategy: NewOpenIDConnectStrategy(key),
+			OpenIDConnectTokenStrategy: NewOpenIDConnectStrategy(config, key),
 			JWTStrategy: &jwt.RS256JWTStrategy{
 				PrivateKey: key,
 			},

--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -55,10 +55,12 @@ func NewOAuth2JWTStrategy(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy)
 	}
 }
 
-func NewOpenIDConnectStrategy(key *rsa.PrivateKey) *openid.DefaultStrategy {
+func NewOpenIDConnectStrategy(config *Config, key *rsa.PrivateKey) *openid.DefaultStrategy {
 	return &openid.DefaultStrategy{
 		JWTStrategy: &jwt.RS256JWTStrategy{
 			PrivateKey: key,
 		},
+		Expiry: config.GetIDTokenLifespan(),
+		Issuer: config.IDTokenIssuer,
 	}
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -34,8 +34,11 @@ type Config struct {
 	// AuthorizeCodeLifespan sets how long an authorize code is going to be valid. Defaults to fifteen minutes.
 	AuthorizeCodeLifespan time.Duration
 
-	// IDTokenLifespan sets how long an id token is going to be valid. Defaults to one hour.
+	// IDTokenLifespan sets the default id token lifetime. Defaults to one hour.
 	IDTokenLifespan time.Duration
+
+	// IDTokenIssuer sets the default issuer of the ID Token.
+	IDTokenIssuer string
 
 	// HashCost sets the cost of the password hashing cost. Defaults to 12.
 	HashCost int

--- a/handler/openid/flow_explicit_token_test.go
+++ b/handler/openid/flow_explicit_token_test.go
@@ -39,7 +39,7 @@ func TestHandleTokenEndpointRequest(t *testing.T) {
 	h := &OpenIDConnectExplicitHandler{}
 	areq := fosite.NewAccessRequest(nil)
 	areq.Client = &fosite.DefaultClient{
-		//ResponseTypes: fosite.Arguments{"id_token"},
+	//ResponseTypes: fosite.Arguments{"id_token"},
 	}
 	assert.EqualError(t, h.HandleTokenEndpointRequest(nil, areq), fosite.ErrUnknownRequest.Error())
 }


### PR DESCRIPTION
Resolves an issue where expiry and issuer where not properly configurable in the strategy.

See https://github.com/ory/hydra/issues/985