### PR TITLE
do omit exp if ExpiresAt is zero value

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -202,6 +202,11 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		return
 	}
 
+	expiresAt := int64(0)
+	if !r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).IsZero() {
+		expiresAt = r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix()
+	}
+
 	rw.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(rw).Encode(struct {
 		Active    bool     `json:"active"`
@@ -218,7 +223,7 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		Active:    true,
 		ClientID:  r.GetAccessRequester().GetClient().GetID(),
 		Scope:     strings.Join(r.GetAccessRequester().GetGrantedScopes(), " "),
-		ExpiresAt: r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix(),
+		ExpiresAt: expiresAt,
 		IssuedAt:  r.GetAccessRequester().GetRequestedAt().Unix(),
 		Subject:   r.GetAccessRequester().GetSession().GetSubject(),
 		Audience:  r.GetAccessRequester().GetGrantedAudience(),


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->

* None

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

* Make sure `exp` will be omitted if `GetExpiresAt(AccessToken)` is nil or zero value (no expiration)
* Currently, even if `GetExpiresAt(AccessToken)` is zero value, Unix() will be called, and `ExpiresAt` will be set to `-62135596800` because golang's zero time is `0001-01-01T00:00:00Z` but not `1970-01-01T00:00:00Z`

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin)
by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you
amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using
force push.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

* Currently, even if we introspect RefreshToken, AccessToken's ExpiresAt will be return in `exp`. Not sure if this is corrent. Maybe it's better to always omit exp field if we introspect RefreshToken, because there is no expiration time for RefreshToken.
* If omit `exp` for introspect RefreshToken is good, I will fire another PR.

Thank you!