### PR TITLE
fix: List all response types in example memory store

### DIFF
--- a/client.go
+++ b/client.go
@@ -38,6 +38,8 @@ type Client interface {
 	GetGrantTypes() Arguments
 
 	// GetResponseTypes returns the client's allowed response types.
+	// All allowed combinations of response types have to be listed, each combination having
+	// response types of the combination separated by a space.
 	GetResponseTypes() Arguments
 
 	// GetScopes returns the scopes this client is allowed to request.

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -79,7 +79,7 @@ func NewExampleStore() *MemoryStore {
 				ID:            "my-client",
 				Secret:        []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`), // = "foobar"
 				RedirectURIs:  []string{"http://localhost:3846/callback"},
-				ResponseTypes: []string{"id_token", "code", "token"},
+				ResponseTypes: []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
 				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 				Scopes:        []string{"fosite", "openid", "photos", "offline"},
 			},
@@ -87,7 +87,7 @@ func NewExampleStore() *MemoryStore {
 				ID:            "encoded:client",
 				Secret:        []byte(`$2a$10$A7M8b65dSSKGHF0H2sNkn.9Z0hT8U1Nv6OWPV3teUUaczXkVkxuDS`), // = "encoded&password"
 				RedirectURIs:  []string{"http://localhost:3846/callback"},
-				ResponseTypes: []string{"id_token", "code", "token"},
+				ResponseTypes: []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
 				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
 				Scopes:        []string{"fosite", "openid", "photos", "offline"},
 			},


### PR DESCRIPTION
## Related issue

#304

## Proposed changes

List all possible combinations in the example response types in example memory store. This really tripps novice users of this library.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
