### PR TITLE
fix: handle transactional errors due to concurrent updates in the refresh token grant handler

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -32,7 +32,10 @@ var (
 	// ErrInvalidatedAuthorizeCode is an error indicating that an authorization code has been
 	// used previously.
 	ErrInvalidatedAuthorizeCode = errors.New("Authorization code has ben invalidated")
-	ErrUnknownRequest           = &RFC6749Error{
+	// ErrSerializationFailure is an error indicating that the transactional capable storage could not guarantee
+	// consistency of Update & Delete operations on the same rows between multiple sessions.
+	ErrSerializationFailure = errors.New("The request could not be completed due to concurrent access")
+	ErrUnknownRequest       = &RFC6749Error{
 		Name:        errUnknownErrorName,
 		Description: "The handler is not responsible for this request",
 		Code:        http.StatusBadRequest,

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -181,5 +181,11 @@ func handleRefreshTokenEndpointResponseStorageError(ctx context.Context, store T
 			WithHint("Failed to refresh token because of multiple concurrent requests using the same token which is not allowed."))
 	}
 
+	if errors.Cause(storageErr) == fosite.ErrNotFound {
+		return errors.WithStack(fosite.ErrInvalidRequest.
+			WithDebugf(storageErr.Error()).
+			WithHint("Failed to refresh token because of multiple concurrent requests using the same token which is not allowed."))
+	}
+
 	return errors.WithStack(fosite.ErrServerError.WithDebug(storageErr.Error()))
 }

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -27,11 +27,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ory/fosite/storage"
-
-	"github.com/pkg/errors"
-
 	"github.com/ory/fosite"
+	"github.com/ory/fosite/storage"
+	"github.com/pkg/errors"
 )
 
 type RefreshTokenGrantHandler struct {
@@ -139,34 +137,22 @@ func (c *RefreshTokenGrantHandler) PopulateTokenEndpointResponse(ctx context.Con
 
 	ts, err := c.TokenRevocationStorage.GetRefreshTokenSession(ctx, signature, nil)
 	if err != nil {
-		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
-			err = rollBackTxnErr
-		}
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return handleRefreshTokenEndpointResponseStorageError(ctx, c.TokenRevocationStorage, err)
 	} else if err := c.TokenRevocationStorage.RevokeAccessToken(ctx, ts.GetID()); err != nil {
-		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
-			err = rollBackTxnErr
-		}
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return handleRefreshTokenEndpointResponseStorageError(ctx, c.TokenRevocationStorage, err)
 	} else if err := c.TokenRevocationStorage.RevokeRefreshToken(ctx, ts.GetID()); err != nil {
-		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
-			err = rollBackTxnErr
-		}
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return handleRefreshTokenEndpointResponseStorageError(ctx, c.TokenRevocationStorage, err)
 	}
 
 	storeReq := requester.Sanitize([]string{})
 	storeReq.SetID(ts.GetID())
+
 	if err := c.TokenRevocationStorage.CreateAccessTokenSession(ctx, accessSignature, storeReq); err != nil {
-		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
-			err = rollBackTxnErr
-		}
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
-	} else if err := c.TokenRevocationStorage.CreateRefreshTokenSession(ctx, refreshSignature, storeReq); err != nil {
-		if rollBackTxnErr := storage.MaybeRollbackTx(ctx, c.TokenRevocationStorage); rollBackTxnErr != nil {
-			err = rollBackTxnErr
-		}
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return handleRefreshTokenEndpointResponseStorageError(ctx, c.TokenRevocationStorage, err)
+	}
+
+	if err := c.TokenRevocationStorage.CreateRefreshTokenSession(ctx, refreshSignature, storeReq); err != nil {
+		return handleRefreshTokenEndpointResponseStorageError(ctx, c.TokenRevocationStorage, err)
 	}
 
 	responder.SetAccessToken(accessToken)
@@ -180,4 +166,20 @@ func (c *RefreshTokenGrantHandler) PopulateTokenEndpointResponse(ctx context.Con
 	}
 
 	return nil
+}
+
+func handleRefreshTokenEndpointResponseStorageError(ctx context.Context, store TokenRevocationStorage, storageErr error) (err error) {
+	defer func() {
+		if rbErr := storage.MaybeRollbackTx(ctx, store); rbErr != nil {
+			err = errors.WithStack(fosite.ErrServerError.WithDebug(rbErr.Error()))
+		}
+	}()
+
+	if errors.Cause(storageErr) == fosite.ErrSerializationFailure {
+		return errors.WithStack(fosite.ErrInvalidRequest.
+			WithDebugf(storageErr.Error()).
+			WithHint("Failed to refresh token because of multiple concurrent requests using the same token which is not allowed."))
+	}
+
+	return errors.WithStack(fosite.ErrServerError.WithDebug(storageErr.Error()))
 }


### PR DESCRIPTION
## Related issue

- https://github.com/ory/hydra/issues/1719
- https://github.com/ory/hydra/issues/1735 

## ⚠️ Dependent PR(s)

https://github.com/ory/hydra/pull/1766

The `hydra` PR has integration test that verifies the end-to-end flow is working as indented. It relies on the API changes introduced here to function.

## Proposed changes

This commit provides the functionality required to address:

- https://github.com/ory/hydra/issues/1719
- https://github.com/ory/hydra/issues/1735 

This has been accomplished by:

- Adding a new error type `ErrSerializationFailure` which an authorization service is expected to wrap and return from its respective storage implementation in the event that it encounters an error due to concurrent access.
- Adding error checking to the `RefreshTokenGrantHandler`'s `PopulateTokenEndpointResponse` method so it can deal with errors due to concurrent access. This will allow the authorization server to render a better error to the user-agent.

## TODO

- [x] Get preliminary feedback from @aeneasr 
  - [x] If feedback is 👍, add some unit tests! 💪📈   

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
