### PR TITLE
Add RefreshTokenScopes Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ var config = &compose.Config{
 }
 ```
 
-**Note:** To issue refresh tokens with any of the grants, you need to include the `offline` scope in the OAuth2 request.
+**Note:** To issue refresh tokens with any of the grants, you need to include the `offline` scope in the OAuth2 request. Refresh tokens can also be turned on for all grants with the `AlwaysProvideRefreshToken` configuration.
 
 #### `fosite.WildcardScopeStrategy`
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ var config = &compose.Config{
 }
 ```
 
-**Note:** To issue refresh tokens with any of the grants, you need to include the `offline` scope in the OAuth2 request. Refresh tokens can also be turned on for all grants with the `AlwaysProvideRefreshToken` configuration.
+**Note:** To issue refresh tokens with any of the grants, you need to include the `offline` scope in the OAuth2 request. This can be modified by the `RefreshTokenScopes` compose configuration. When set to an empty array, _all_ grants will issue refresh tokens.
 
 #### `fosite.WildcardScopeStrategy`
 

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -29,18 +29,18 @@ import (
 // an access token, refresh token and authorize code validator.
 func OAuth2AuthorizeExplicitFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.AuthorizeExplicitGrantHandler{
-		AccessTokenStrategy:       strategy.(oauth2.AccessTokenStrategy),
-		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
-		AuthorizeCodeStrategy:     strategy.(oauth2.AuthorizeCodeStrategy),
-		CoreStorage:               storage.(oauth2.CoreStorage),
-		AuthCodeLifespan:          config.GetAuthorizeCodeLifespan(),
-		RefreshTokenLifespan:      config.GetRefreshTokenLifespan(),
-		AccessTokenLifespan:       config.GetAccessTokenLifespan(),
-		ScopeStrategy:             config.GetScopeStrategy(),
-		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
-		TokenRevocationStorage:    storage.(oauth2.TokenRevocationStorage),
-		IsRedirectURISecure:       config.GetRedirectSecureChecker(),
-		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
+		AccessTokenStrategy:      strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
+		AuthorizeCodeStrategy:    strategy.(oauth2.AuthorizeCodeStrategy),
+		CoreStorage:              storage.(oauth2.CoreStorage),
+		AuthCodeLifespan:         config.GetAuthorizeCodeLifespan(),
+		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
+		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
+		IsRedirectURISecure:      config.GetRedirectSecureChecker(),
+		RefreshTokenScopes:       config.GetRefreshTokenScopes(),
 	}
 }
 
@@ -62,14 +62,14 @@ func OAuth2ClientCredentialsGrantFactory(config *Config, storage interface{}, st
 // an access token, refresh token and authorize code validator.
 func OAuth2RefreshTokenGrantFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.RefreshTokenGrantHandler{
-		AccessTokenStrategy:       strategy.(oauth2.AccessTokenStrategy),
-		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
-		TokenRevocationStorage:    storage.(oauth2.TokenRevocationStorage),
-		AccessTokenLifespan:       config.GetAccessTokenLifespan(),
-		RefreshTokenLifespan:      config.GetRefreshTokenLifespan(),
-		ScopeStrategy:             config.GetScopeStrategy(),
-		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
-		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
+		AccessTokenStrategy:      strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
+		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
+		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
+		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		RefreshTokenScopes:       config.GetRefreshTokenScopes(),
 	}
 }
 
@@ -96,10 +96,10 @@ func OAuth2ResourceOwnerPasswordCredentialsFactory(config *Config, storage inter
 			AccessTokenLifespan:  config.GetAccessTokenLifespan(),
 			RefreshTokenLifespan: config.GetRefreshTokenLifespan(),
 		},
-		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
-		ScopeStrategy:             config.GetScopeStrategy(),
-		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
-		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
+		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		RefreshTokenScopes:       config.GetRefreshTokenScopes(),
 	}
 }
 

