### PR TITLE
Fix for ory/hydra#1642. Return state parameter in authorization error

### DIFF
--- a/authorize_request_handler_test.go
+++ b/authorize_request_handler_test.go
@@ -239,6 +239,8 @@ func TestNewAuthorizeRequest(t *testing.T) {
 			ar, err := c.conf.NewAuthorizeRequest(context.Background(), c.r)
 			if c.expectedError != nil {
 				assert.EqualError(t, errors.Cause(err), c.expectedError.Error())
+				// https://github.com/ory/hydra/issues/1642
+				AssertObjectKeysEqual(t, &AuthorizeRequest{State: c.query.Get("state")}, ar, "State")
 			} else {
 				require.NoError(t, err)
 				AssertObjectKeysEqual(t, c.expect, ar, "ResponseTypes", "RequestedAudience", "RequestedScope", "Client", "RedirectURI", "State")


### PR DESCRIPTION
## Related issue
https://github.com/ory/hydra/issues/1642
@aeneasr 

## Proposed changes

Changing where the state parameter is saved to the AuthorizeRequester so it can be used and returned in error conditions.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [X] I have read the [security policy](../security/policy)
- [X] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation within the code base (if appropriate)