### PR TITLE
update to the Introspection example in the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,16 +336,15 @@ func tokenHandlerFunc(rw http.ResponseWriter, req *http.Request) {
 
 func someResourceProviderHandlerFunc(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
-	mySessionData := new(fosite.DefaultSession)
 	requiredScope := "blogposts.create"
 
-	_, ar, err := oauth2Provider.IntrospectToken(ctx, fosite.AccessTokenFromRequest(req), fosite.AccessToken, mySessionData, requiredScope)
+	_, ar, err := oauth2Provider.IntrospectToken(ctx, fosite.AccessTokenFromRequest(req), fosite.AccessToken, new(fosite.DefaultSession), requiredScope)
 	if err != nil {
 		// ...
 	}
 
 	// If no error occurred the token + scope is valid and you have access to:
-	// ar.GetClient().GetID(), ar.GetGrantedScopes(), ar.GetScopes(), mySessionData.UserID, ar.GetRequestedAt(), ...
+	// ar.GetClient().GetID(), ar.GetGrantedScopes(), ar.GetScopes(), ar.GetSession().UserID, ar.GetRequestedAt(), ...
 }
 ```
 


### PR DESCRIPTION
## Proposed changes

The TokenIntrospection example in the README is slightly inaccurate and misleading; the session data will need to come from the returned AccessRequester, not the pre-created session. The session passed to IntrospectToken isn't mutated.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security vulnerability, I confirm that I got green light (please contact [hi@ory.sh](mailto:hi@ory.sh)) from the maintainers to push the changes.
- [x] I signed the [Developer's Certificate of Origin](https://github.com/ory/keto/blob/master/CONTRIBUTING.md#developers-certificate-of-origin) by signing my commit(s). You can amend your signature to the most recent commit by using `git commit --amend -s`. If you amend the commit, you might need to force push using `git push --force HEAD:<branch>`. Please be very careful when using force push.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)