### PR TITLE
fosite.Arguments: Nano optimization of .Exact()

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -57,6 +57,23 @@ func (r Arguments) HasOneOf(items ...string) bool {
 	return false
 }
 
+// Deprecated: Use ExactOne, Matches or MatchesExact
 func (r Arguments) Exact(name string) bool {
 	return name == strings.Join(r, " ")
+}
+
+func (r Arguments) ExactOne(name string) bool {
+	return len(r) == 1 && r[0] == name
+}
+
+func (r Arguments) MatchesExact(items ...string) bool {
+	if len(r) != len(items) {
+		return false
+	}
+	for i, item := range items {
+		if item != r[i] {
+			return false
+		}
+	}
+	return false
 }

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -27,39 +27,66 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+type exactTestCase struct {
+	args   Arguments
+	exact  string
+	expect bool
+}
+
+var exactTests = []exactTestCase{
+	{
+		args:   Arguments{"foo"},
+		exact:  "foo",
+		expect: true,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		exact:  "foo",
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		exact:  "bar",
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		exact:  "baz",
+		expect: false,
+	},
+	{
+		args:   Arguments{},
+		exact:  "baz",
+		expect: false,
+	},
+}
+
 func TestArgumentsExact(t *testing.T) {
-	for k, c := range []struct {
-		args   Arguments
-		exact  string
-		expect bool
-	}{
+	testCases := append(exactTests, []exactTestCase{
 		{
-			args:   Arguments{"foo"},
-			exact:  "foo",
+			args:   Arguments{"foo", "bar"},
+			exact:  "foo bar",
 			expect: true,
 		},
-		{
-			args:   Arguments{"foo", "bar"},
-			exact:  "foo",
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "bar"},
-			exact:  "bar",
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "bar"},
-			exact:  "baz",
-			expect: false,
-		},
-		{
-			args:   Arguments{},
-			exact:  "baz",
-			expect: false,
-		},
-	} {
+	}...)
+
+	for k, c := range testCases {
 		assert.Equal(t, c.expect, c.args.Exact(c.exact), "%d", k)
+		t.Logf("Passed test case %d", k)
+	}
+}
+
+func TestArgumentsExactOne(t *testing.T) {
+	testCases := append(exactTests, []exactTestCase{
+		{
+			args:   Arguments{"foo", "bar"},
+			exact:  "foo bar",
+			expect: false,
+		},
+	}...)
+
+	for k, c := range testCases {
+		assert.Equal(t, c.expect, c.args.ExactOne(c.exact), "%d", k)
 		t.Logf("Passed test case %d", k)
 	}
 }
@@ -116,53 +143,78 @@ func TestArgumentsHas(t *testing.T) {
 	}
 }
 
+type matchesTestCase struct {
+	args   Arguments
+	is     []string
+	expect bool
+}
+
+var matchesTests = []matchesTestCase{
+	{
+		args:   Arguments{"foo", "foo"},
+		is:     []string{"foo"},
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "foo"},
+		is:     []string{"bar", "foo"},
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		is:     []string{"bar", "foo", "baz"},
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		is:     []string{"foo"},
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		is:     []string{"bar", "bar"},
+		expect: false,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		is:     []string{"baz"},
+		expect: false,
+	},
+	{
+		args:   Arguments{},
+		is:     []string{"baz"},
+		expect: false,
+	},
+}
+
+func TestArgumentsMatchesExact(t *testing.T) {
+	testCases := append(matchesTests, []matchesTestCase{
+		{
+			args:   Arguments{"foo", "bar"},
+			is:     []string{"bar", "foo"},
+			expect: false,
+		},
+	}...)
+	for k, c := range testCases {
+		assert.Equal(t, c.expect, c.args.MatchesExact(c.is...), "%d", k)
+		t.Logf("Passed test case %d", k)
+	}
+}
+
 func TestArgumentsMatches(t *testing.T) {
-	for k, c := range []struct {
-		args   Arguments
-		is     []string
-		expect bool
-	}{
+	testCases := append(matchesTests, []matchesTestCase{
 		{
 			args:   Arguments{"foo", "bar"},
 			is:     []string{"foo", "bar"},
 			expect: true,
 		},
 		{
-			args:   Arguments{"foo", "foo"},
-			is:     []string{"foo"},
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "foo"},
+			args:   Arguments{"foo", "bar"},
 			is:     []string{"bar", "foo"},
-			expect: false,
+			expect: true,
 		},
-		{
-			args:   Arguments{"foo", "bar"},
-			is:     []string{"bar", "foo", "baz"},
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "bar"},
-			is:     []string{"foo"},
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "bar"},
-			is:     []string{"bar", "bar"},
-			expect: false,
-		},
-		{
-			args:   Arguments{"foo", "bar"},
-			is:     []string{"baz"},
-			expect: false,
-		},
-		{
-			args:   Arguments{},
-			is:     []string{"baz"},
-			expect: false,
-		},
-	} {
+	}...)
+	for k, c := range testCases {
 		assert.Equal(t, c.expect, c.args.Matches(c.is...), "%d", k)
 		t.Logf("Passed test case %d", k)
 	}