--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -29,17 +29,18 @@ import (
 // an access token, refresh token and authorize code validator.
 func OAuth2AuthorizeExplicitFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.AuthorizeExplicitGrantHandler{
-		AccessTokenStrategy:      strategy.(oauth2.AccessTokenStrategy),
-		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
-		AuthorizeCodeStrategy:    strategy.(oauth2.AuthorizeCodeStrategy),
-		CoreStorage:              storage.(oauth2.CoreStorage),
-		AuthCodeLifespan:         config.GetAuthorizeCodeLifespan(),
-		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
-		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
-		ScopeStrategy:            config.GetScopeStrategy(),
-		AudienceMatchingStrategy: config.GetAudienceStrategy(),
-		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
-		IsRedirectURISecure:      config.GetRedirectSecureChecker(),
+		AccessTokenStrategy:       strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
+		AuthorizeCodeStrategy:     strategy.(oauth2.AuthorizeCodeStrategy),
+		CoreStorage:               storage.(oauth2.CoreStorage),
+		AuthCodeLifespan:          config.GetAuthorizeCodeLifespan(),
+		RefreshTokenLifespan:      config.GetRefreshTokenLifespan(),
+		AccessTokenLifespan:       config.GetAccessTokenLifespan(),
+		ScopeStrategy:             config.GetScopeStrategy(),
+		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
+		TokenRevocationStorage:    storage.(oauth2.TokenRevocationStorage),
+		IsRedirectURISecure:       config.GetRedirectSecureChecker(),
+		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
 	}
 }
 
@@ -61,13 +62,14 @@ func OAuth2ClientCredentialsGrantFactory(config *Config, storage interface{}, st
 // an access token, refresh token and authorize code validator.
 func OAuth2RefreshTokenGrantFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.RefreshTokenGrantHandler{
-		AccessTokenStrategy:      strategy.(oauth2.AccessTokenStrategy),
-		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
-		TokenRevocationStorage:   storage.(oauth2.TokenRevocationStorage),
-		AccessTokenLifespan:      config.GetAccessTokenLifespan(),
-		RefreshTokenLifespan:     config.GetRefreshTokenLifespan(),
-		ScopeStrategy:            config.GetScopeStrategy(),
-		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		AccessTokenStrategy:       strategy.(oauth2.AccessTokenStrategy),
+		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
+		TokenRevocationStorage:    storage.(oauth2.TokenRevocationStorage),
+		AccessTokenLifespan:       config.GetAccessTokenLifespan(),
+		RefreshTokenLifespan:      config.GetRefreshTokenLifespan(),
+		ScopeStrategy:             config.GetScopeStrategy(),
+		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
+		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
 	}
 }
 
@@ -94,9 +96,10 @@ func OAuth2ResourceOwnerPasswordCredentialsFactory(config *Config, storage inter
 			AccessTokenLifespan:  config.GetAccessTokenLifespan(),
 			RefreshTokenLifespan: config.GetRefreshTokenLifespan(),
 		},
-		RefreshTokenStrategy:     strategy.(oauth2.RefreshTokenStrategy),
-		ScopeStrategy:            config.GetScopeStrategy(),
-		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		RefreshTokenStrategy:      strategy.(oauth2.RefreshTokenStrategy),
+		ScopeStrategy:             config.GetScopeStrategy(),
+		AudienceMatchingStrategy:  config.GetAudienceStrategy(),
+		AlwaysProvideRefreshToken: config.GetAlwaysProvideRefreshToken(),
 	}
 }
 

