### PR TITLE
revoke_handler: respecting ErrInvalidRequest code

### DIFF
--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -101,7 +101,16 @@ func (f *Fosite) WriteRevocationResponse(rw http.ResponseWriter, err error) {
 
 	switch errors.Cause(err).Error() {
 	case ErrInvalidRequest.Error():
-		fallthrough
+		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
+
+		js, err := json.Marshal(ErrInvalidRequest)
+		if err != nil {
+			http.Error(rw, fmt.Sprintf(`{"error": "%s"}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		rw.WriteHeader(ErrInvalidRequest.Code)
+		rw.Write(js)
 	case ErrInvalidClient.Error():
 		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 


### PR DESCRIPTION
##  Related issue
https://github.com/ory/fosite/issues/379

## Proposed changes

This commit modifies the case for ErrInvalidRequest in
WriteRevocationResponse to respect the 400 error code
and not fallthrough to ErrInvalidClient.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. 