### PR TITLE
raise bcrypt cost factor lower bound to x/crypto/bcrypt default

### DIFF
--- a/compose/config.go
+++ b/compose/config.go
@@ -108,7 +108,7 @@ func (c *Config) GetAccessTokenLifespan() time.Duration {
 // GetAccessTokenLifespan returns how long a refresh token should be valid. Defaults to one hour.
 func (c *Config) GetHashCost() int {
 	if c.HashCost == 0 {
-		return 12
+		return fosite.DefaultBCryptWorkFactor
 	}
 	return c.HashCost
 }

--- a/hash_bcrypt.go
+++ b/hash_bcrypt.go
@@ -28,12 +28,17 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+const DefaultBCryptWorkFactor = 12
+
 // BCrypt implements the Hasher interface by using BCrypt.
 type BCrypt struct {
 	WorkFactor int
 }
 
 func (b *BCrypt) Hash(ctx context.Context, data []byte) ([]byte, error) {
+	if b.WorkFactor == 0 {
+		b.WorkFactor = DefaultBCryptWorkFactor
+	}
 	s, err := bcrypt.GenerateFromPassword(data, b.WorkFactor)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/hash_bcrypt_test.go
+++ b/hash_bcrypt_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
 )
 
 func TestCompare(t *testing.T) {
@@ -108,5 +109,19 @@ func TestHash(t *testing.T) {
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestDefaultWorkFactor(t *testing.T) {
+	b := &BCrypt{}
+	data := []byte("secrets")
+	hash, err := b.Hash(context.TODO(), data)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cost, err := bcrypt.Cost(hash)
+	if cost != 12 {
+		t.Errorf("got cost factor %d", cost)
 	}
 }


### PR DESCRIPTION
## Proposed changes

Users of this library could easily create the following:

```Go
hasher := fosite.BCrypt{}
hasher.Hash(..)
```

This is a problem because `WorkFactor` will default to 0 and `x/crypto/bcrypt` will default that to 4 (See https://godoc.org/golang.org/x/crypto/bcrypt). Instead this should be some higher cost factor.

I didn't use `config.GetHashCost()` because that's in another package. 

Callers who need a lower WorkFactor can still lower the cost, if needed.  

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