--- a/compose/config.go
+++ b/compose/config.go
@@ -87,8 +87,8 @@ type Config struct {
 	// RedirectSecureChecker is a function that returns true if the provided URL can be securely used as a redirect URL.
 	RedirectSecureChecker func(*url.URL) bool
 
-	// AlwaysProvideRefreshToken, if set to true, will cause token responses on authorization code grant exchange to always provide a refresh token. Otherwise refresh tokens are only provided on requests with the "offline" or "offline_access" scope.
-	AlwaysProvideRefreshToken bool
+	// RefreshTokenScopes defines which OAuth scopes will be given refresh tokens during the authorization code grant exchange. This defaults to "offline" and "offline_access". When set to an empty array, all exchanges will be given refresh tokens.
+	RefreshTokenScopes []string
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.
@@ -172,7 +172,10 @@ func (c *Config) GetRedirectSecureChecker() func(*url.URL) bool {
 	return c.RedirectSecureChecker
 }
 
-// GetAlwaysProvideRefreshToken returns true if a refresh token should always be returned in the response of a successful authorization code grant exchange.
-func (c *Config) GetAlwaysProvideRefreshToken() bool {
-	return c.AlwaysProvideRefreshToken
+// GetRefreshTokenScopes returns which scopes will provide refresh tokens.
+func (c *Config) GetRefreshTokenScopes() []string {
+	if c.RefreshTokenScopes == nil {
+		return []string{"offline", "offline_access"}
+	}
+	return c.RefreshTokenScopes
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -86,6 +86,9 @@ type Config struct {
 
 	// RedirectSecureChecker is a function that returns true if the provided URL can be securely used as a redirect URL.
 	RedirectSecureChecker func(*url.URL) bool
+
+	// AlwaysProvideRefreshToken, if set to true, will cause token responses on authorization code grant exchange to always provide a refresh token. Otherwise refresh tokens are only provided on requests with the "offline" or "offline_access" scope.
+	AlwaysProvideRefreshToken bool
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.
@@ -167,4 +170,9 @@ func (c *Config) GetRedirectSecureChecker() func(*url.URL) bool {
 		return fosite.IsRedirectURISecure
 	}
 	return c.RedirectSecureChecker
+}
+
+// GetAlwaysProvideRefreshToken returns true if a refresh token should always be returned in the response of a successful authorization code grant exchange.
+func (c *Config) GetAlwaysProvideRefreshToken() bool {
+	return c.AlwaysProvideRefreshToken
 }

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -60,6 +60,8 @@ type AuthorizeExplicitGrantHandler struct {
 	TokenRevocationStorage TokenRevocationStorage
 
 	IsRedirectURISecure func(*url.URL) bool
+
+	AlwaysProvideRefreshToken bool
 }
 
 func (c *AuthorizeExplicitGrantHandler) secureChecker() func(*url.URL) bool {

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -61,7 +61,7 @@ type AuthorizeExplicitGrantHandler struct {
 
 	IsRedirectURISecure func(*url.URL) bool
 
-	AlwaysProvideRefreshToken bool
+	RefreshTokenScopes []string
 }
 
 func (c *AuthorizeExplicitGrantHandler) secureChecker() func(*url.URL) bool {

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -149,7 +149,7 @@ func (c *AuthorizeExplicitGrantHandler) PopulateTokenEndpointResponse(ctx contex
 	}
 
 	var refresh, refreshSignature string
-	if authorizeRequest.GetGrantedScopes().HasOneOf("offline", "offline_access") {
+	if c.AlwaysProvideRefreshToken || authorizeRequest.GetGrantedScopes().HasOneOf("offline", "offline_access") {
 		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, requester)
 		if err != nil {
 			return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -149,7 +149,7 @@ func (c *AuthorizeExplicitGrantHandler) PopulateTokenEndpointResponse(ctx contex
 	}
 
 	var refresh, refreshSignature string
-	if c.AlwaysProvideRefreshToken || authorizeRequest.GetGrantedScopes().HasOneOf("offline", "offline_access") {
+	if len(c.RefreshTokenScopes) == 0 || authorizeRequest.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...) {
 		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, requester)
 		if err != nil {
 			return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -145,7 +145,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						},
 					},
 					setup: func(t *testing.T, areq *fosite.AccessRequest) {
-						h.AlwaysProvideRefreshToken = true
+						h.RefreshTokenScopes = []string{}
 						code, sig, err := strategy.GenerateAuthorizeCode(nil, nil)
 						require.NoError(t, err)
 						areq.Form.Add("code", code)
@@ -200,6 +200,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						ScopeStrategy:            fosite.HierarchicScopeStrategy,
 						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
 						AccessTokenLifespan:      time.Minute,
+						RefreshTokenScopes:       []string{"offline"},
 					}
 
 					if c.setup != nil {

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -48,16 +48,8 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 		t.Run("strategy="+k, func(t *testing.T) {
 			store := storage.NewMemoryStore()
 
-			h := AuthorizeExplicitGrantHandler{
-				CoreStorage:              store,
-				AuthorizeCodeStrategy:    strategy,
-				AccessTokenStrategy:      strategy,
-				RefreshTokenStrategy:     strategy,
-				ScopeStrategy:            fosite.HierarchicScopeStrategy,
-				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
-				AccessTokenLifespan:      time.Minute,
-				//TokenRevocationStorage: store,
-			}
+			var h AuthorizeExplicitGrantHandler
+
 			for _, c := range []struct {
 				areq        *fosite.AccessRequest
 				description string
@@ -130,7 +122,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 
 						require.NoError(t, store.CreateAuthorizeCodeSession(nil, sig, areq))
 					},
-					description: "should pass",
+					description: "should pass with offline scope and refresh token",
 					check: func(t *testing.T, aresp *fosite.AccessResponse) {
 						assert.NotEmpty(t, aresp.AccessToken)
 						assert.Equal(t, "bearer", aresp.TokenType)
@@ -139,8 +131,77 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 						assert.Equal(t, "foo offline", aresp.GetExtra("scope"))
 					},
 				},
+				{
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{"authorization_code"},
+							},
+							GrantedScope: fosite.Arguments{"foo"},
+							Session:      &fosite.DefaultSession{},
+							RequestedAt:  time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest) {
+						h.AlwaysProvideRefreshToken = true
+						code, sig, err := strategy.GenerateAuthorizeCode(nil, nil)
+						require.NoError(t, err)
+						areq.Form.Add("code", code)
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(nil, sig, areq))
+					},
+					description: "should pass with refresh token always provided",
+					check: func(t *testing.T, aresp *fosite.AccessResponse) {
+						assert.NotEmpty(t, aresp.AccessToken)
+						assert.Equal(t, "bearer", aresp.TokenType)
+						assert.NotEmpty(t, aresp.GetExtra("refresh_token"))
+						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
+						assert.Equal(t, "foo", aresp.GetExtra("scope"))
+					},
+				},
+				{
+					areq: &fosite.AccessRequest{
+						GrantTypes: fosite.Arguments{"authorization_code"},
+						Request: fosite.Request{
+							Form: url.Values{},
+							Client: &fosite.DefaultClient{
+								GrantTypes: fosite.Arguments{"authorization_code"},
+							},
+							GrantedScope: fosite.Arguments{"foo"},
+							Session:      &fosite.DefaultSession{},
+							RequestedAt:  time.Now().UTC(),
+						},
+					},
+					setup: func(t *testing.T, areq *fosite.AccessRequest) {
+						code, sig, err := strategy.GenerateAuthorizeCode(nil, nil)
+						require.NoError(t, err)
+						areq.Form.Add("code", code)
+
+						require.NoError(t, store.CreateAuthorizeCodeSession(nil, sig, areq))
+					},
+					description: "should not have refresh token",
+					check: func(t *testing.T, aresp *fosite.AccessResponse) {
+						assert.NotEmpty(t, aresp.AccessToken)
+						assert.Equal(t, "bearer", aresp.TokenType)
+						assert.Empty(t, aresp.GetExtra("refresh_token"))
+						assert.NotEmpty(t, aresp.GetExtra("expires_in"))
+						assert.Equal(t, "foo", aresp.GetExtra("scope"))
+					},
+				},
 			} {
 				t.Run("case="+c.description, func(t *testing.T) {
+					h = AuthorizeExplicitGrantHandler{
+						CoreStorage:              store,
+						AuthorizeCodeStrategy:    strategy,
+						AccessTokenStrategy:      strategy,
+						RefreshTokenStrategy:     strategy,
+						ScopeStrategy:            fosite.HierarchicScopeStrategy,
+						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+						AccessTokenLifespan:      time.Minute,
+					}
+
 					if c.setup != nil {
 						c.setup(t, c.areq)
 					}

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -43,8 +43,9 @@ type RefreshTokenGrantHandler struct {
 	// RefreshTokenLifespan defines the lifetime of a refresh token.
 	RefreshTokenLifespan time.Duration
 
-	ScopeStrategy            fosite.ScopeStrategy
-	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+	ScopeStrategy             fosite.ScopeStrategy
+	AudienceMatchingStrategy  fosite.AudienceMatchingStrategy
+	AlwaysProvideRefreshToken bool
 }
 
 // HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-6
@@ -72,7 +73,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(err.Error()))
 	}
 
-	if !originalRequest.GetGrantedScopes().HasOneOf("offline", "offline_access") {
+	if !(c.AlwaysProvideRefreshToken || originalRequest.GetGrantedScopes().HasOneOf("offline", "offline_access")) {
 		return errors.WithStack(fosite.ErrScopeNotGranted.WithHint("The OAuth 2.0 Client was not granted scope \"offline\" or \"offline_access\" and may thus not perform the \"refresh_token\" authorization grant."))
 
 	}

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -23,6 +23,8 @@ package oauth2
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/ory/fosite/storage"
@@ -74,7 +76,9 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 	}
 
 	if !(len(c.RefreshTokenScopes) == 0 || originalRequest.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...)) {
-		return errors.WithStack(fosite.ErrScopeNotGranted.WithHint("The OAuth 2.0 Client was not granted scope \"offline\" or \"offline_access\" and may thus not perform the \"refresh_token\" authorization grant."))
+		scopeNames := strings.Join(c.RefreshTokenScopes, " or ")
+		hint := fmt.Sprintf("The OAuth 2.0 Client was not granted scope %s and may thus not perform the \"refresh_token\" authorization grant.", scopeNames)
+		return errors.WithStack(fosite.ErrScopeNotGranted.WithHint(hint))
 
 	}
 

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -43,9 +43,9 @@ type RefreshTokenGrantHandler struct {
 	// RefreshTokenLifespan defines the lifetime of a refresh token.
 	RefreshTokenLifespan time.Duration
 
-	ScopeStrategy             fosite.ScopeStrategy
-	AudienceMatchingStrategy  fosite.AudienceMatchingStrategy
-	AlwaysProvideRefreshToken bool
+	ScopeStrategy            fosite.ScopeStrategy
+	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+	RefreshTokenScopes       []string
 }
 
 // HandleTokenEndpointRequest implements https://tools.ietf.org/html/rfc6749#section-6
@@ -73,7 +73,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 		return errors.WithStack(fosite.ErrInvalidRequest.WithDebug(err.Error()))
 	}
 
-	if !(c.AlwaysProvideRefreshToken || originalRequest.GetGrantedScopes().HasOneOf("offline", "offline_access")) {
+	if !(len(c.RefreshTokenScopes) == 0 || originalRequest.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...)) {
 		return errors.WithStack(fosite.ErrScopeNotGranted.WithHint("The OAuth 2.0 Client was not granted scope \"offline\" or \"offline_access\" and may thus not perform the \"refresh_token\" authorization grant."))
 
 	}

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -197,7 +197,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 				{
 					description: "should pass without offline scope when configured to allow refresh tokens",
 					setup: func() {
-						h.AlwaysProvideRefreshToken = true
+						h.RefreshTokenScopes = []string{}
 						areq.GrantTypes = fosite.Arguments{"refresh_token"}
 						areq.Client = &fosite.DefaultClient{
 							ID:         "foo",
@@ -238,6 +238,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 						RefreshTokenLifespan:     time.Hour,
 						ScopeStrategy:            fosite.HierarchicScopeStrategy,
 						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+						RefreshTokenScopes:       []string{"offline"},
 					}
 
 					areq = fosite.NewAccessRequest(&fosite.DefaultSession{})

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -50,14 +50,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 		t.Run("strategy="+k, func(t *testing.T) {
 
 			store := storage.NewMemoryStore()
-			h := RefreshTokenGrantHandler{
-				TokenRevocationStorage:   store,
-				RefreshTokenStrategy:     strategy,
-				AccessTokenLifespan:      time.Hour,
-				RefreshTokenLifespan:     time.Hour,
-				ScopeStrategy:            fosite.HierarchicScopeStrategy,
-				AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
-			}
+			var h RefreshTokenGrantHandler
 
 			for _, c := range []struct {
 				description string
@@ -175,8 +168,78 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 						assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.RefreshToken))
 					},
 				},
+				{
+					description: "should fail without offline scope",
+					setup: func() {
+						areq.GrantTypes = fosite.Arguments{"refresh_token"}
+						areq.Client = &fosite.DefaultClient{
+							ID:         "foo",
+							GrantTypes: fosite.Arguments{"refresh_token"},
+							Scopes:     []string{"foo", "bar"},
+						}
+
+						token, sig, err := strategy.GenerateRefreshToken(nil, nil)
+						require.NoError(t, err)
+
+						areq.Form.Add("refresh_token", token)
+						err = store.CreateRefreshTokenSession(nil, sig, &fosite.Request{
+							Client:         areq.Client,
+							GrantedScope:   fosite.Arguments{"foo"},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							Session:        sess,
+							Form:           url.Values{"foo": []string{"bar"}},
+							RequestedAt:    time.Now().UTC().Add(-time.Hour).Round(time.Hour),
+						})
+						require.NoError(t, err)
+					},
+					expectErr: fosite.ErrScopeNotGranted,
+				},
+				{
+					description: "should pass without offline scope when configured to allow refresh tokens",
+					setup: func() {
+						h.AlwaysProvideRefreshToken = true
+						areq.GrantTypes = fosite.Arguments{"refresh_token"}
+						areq.Client = &fosite.DefaultClient{
+							ID:         "foo",
+							GrantTypes: fosite.Arguments{"refresh_token"},
+							Scopes:     []string{"foo", "bar"},
+						}
+
+						token, sig, err := strategy.GenerateRefreshToken(nil, nil)
+						require.NoError(t, err)
+
+						areq.Form.Add("refresh_token", token)
+						err = store.CreateRefreshTokenSession(nil, sig, &fosite.Request{
+							Client:         areq.Client,
+							GrantedScope:   fosite.Arguments{"foo"},
+							RequestedScope: fosite.Arguments{"foo", "bar"},
+							Session:        sess,
+							Form:           url.Values{"foo": []string{"bar"}},
+							RequestedAt:    time.Now().UTC().Add(-time.Hour).Round(time.Hour),
+						})
+						require.NoError(t, err)
+					},
+					expect: func(t *testing.T) {
+						assert.NotEqual(t, sess, areq.Session)
+						assert.NotEqual(t, time.Now().UTC().Add(-time.Hour).Round(time.Hour), areq.RequestedAt)
+						assert.Equal(t, fosite.Arguments{"foo"}, areq.GrantedScope)
+						assert.Equal(t, fosite.Arguments{"foo", "bar"}, areq.RequestedScope)
+						assert.NotEqual(t, url.Values{"foo": []string{"bar"}}, areq.Form)
+						assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.AccessToken))
+						assert.Equal(t, time.Now().Add(time.Hour).UTC().Round(time.Second), areq.GetSession().GetExpiresAt(fosite.RefreshToken))
+					},
+				},
 			} {
 				t.Run("case="+c.description, func(t *testing.T) {
+					h = RefreshTokenGrantHandler{
+						TokenRevocationStorage:   store,
+						RefreshTokenStrategy:     strategy,
+						AccessTokenLifespan:      time.Hour,
+						RefreshTokenLifespan:     time.Hour,
+						ScopeStrategy:            fosite.HierarchicScopeStrategy,
+						AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+					}
+
 					areq = fosite.NewAccessRequest(&fosite.DefaultSession{})
 					areq.Form = url.Values{}
 					c.setup()

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -34,10 +34,10 @@ type ResourceOwnerPasswordCredentialsGrantHandler struct {
 	// ResourceOwnerPasswordCredentialsGrantStorage is used to persist session data across requests.
 	ResourceOwnerPasswordCredentialsGrantStorage ResourceOwnerPasswordCredentialsGrantStorage
 
-	RefreshTokenStrategy      RefreshTokenStrategy
-	ScopeStrategy             fosite.ScopeStrategy
-	AudienceMatchingStrategy  fosite.AudienceMatchingStrategy
-	AlwaysProvideRefreshToken bool
+	RefreshTokenStrategy     RefreshTokenStrategy
+	ScopeStrategy            fosite.ScopeStrategy
+	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+	RefreshTokenScopes       []string
 
 	*HandleHelper
 }
@@ -93,7 +93,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) PopulateTokenEndpointResp
 	}
 
 	var refresh, refreshSignature string
-	if c.AlwaysProvideRefreshToken || requester.GetGrantedScopes().HasOneOf("offline", "offline_access") {
+	if len(c.RefreshTokenScopes) == 0 || requester.GetGrantedScopes().HasOneOf(c.RefreshTokenScopes...) {
 		var err error
 		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, requester)
 		if err != nil {

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -34,9 +34,10 @@ type ResourceOwnerPasswordCredentialsGrantHandler struct {
 	// ResourceOwnerPasswordCredentialsGrantStorage is used to persist session data across requests.
 	ResourceOwnerPasswordCredentialsGrantStorage ResourceOwnerPasswordCredentialsGrantStorage
 
-	RefreshTokenStrategy     RefreshTokenStrategy
-	ScopeStrategy            fosite.ScopeStrategy
-	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+	RefreshTokenStrategy      RefreshTokenStrategy
+	ScopeStrategy             fosite.ScopeStrategy
+	AudienceMatchingStrategy  fosite.AudienceMatchingStrategy
+	AlwaysProvideRefreshToken bool
 
 	*HandleHelper
 }
@@ -92,7 +93,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) PopulateTokenEndpointResp
 	}
 
 	var refresh, refreshSignature string
-	if requester.GetGrantedScopes().HasOneOf("offline", "offline_access") {
+	if c.AlwaysProvideRefreshToken || requester.GetGrantedScopes().HasOneOf("offline", "offline_access") {
 		var err error
 		refresh, refreshSignature, err = c.RefreshTokenStrategy.GenerateRefreshToken(ctx, requester)
 		if err != nil {

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -184,7 +184,7 @@ func TestResourceOwnerFlow_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should pass - refresh token without offline scope",
 			setup: func() {
-				h.AlwaysProvideRefreshToken = true
+				h.RefreshTokenScopes = []string{}
 				areq.GrantTypes = fosite.Arguments{"password"}
 				rtstr.EXPECT().GenerateRefreshToken(nil, areq).Return(mockRT, "bar", nil)
 				store.EXPECT().CreateRefreshTokenSession(nil, "bar", gomock.Eq(areq.Sanitize([]string{}))).Return(nil)
@@ -208,6 +208,7 @@ func TestResourceOwnerFlow_PopulateTokenEndpointResponse(t *testing.T) {
 					AccessTokenLifespan: time.Hour,
 				},
 				RefreshTokenStrategy: rtstr,
+				RefreshTokenScopes:   []string{"offline"},
 			}
 			c.setup()
 			err := h.PopulateTokenEndpointResponse(nil, areq, aresp)

--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -135,22 +135,14 @@ func TestResourceOwnerFlow_PopulateTokenEndpointResponse(t *testing.T) {
 	store := internal.NewMockResourceOwnerPasswordCredentialsGrantStorage(ctrl)
 	chgen := internal.NewMockAccessTokenStrategy(ctrl)
 	rtstr := internal.NewMockRefreshTokenStrategy(ctrl)
-	aresp := fosite.NewAccessResponse()
 	mockAT := "accesstoken.foo.bar"
 	mockRT := "refreshtoken.bar.foo"
 	defer ctrl.Finish()
 
-	areq := fosite.NewAccessRequest(nil)
+	var areq *fosite.AccessRequest
+	var aresp *fosite.AccessResponse
+	var h ResourceOwnerPasswordCredentialsGrantHandler
 
-	h := ResourceOwnerPasswordCredentialsGrantHandler{
-		ResourceOwnerPasswordCredentialsGrantStorage: store,
-		HandleHelper: &HandleHelper{
-			AccessTokenStorage:  store,
-			AccessTokenStrategy: chgen,
-			AccessTokenLifespan: time.Hour,
-		},
-		RefreshTokenStrategy: rtstr,
-	}
 	for k, c := range []struct {
 		description string
 		setup       func()
@@ -167,7 +159,6 @@ func TestResourceOwnerFlow_PopulateTokenEndpointResponse(t *testing.T) {
 		{
 			description: "should pass",
 			setup: func() {
-				areq.Session = &fosite.DefaultSession{}
 				areq.GrantTypes = fosite.Arguments{"password"}
 				chgen.EXPECT().GenerateAccessToken(nil, areq).Return(mockAT, "bar", nil)
 				store.EXPECT().CreateAccessTokenSession(nil, "bar", gomock.Eq(areq.Sanitize([]string{}))).Return(nil)
@@ -190,8 +181,34 @@ func TestResourceOwnerFlow_PopulateTokenEndpointResponse(t *testing.T) {
 				assert.NotNil(t, aresp.GetExtra("refresh_token"), "expected refresh token")
 			},
 		},
+		{
+			description: "should pass - refresh token without offline scope",
+			setup: func() {
+				h.AlwaysProvideRefreshToken = true
+				areq.GrantTypes = fosite.Arguments{"password"}
+				rtstr.EXPECT().GenerateRefreshToken(nil, areq).Return(mockRT, "bar", nil)
+				store.EXPECT().CreateRefreshTokenSession(nil, "bar", gomock.Eq(areq.Sanitize([]string{}))).Return(nil)
+				chgen.EXPECT().GenerateAccessToken(nil, areq).Return(mockAT, "bar", nil)
+				store.EXPECT().CreateAccessTokenSession(nil, "bar", gomock.Eq(areq.Sanitize([]string{}))).Return(nil)
+			},
+			expect: func() {
+				assert.NotNil(t, aresp.GetExtra("refresh_token"), "expected refresh token")
+			},
+		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			areq = fosite.NewAccessRequest(nil)
+			aresp = fosite.NewAccessResponse()
+			areq.Session = &fosite.DefaultSession{}
+			h = ResourceOwnerPasswordCredentialsGrantHandler{
+				ResourceOwnerPasswordCredentialsGrantStorage: store,
+				HandleHelper: &HandleHelper{
+					AccessTokenStorage:  store,
+					AccessTokenStrategy: chgen,
+					AccessTokenLifespan: time.Hour,
+				},
+				RefreshTokenStrategy: rtstr,
+			}
 			c.setup()
 			err := h.PopulateTokenEndpointResponse(nil, areq, aresp)
 			if c.expectErr != nil {


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the [ORY Community Forums](https://community.ory.sh/) or
join the [ORY Chat](https://www.ory.sh/chat).
-->
Original discussion #370 discussed with @aeneasr

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
This adds the `RefreshTokenScopes` to compose config to set which scopes will provide a refresh token on grant exchange. This defaults to "offline" and "offline_access". When empty all grant exchanges will provide a refresh token.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] I have read the [security policy](SECURITY.md)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
