### PR TITLE
oauth2: Add ability to specify refresh token lifespan

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -63,6 +63,13 @@ bumps (`0.1.0` -> `0.2.0`).
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
+## 0.28.0
+
+This version (re-)introduces refresh token lifespans. Per default, this feature is enabled and set to 30 days.
+If a refresh token has not been used within 30 days, it will expire.
+
+To disable refresh token lifespans (previous behaviour), set `compose.Config.RefreshTokenLifespan = -1`.
+
 ## 0.27.0
 
 This PR adds the ability to specify a target audience for OAuth 2.0 Access Tokens.

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -34,6 +34,7 @@ func OAuth2AuthorizeExplicitFactory(config *Config, storage interface{}, strateg
 		AuthorizeCodeStrategy:    strategy.(oauth2.AuthorizeCodeStrategy),
 		CoreStorage:              storage.(oauth2.CoreStorage),
 		AuthCodeLifespan:         config.GetAuthorizeCodeLifespan(),
+		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
 		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
 		ScopeStrategy:            config.GetScopeStrategy(),
 		AudienceMatchingStrategy: config.GetAudienceStrategy(),
@@ -63,6 +64,7 @@ func OAuth2RefreshTokenGrantFactory(config *Config, storage interface{}, strateg
 		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
 		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
 		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
+		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
 		ScopeStrategy:            config.GetScopeStrategy(),
 		AudienceMatchingStrategy: config.GetAudienceStrategy(),
 	}
@@ -86,9 +88,10 @@ func OAuth2ResourceOwnerPasswordCredentialsFactory(config *Config, storage inter
 	return &oauth2.ResourceOwnerPasswordCredentialsGrantHandler{
 		ResourceOwnerPasswordCredentialsGrantStorage: storage.(oauth2.ResourceOwnerPasswordCredentialsGrantStorage),
 		HandleHelper: &oauth2.HandleHelper{
-			AccessTokenStrategy: strategy.(oauth2.AccessTokenStrategy),
-			AccessTokenStorage:  storage.(oauth2.AccessTokenStorage),
-			AccessTokenLifespan: config.GetAccessTokenLifespan(),
+			AccessTokenStrategy:  strategy.(oauth2.AccessTokenStrategy),
+			AccessTokenStorage:   storage.(oauth2.AccessTokenStorage),
+			AccessTokenLifespan:  config.GetAccessTokenLifespan(),
+			RefreshTokenLifespan: config.GetRefreshTokenLifespan(),
 		},
 		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
 		ScopeStrategy:            config.GetScopeStrategy(),

--- a/compose/compose_openid.go
+++ b/compose/compose_openid.go
@@ -81,6 +81,7 @@ func OpenIDConnectHybridFactory(config *Config, storage interface{}, strategy in
 			CoreStorage:           storage.(oauth2.CoreStorage),
 			AuthCodeLifespan:      config.GetAuthorizeCodeLifespan(),
 			AccessTokenLifespan:   config.GetAccessTokenLifespan(),
+			RefreshTokenLifespan:  config.GetRefreshTokenLifespan(),
 		},
 		ScopeStrategy: config.GetScopeStrategy(),
 		AuthorizeImplicitGrantTypeHandler: &oauth2.AuthorizeImplicitGrantTypeHandler{

--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -44,6 +44,7 @@ func NewOAuth2HMACStrategy(config *Config, secret []byte, rotatedSecrets [][]byt
 		},
 		AccessTokenLifespan:   config.GetAccessTokenLifespan(),
 		AuthorizeCodeLifespan: config.GetAuthorizeCodeLifespan(),
+		RefreshTokenLifespan:  config.GetRefreshTokenLifespan(),
 	}
 }
 

--- a/compose/config.go
+++ b/compose/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	// AccessTokenLifespan sets how long an access token is going to be valid. Defaults to one hour.
 	AccessTokenLifespan time.Duration
 
+	// RefreshTokenLifespan sets how long a refresh token is going to be valid. Defaults to 30 days. Set to -1 for
+	// refresh tokens that never expire.
+	RefreshTokenLifespan time.Duration
+
 	// AuthorizeCodeLifespan sets how long an authorize code is going to be valid. Defaults to fifteen minutes.
 	AuthorizeCodeLifespan time.Duration
 
@@ -108,12 +112,21 @@ func (c *Config) GetIDTokenLifespan() time.Duration {
 	return c.IDTokenLifespan
 }
 
-// GetAccessTokenLifespan returns how long a refresh token should be valid. Defaults to one hour.
+// GetAccessTokenLifespan returns how long an access token should be valid. Defaults to one hour.
 func (c *Config) GetAccessTokenLifespan() time.Duration {
 	if c.AccessTokenLifespan == 0 {
 		return time.Hour
 	}
 	return c.AccessTokenLifespan
+}
+
+// GetRefreshTokenLifespan sets how long a refresh token is going to be valid. Defaults to 30 days. Set to -1 for
+// refresh tokens that never expire.
+func (c *Config) GetRefreshTokenLifespan() time.Duration {
+	if c.RefreshTokenLifespan == 0 {
+		return time.Hour * 24 * 30
+	}
+	return c.RefreshTokenLifespan
 }
 
 // GetHashCost returns the bcrypt cost factor. Defaults to 12.

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -46,6 +46,9 @@ type AuthorizeExplicitGrantHandler struct {
 	// AccessTokenLifespan defines the lifetime of an access token.
 	AccessTokenLifespan time.Duration
 
+	// RefreshTokenLifespan defines the lifetime of a refresh token. Leave to 0 for unlimited lifetime.
+	RefreshTokenLifespan time.Duration
+
 	ScopeStrategy            fosite.ScopeStrategy
 	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
 

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -106,8 +106,13 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 	// client MUST authenticate with the authorization server as described
 	// in Section 3.2.1.
 	request.SetSession(authorizeRequest.GetSession())
-	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan))
 	request.SetID(authorizeRequest.GetID())
+
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan).Round(time.Second))
+	if c.RefreshTokenLifespan > -1 {
+		request.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(c.RefreshTokenLifespan).Round(time.Second))
+	}
+
 	return nil
 }
 