--- a/authorize_error.go
+++ b/authorize_error.go
@@ -61,7 +61,7 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 		query.Add("error_hint", rfcerr.Hint)
 	}
 
-	if !(len(ar.GetResponseTypes()) == 0 || ar.GetResponseTypes().Exact("code")) && errors.Cause(err) != ErrUnsupportedResponseType {
+	if !(len(ar.GetResponseTypes()) == 0 || ar.GetResponseTypes().ExactOne("code")) && errors.Cause(err) != ErrUnsupportedResponseType {
 		redirectURI.Fragment = query.Encode()
 	} else {
 		for key, values := range redirectURI.Query() {

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -73,7 +73,7 @@ func (c *AuthorizeExplicitGrantHandler) secureChecker() func(*url.URL) bool {
 
 func (c *AuthorizeExplicitGrantHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
 	// This let's us define multiple response types, for example open id connect's id_token
-	if !ar.GetResponseTypes().Exact("code") {
+	if !ar.GetResponseTypes().ExactOne("code") {
 		return nil
 	}
 

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -37,7 +37,7 @@ import (
 func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
 	// grant_type REQUIRED.
 	// Value MUST be set to "authorization_code".
-	if !request.GetGrantTypes().Exact("authorization_code") {
+	if !request.GetGrantTypes().ExactOne("authorization_code") {
 		return errors.WithStack(errors.WithStack(fosite.ErrUnknownRequest))
 	}
 
@@ -121,7 +121,7 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 func (c *AuthorizeExplicitGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
 	// grant_type REQUIRED.
 	// Value MUST be set to "authorization_code", as this is the explicit grant handler.
-	if !requester.GetGrantTypes().Exact("authorization_code") {
+	if !requester.GetGrantTypes().ExactOne("authorization_code") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -49,7 +49,7 @@ type AuthorizeImplicitGrantTypeHandler struct {
 
 func (c *AuthorizeImplicitGrantTypeHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
 	// This let's us define multiple response types, for example open id connect's id_token
-	if !ar.GetResponseTypes().Exact("token") {
+	if !ar.GetResponseTypes().ExactOne("token") {
 		return nil
 	}
 

--- a/handler/oauth2/flow_client_credentials.go
+++ b/handler/oauth2/flow_client_credentials.go
@@ -40,7 +40,7 @@ type ClientCredentialsGrantHandler struct {
 func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(_ context.Context, request fosite.AccessRequester) error {
 	// grant_type REQUIRED.
 	// Value MUST be set to "client_credentials".
-	if !request.GetGrantTypes().Exact("client_credentials") {
+	if !request.GetGrantTypes().ExactOne("client_credentials") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 
@@ -69,7 +69,7 @@ func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(_ context.Con
 
 // PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.4.3
 func (c *ClientCredentialsGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, request fosite.AccessRequester, response fosite.AccessResponder) error {
-	if !request.GetGrantTypes().Exact("client_credentials") {
+	if !request.GetGrantTypes().ExactOne("client_credentials") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -54,7 +54,7 @@ type RefreshTokenGrantHandler struct {
 func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
 	// grant_type REQUIRED.
 	// Value MUST be set to "refresh_token".
-	if !request.GetGrantTypes().Exact("refresh_token") {
+	if !request.GetGrantTypes().ExactOne("refresh_token") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 
@@ -116,7 +116,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 
 // PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-6
 func (c *RefreshTokenGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
-	if !requester.GetGrantTypes().Exact("refresh_token") {
+	if !requester.GetGrantTypes().ExactOne("refresh_token") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -46,7 +46,7 @@ type ResourceOwnerPasswordCredentialsGrantHandler struct {
 func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
 	// grant_type REQUIRED.
 	// Value MUST be set to "password".
-	if !request.GetGrantTypes().Exact("password") {
+	if !request.GetGrantTypes().ExactOne("password") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 
@@ -88,7 +88,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 
 // PopulateTokenEndpointResponse implements https://tools.ietf.org/html/rfc6749#section-4.3.3
 func (c *ResourceOwnerPasswordCredentialsGrantHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
-	if !requester.GetGrantTypes().Exact("password") {
+	if !requester.GetGrantTypes().ExactOne("password") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -46,7 +46,7 @@ var oidcParameters = []string{"grant_type",
 }
 
 func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
-	if !(ar.GetGrantedScopes().Has("openid") && ar.GetResponseTypes().Exact("code")) {
+	if !(ar.GetGrantedScopes().Has("openid") && ar.GetResponseTypes().ExactOne("code")) {
 		return nil
 	}
 

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -34,7 +34,7 @@ func (c *OpenIDConnectExplicitHandler) HandleTokenEndpointRequest(ctx context.Co
 }
 
 func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
-	if !requester.GetGrantTypes().Exact("authorization_code") {
+	if !requester.GetGrantTypes().ExactOne("authorization_code") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -42,7 +42,7 @@ type OpenIDConnectImplicitHandler struct {
 }
 
 func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
-	if !(ar.GetGrantedScopes().Has("openid") && (ar.GetResponseTypes().Has("token", "id_token") || ar.GetResponseTypes().Exact("id_token"))) {
+	if !(ar.GetGrantedScopes().Has("openid") && (ar.GetResponseTypes().Has("token", "id_token") || ar.GetResponseTypes().ExactOne("id_token"))) {
 		return nil
 	} else if ar.GetResponseTypes().Has("code") {
 		// hybrid flow
@@ -54,7 +54,7 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 	}
 
 	// Disabled because this is already handled at the authorize_request_handler
-	//if ar.GetResponseTypes().Exact("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
+	//if ar.GetResponseTypes().ExactOne("id_token") && !ar.GetClient().GetResponseTypes().Has("id_token") {
 	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type id_token"))
 	//} else if ar.GetResponseTypes().Matches("token", "id_token") && !ar.GetClient().GetResponseTypes().Has("token", "id_token") {
 	//	return errors.WithStack(fosite.ErrInvalidGrant.WithDebug("The client is not allowed to use response type token and id_token"))

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -35,7 +35,7 @@ type OpenIDConnectRefreshHandler struct {
 }
 
 func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
-	if !request.GetGrantTypes().Exact("refresh_token") {
+	if !request.GetGrantTypes().ExactOne("refresh_token") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 
@@ -66,7 +66,7 @@ func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Con
 }
 
 func (c *OpenIDConnectRefreshHandler) PopulateTokenEndpointResponse(ctx context.Context, requester fosite.AccessRequester, responder fosite.AccessResponder) error {
-	if !requester.GetGrantTypes().Exact("refresh_token") {
+	if !requester.GetGrantTypes().ExactOne("refresh_token") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 

--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -119,7 +119,7 @@ func (c *Handler) validate(challenge, method string) error {
 }
 
 func (c *Handler) HandleTokenEndpointRequest(ctx context.Context, request fosite.AccessRequester) error {
-	if !request.GetGrantTypes().Exact("authorization_code") {
+	if !request.GetGrantTypes().ExactOne("authorization_code") {
 		return errors.WithStack(fosite.ErrUnknownRequest)
 	}
 


### PR DESCRIPTION
Previously Arguments.Exact had vague semantic where
it coudln't distinguish between value with a space and multiple
values. Split it into 2 functions with clear semantic.
   
Old .Exact() remains for compatibility and marked as deprecated
