### PR TITLE
Enable PKCE for private clients

### DIFF
--- a/compose/config.go
+++ b/compose/config.go
@@ -62,7 +62,7 @@ type Config struct {
 	// AudienceMatchingStrategy sets the audience matching strategy that should be supported, defaults to fosite.DefaultsAudienceMatchingStrategy.
 	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
 
-	// EnforcePKCE, if set to true, requires public clients to perform authorize code flows with PKCE. Defaults to false.
+	// EnforcePKCE, if set to true, requires clients to perform authorize code flows with PKCE. Defaults to false.
 	EnforcePKCE bool
 
 	// EnablePKCEPlainChallengeMethod sets whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged). Defaults to false.

--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -33,7 +33,7 @@ import (
 )
 
 type Handler struct {
-	// If set to true, public clients must use PKCE.
+	// If set to true, clients must use PKCE.
 	Force bool
 
 	// Whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged).
@@ -75,15 +75,15 @@ func (c *Handler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.
 func (c *Handler) validate(challenge, method string) error {
 	if c.Force && challenge == "" {
 		// If the server requires Proof Key for Code Exchange (PKCE) by OAuth
-		// public clients and the client does not send the "code_challenge" in
+		// clients and the client does not send the "code_challenge" in
 		// the request, the authorization endpoint MUST return the authorization
 		// error response with the "error" value set to "invalid_request".  The
 		// "error_description" or the response of "error_uri" SHOULD explain the
 		// nature of error, e.g., code challenge required.
 
 		return errors.WithStack(fosite.ErrInvalidRequest.
-			WithHint("Public clients must include a code_challenge when performing the authorize code flow, but it is missing.").
-			WithDebug("The server is configured in a way that enforces PKCE for public clients."))
+			WithHint("Clients must include a code_challenge when performing the authorize code flow, but it is missing.").
+			WithDebug("The server is configured in a way that enforces PKCE for clients."))
 	}
 
 	if !c.Force && challenge == "" {
@@ -104,8 +104,8 @@ func (c *Handler) validate(challenge, method string) error {
 	case "":
 		if !c.EnablePlainChallengeMethod {
 			return errors.WithStack(fosite.ErrInvalidRequest.
-				WithHint("Public clients must use code_challenge_method=S256, plain is not allowed.").
-				WithDebug("The server is configured in a way that enforces PKCE S256 as challenge method for public clients."))
+				WithHint("Clients must use code_challenge_method=S256, plain is not allowed.").
+				WithDebug("The server is configured in a way that enforces PKCE S256 as challenge method for clients."))
 		}
 		break
 	default:

--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -101,7 +101,16 @@ func (f *Fosite) WriteRevocationResponse(rw http.ResponseWriter, err error) {
 
 	switch errors.Cause(err).Error() {
 	case ErrInvalidRequest.Error():
-		fallthrough
+		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
+
+		js, err := json.Marshal(ErrInvalidRequest)
+		if err != nil {
+			http.Error(rw, fmt.Sprintf(`{"error": "%s"}`, err.Error()), http.StatusInternalServerError)
+			return
+		}
+
+		rw.WriteHeader(ErrInvalidRequest.Code)
+		rw.Write(js)
 	case ErrInvalidClient.Error():
 		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 


### PR DESCRIPTION
## Related issue
#1512
@aeneasr 

## Proposed changes

Remove the checks in PKCE flow that limits the feature to Public clients only.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [ ] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments
