### PR TITLE
RFC8252#section-7.3 Loopback Interface Redirection

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -23,6 +23,7 @@ package fosite
 
 import (
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/asaskevich/govalidator"
@@ -83,7 +84,7 @@ func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.
 			// If no redirect_uri was given and the client has exactly one valid redirect_uri registered, use that instead
 			return redirectURIFromClient, nil
 		}
-	} else if rawurl != "" && StringInSlice(rawurl, client.GetRedirectURIs()) {
+	} else if rawurl != "" && isMatchingRedirectURI(rawurl, client.GetRedirectURIs()) {
 		// If a redirect_uri was given and the clients knows it (simple string comparison!)
 		// return it.
 		if parsed, err := url.Parse(rawurl); err == nil && IsValidRedirectURI(parsed) {
@@ -93,6 +94,40 @@ func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.
 	}
 
 	return nil, errors.WithStack(ErrInvalidRequest.WithHint(`The "redirect_uri" parameter does not match any of the OAuth 2.0 Client's pre-registered redirect urls.`))
+}
+
+// Match a requested  redirect URI against a pool of registered client URIs
+//
+// Test a given redirect URI against a pool of URIs provided by a registered client.
+// If the OAuth 2.0 Client has loopback URIs registered either an IPv4 URI http://127.0.0.1 or
+// an IPv6 URI http://[::1] a client is allowed to request a dynamic port and the server MUST accept
+// it as a valid redirection uri.
+//
+// https://tools.ietf.org/html/rfc8252#section-7.3
+// Native apps that are able to open a port on the loopback network
+// interface without needing special permissions (typically, those on
+// desktop operating systems) can use the loopback interface to receive
+// the OAuth redirect.
+//
+// Loopback redirect URIs use the "http" scheme and are constructed with
+// the loopback IP literal and whatever port the client is listening on.
+func isMatchingRedirectURI(uri string, haystack []string) bool {
+	for _, b := range haystack {
+		l := strings.ToLower(b)
+		if l == strings.ToLower(uri) || isLoopbackURI(uri, l) {
+			return true
+		}
+	}
+	return false
+}
+
+func isLoopbackURI(uri string, registeredURI string) bool {
+	if registeredURI != "http://127.0.0.1" && registeredURI != "http://[::1]" {
+		return false
+	}
+
+	match, _ := regexp.MatchString("http://(127.0.0.1|\\[::1\\]):?(\\d+)?", uri)
+	return match
 }
 
 // IsValidRedirectURI validates a redirect_uri as specified in:

--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -112,14 +112,13 @@ func MatchRedirectURIWithClientRedirectURIs(rawurl string, client Client) (*url.
 // Loopback redirect URIs use the "http" scheme and are constructed with
 // the loopback IP literal and whatever port the client is listening on.
 func isMatchingRedirectURI(uri string, haystack []string) bool {
-	requested, err := url.Parse(strings.ToLower(uri))
+	requested, err := url.Parse(uri)
 	if err != nil {
 		return false
 	}
 
 	for _, b := range haystack {
-		l := strings.ToLower(b)
-		if l == requested.String() || isLoopbackURI(requested, l) {
+		if strings.ToLower(b) == strings.ToLower(uri) || isLoopbackURI(requested, b) {
 			return true
 		}
 	}

--- a/authorize_helper_test.go
+++ b/authorize_helper_test.go
@@ -200,6 +200,12 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 			expected: "http://127.0.0.1",
 		},
 		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1/Cb"}},
+			url:      "http://127.0.0.1:8080/Cb",
+			isError:  false,
+			expected: "http://127.0.0.1:8080/Cb",
+		},
+		{
 			client:  &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
 			url:     "http://foo.bar/bar",
 			isError: true,

--- a/authorize_helper_test.go
+++ b/authorize_helper_test.go
@@ -161,7 +161,12 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 			expected: "http://[::1]:1024",
 		},
 		{
-			client:   &DefaultClient{RedirectURIs: []string{"http://[::1]"}},
+			client:  &DefaultClient{RedirectURIs: []string{"http://[::1]"}},
+			url:     "http://[::1]:1024/cb",
+			isError: true,
+		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://[::1]/cb"}},
 			url:      "http://[::1]:1024/cb",
 			isError:  false,
 			expected: "http://[::1]:1024/cb",
@@ -178,10 +183,15 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 			expected: "http://127.0.0.1:1024",
 		},
 		{
-			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1/cb"}},
 			url:      "http://127.0.0.1:64000/cb",
 			isError:  false,
 			expected: "http://127.0.0.1:64000/cb",
+		},
+		{
+			client:  &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:     "http://127.0.0.1:64000/cb",
+			isError: true,
 		},
 		{
 			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
@@ -192,6 +202,11 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 		{
 			client:  &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
 			url:     "http://foo.bar/bar",
+			isError: true,
+		},
+		{
+			client:  &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:     ":/invalid.uri)bar",
 			isError: true,
 		},
 	} {

--- a/authorize_helper_test.go
+++ b/authorize_helper_test.go
@@ -154,6 +154,46 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 			url:     "https://bar.com/cb123",
 			isError: true,
 		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://[::1]"}},
+			url:      "http://[::1]:1024",
+			isError:  false,
+			expected: "http://[::1]:1024",
+		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://[::1]"}},
+			url:      "http://[::1]:1024/cb",
+			isError:  false,
+			expected: "http://[::1]:1024/cb",
+		},
+		{
+			client:  &DefaultClient{RedirectURIs: []string{"http://[::1]"}},
+			url:     "http://foo.bar/bar",
+			isError: true,
+		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:      "http://127.0.0.1:1024",
+			isError:  false,
+			expected: "http://127.0.0.1:1024",
+		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:      "http://127.0.0.1:64000/cb",
+			isError:  false,
+			expected: "http://127.0.0.1:64000/cb",
+		},
+		{
+			client:   &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:      "http://127.0.0.1",
+			isError:  false,
+			expected: "http://127.0.0.1",
+		},
+		{
+			client:  &DefaultClient{RedirectURIs: []string{"http://127.0.0.1"}},
+			url:     "http://foo.bar/bar",
+			isError: true,
+		},
 	} {
 		redir, err := MatchRedirectURIWithClientRedirectURIs(c.url, c.client)
 		assert.Equal(t, c.isError, err != nil, "%d: %s", k, err)


### PR DESCRIPTION
This implements support for a dynamic port request from an oauth2 client.
RFC reference: https://tools.ietf.org/html/rfc8252#section-7.3

## Related issue
#284
https://github.com/ory/hydra/issues/1732

## Proposed changes
## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments
The RFC (https://tools.ietf.org/html/rfc8252#section-7.3) states an URI like `http://127.0.0.1:{port}/{path}` and `http://[::1]:{port}/{path}`. I am not 100% sure if this is a must or just a regex example. 
I have implemented this in fosil that it is now possible to register:

* http://127.0.0.1
* http://[::1]

... and if a registered client has one or both of these redirect uri's a client may request a dynamic port onto the loopback interface. For example http://127.0.0.1:9988 or with a path http://127.0.0.1:9988/callback. Note as with this PR, if both IPv4 and IPv6 should be supported for redirect loopback uris the clients needs to be registered with both.

If the RFC requests that the redirect URI must exactly be `http://127.0.0.1:{port}/{path}` then more code needs to be changed, for example the client registration in hydra would also fail with this (invalid) uri.
