### PR TITLE
oauth2: Improve refresh security and reliability

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -28,7 +28,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
 	"github.com/ory/go-convenience/stringslice"

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -31,10 +31,10 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 )
 
 func mustGenerateAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {

--- a/client.go
+++ b/client.go
@@ -21,9 +21,7 @@
 
 package fosite
 
-import (
-	"gopkg.in/square/go-jose.v2"
-)
+import jose "gopkg.in/square/go-jose.v2"
 
 // Client represents a client or an app.
 type Client interface {

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -28,9 +28,9 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 )
 
 const clientAssertionJWTBearerType = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"

--- a/client_authentication_jwks_strategy.go
+++ b/client_authentication_jwks_strategy.go
@@ -21,13 +21,13 @@
 
 package fosite
 
-import "sync"
 import (
 	"encoding/json"
 	"net/http"
+	"sync"
 
 	"github.com/pkg/errors"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 )
 
 // JWKSFetcherStrategy is a strategy which pulls (optionally caches) JSON Web Key Sets from a location,

--- a/client_authentication_jwks_strategy_test.go
+++ b/client_authentication_jwks_strategy_test.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 
 	. "github.com/ory/fosite"
 	"github.com/ory/fosite/internal"

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -33,11 +33,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
+	jose "gopkg.in/square/go-jose.v2"
 
 	. "github.com/ory/fosite"
 	"github.com/ory/fosite/internal"

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -59,10 +59,12 @@ func OAuth2ClientCredentialsGrantFactory(config *Config, storage interface{}, st
 // an access token, refresh token and authorize code validator.
 func OAuth2RefreshTokenGrantFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.RefreshTokenGrantHandler{
-		AccessTokenStrategy:    strategy.(oauth2.AccessTokenStrategy),
-		RefreshTokenStrategy:   strategy.(oauth2.RefreshTokenStrategy),
-		TokenRevocationStorage: storage.(oauth2.TokenRevocationStorage),
-		AccessTokenLifespan:    config.GetAccessTokenLifespan(),
+		AccessTokenStrategy:      strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
+		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
+		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
 	}
 }
 

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -26,7 +26,6 @@ import (
 	"fmt"
 	"net/url"
 	"testing" //"time"
-
 	//"github.com/golang/mock/gomock"
 	"time"
 

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -31,10 +31,9 @@ import (
 	"github.com/mohae/deepcopy"
 	"github.com/pkg/errors"
 
-	"github.com/ory/go-convenience/stringslice"
-
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
+	"github.com/ory/go-convenience/stringslice"
 )
 
 const defaultExpiryTime = time.Hour

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -29,11 +29,10 @@ import (
 	jwtgo "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
-	"github.com/ory/go-convenience/stringslice"
-	"github.com/ory/go-convenience/stringsx"
-
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
+	"github.com/ory/go-convenience/stringslice"
+	"github.com/ory/go-convenience/stringsx"
 )
 
 type OpenIDConnectRequestValidator struct {

--- a/integration/helper_endpoints_test.go
+++ b/integration/helper_endpoints_test.go
@@ -105,7 +105,6 @@ func authEndpointHandler(t *testing.T, oauth2 fosite.OAuth2Provider, session fos
 		}
 
 		for _, a := range ar.GetRequestedAudience() {
-			t.Logf("Granting audience: %s", a)
 			ar.GrantAudience(a)
 		}
 
@@ -119,7 +118,6 @@ func authEndpointHandler(t *testing.T, oauth2 fosite.OAuth2Provider, session fos
 			oauth2.WriteAuthorizeError(rw, ar, err)
 			return
 		}
-		t.Logf("Requested audience3: %+v", ar)
 
 		oauth2.WriteAuthorizeResponse(rw, ar, response)
 	}

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -212,7 +212,8 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		IssuedAt  int64    `json:"iat,omitempty"`
 		Subject   string   `json:"sub,omitempty"`
 		Username  string   `json:"username,omitempty"`
-		Session   Session  `json:"sess,omitempty"`
+		// Session is not included per default because it might expose sensitive information.
+		// Session   Session  `json:"sess,omitempty"`
 	}{
 		Active:    true,
 		ClientID:  r.GetAccessRequester().GetClient().GetID(),
@@ -222,6 +223,7 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		Subject:   r.GetAccessRequester().GetSession().GetSubject(),
 		Audience:  r.GetAccessRequester().GetGrantedAudience(),
 		Username:  r.GetAccessRequester().GetSession().GetUsername(),
+		// Session is not included because it might expose sensitive information.
 		// Session:   r.GetAccessRequester().GetSession(),
 	})
 }

--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -24,7 +24,7 @@ package jwt
 import (
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 )
 

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -24,7 +24,7 @@ package jwt
 import (
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 )
 

--- a/token/jwt/header.go
+++ b/token/jwt/header.go
@@ -21,7 +21,7 @@
 
 package jwt
 
-import "github.com/dgrijalva/jwt-go"
+import jwt "github.com/dgrijalva/jwt-go"
 
 // Headers is the jwt headers
 type Headers struct {

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -31,7 +31,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/dgrijalva/jwt-go"
+	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
 	"github.com/ory/fosite"


### PR DESCRIPTION
This patch resolves several issues regarding the refresh flow. First,
an issue has been resolved which caused the audience to not be
set in the refreshed access tokens.

Second, scope and audience are validated against the client's
whitelisted values and if the values are no longer allowed,
the grant is canceled.

Closes #331
Closes #325
Closes #324