--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -80,7 +80,10 @@ func (c *AuthorizeImplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx c
 }
 
 func (c *AuthorizeImplicitGrantTypeHandler) IssueImplicitAccessToken(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
-	ar.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan))
+	// Only override expiry if none is set.
+	if ar.GetSession().GetExpiresAt(fosite.AccessToken).IsZero() {
+		ar.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan).Round(time.Second))
+	}
 
 	// Generate the code
 	token, signature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, ar)

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -48,6 +48,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 				TokenRevocationStorage:   store,
 				RefreshTokenStrategy:     strategy,
 				AccessTokenLifespan:      time.Hour,
+				RefreshTokenLifespan:     time.Hour,
 				ScopeStrategy:            fosite.HierarchicScopeStrategy,
 				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
 			}
@@ -103,6 +104,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 						err = store.CreateRefreshTokenSession(nil, sig, &fosite.Request{
 							Client:       &fosite.DefaultClient{ID: ""},
 							GrantedScope: []string{"offline"},
+							Session:      sess,
 						})
 						require.NoError(t, err)
 					},
@@ -163,6 +165,8 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 						assert.Equal(t, fosite.Arguments{"foo", "offline"}, areq.GrantedScope)
 						assert.Equal(t, fosite.Arguments{"foo", "bar", "offline"}, areq.RequestedScope)
 						assert.NotEqual(t, url.Values{"foo": []string{"bar"}}, areq.Form)
+						assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.AccessToken))
+						assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.RefreshToken))
 					},
 				},
 			} {

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -77,7 +77,11 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 	// Credentials must not be passed around, potentially leaking to the database!
 	delete(request.GetRequestForm(), "password")
 
-	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan))
+	request.GetSession().SetExpiresAt(fosite.AccessToken, time.Now().UTC().Add(c.AccessTokenLifespan).Round(time.Second))
+	if c.RefreshTokenLifespan > -1 {
+		request.GetSession().SetExpiresAt(fosite.RefreshToken, time.Now().UTC().Add(c.RefreshTokenLifespan).Round(time.Second))
+	}
+
 	return nil
 }
 

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -47,8 +47,9 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 	h := ResourceOwnerPasswordCredentialsGrantHandler{
 		ResourceOwnerPasswordCredentialsGrantStorage: store,
 		HandleHelper: &HandleHelper{
-			AccessTokenStorage:  store,
-			AccessTokenLifespan: time.Hour,
+			AccessTokenStorage:   store,
+			AccessTokenLifespan:  time.Hour,
+			RefreshTokenLifespan: time.Hour,
 		},
 		ScopeStrategy:            fosite.HierarchicScopeStrategy,
 		AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
@@ -107,7 +108,9 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 				store.EXPECT().Authenticate(nil, "peter", "pan").Return(nil)
 			},
 			check: func(areq *fosite.AccessRequest) {
-				assert.NotEmpty(t, areq.GetSession().GetExpiresAt(fosite.AccessToken))
+				//assert.NotEmpty(t, areq.GetSession().GetExpiresAt(fosite.AccessToken))
+				assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.AccessToken))
+				assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.RefreshToken))
 			},
 		},
 	} {

--- a/handler/oauth2/helper.go
+++ b/handler/oauth2/helper.go
@@ -29,9 +29,10 @@ import (
 )
 
 type HandleHelper struct {
-	AccessTokenStrategy AccessTokenStrategy
-	AccessTokenStorage  AccessTokenStorage
-	AccessTokenLifespan time.Duration
+	AccessTokenStrategy  AccessTokenStrategy
+	AccessTokenStorage   AccessTokenStorage
+	AccessTokenLifespan  time.Duration
+	RefreshTokenLifespan time.Duration
 }
 
 func (h *HandleHelper) IssueAccessToken(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {

--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -82,6 +82,7 @@ func TestHybrid_HandleAuthorizeEndpointRequest(t *testing.T) {
 			AuthorizeCodeStrategy: hmacStrategy,
 			AccessTokenLifespan:   time.Hour,
 			AuthCodeLifespan:      time.Hour,
+			RefreshTokenLifespan:  time.Hour,
 			AccessTokenStrategy:   hmacStrategy,
 			CoreStorage:           storage.NewMemoryStore(),
 		},
@@ -199,6 +200,7 @@ func TestHybrid_HandleAuthorizeEndpointRequest(t *testing.T) {
 				assert.NotEmpty(t, aresp.GetFragment().Get("id_token"))
 				assert.NotEmpty(t, aresp.GetFragment().Get("code"))
 				assert.NotEmpty(t, aresp.GetFragment().Get("access_token"))
+				assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.AuthorizeCode))
 			},
 		},
 	} {

--- a/integration/oidc_implicit_hybrid_public_client_pkce_test.go
+++ b/integration/oidc_implicit_hybrid_public_client_pkce_test.go
@@ -29,15 +29,16 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	goauth "golang.org/x/oauth2"
+
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"
 	"github.com/ory/fosite/handler/openid"
 	"github.com/ory/fosite/internal"
 	"github.com/ory/fosite/token/jwt"
-	"github.com/pkg/errors"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	goauth "golang.org/x/oauth2"
 )
 
 func TestOIDCImplicitFlowPublicClientPKCE(t *testing.T) {


### PR DESCRIPTION
Set it to `-1` to disable this feature. Defaults to 30 days.