### PR TITLE
oauth2: Update jwt access token interface

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -108,6 +108,15 @@ type fosite.Requester interface {
 }
 ```
 
+```
+type fosite/token/jwt.JWTClaimsContainer interface {
+-	// With returns a copy of itself with expiresAt and scope set to the given values.
+-	With(expiry time.Time, scope, audience []string) JWTClaimsContainer
+
++	// With returns a copy of itself with expiresAt, scope, audience set to the given values.
++	With(expiry time.Time, scope, audience []string) JWTClaimsContainer
+}
+
 ## 0.26.0
 
 This release makes it easier to define custom JWT Containers for access tokens when using the JWT strategy. To do that,

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+format:
+		goreturns -w -local github.com/ory $$(listx .)
+
+test:
+		go test ./...

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -164,6 +164,7 @@ func (h *DefaultJWTStrategy) generate(ctx context.Context, tokenType fosite.Toke
 			With(
 				jwtSession.GetExpiresAt(tokenType),
 				requester.GetGrantedScopes(),
+				requester.GetGrantedAudience(),
 			).
 			WithDefaults(
 				time.Now().UTC(),

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -36,8 +36,8 @@ type JWTClaimsDefaults struct {
 }
 
 type JWTClaimsContainer interface {
-	// With returns a copy of itself with expiresAt and scope set to the given values.
-	With(expiry time.Time, scope []string) JWTClaimsContainer
+	// With returns a copy of itself with expiresAt, scope, audience set to the given values.
+	With(expiry time.Time, scope, audience []string) JWTClaimsContainer
 
 	// WithDefaults returns a copy of itself with issuedAt and issuer set to the given default values. If those
 	// values are already set in the claims, they will not be updated.
@@ -60,11 +60,11 @@ type JWTClaims struct {
 	Extra     map[string]interface{}
 }
 
-func (c *JWTClaims) With(expiry time.Time, scope []string) JWTClaimsContainer {
+func (c *JWTClaims) With(expiry time.Time, scope, audience []string) JWTClaimsContainer {
 	c.ExpiresAt = expiry
 	c.Scope = scope
+	c.Audience = audience
 	return c
-
 }
 
 func (c *JWTClaims) WithDefaults(iat time.Time, issuer string) JWTClaimsContainer {


### PR DESCRIPTION
The interface needed to change in order to natively handle the audience claim.