### PR TITLE
fix: Not part of any interface

### DIFF
--- a/storage/memory.go
+++ b/storage/memory.go
@@ -187,11 +187,6 @@ func (s *MemoryStore) InvalidateAuthorizeCodeSession(ctx context.Context, code s
 	return nil
 }
 
-func (s *MemoryStore) DeleteAuthorizeCodeSession(_ context.Context, code string) error {
-	delete(s.AuthorizeCodes, code)
-	return nil
-}
-
 func (s *MemoryStore) CreatePKCERequestSession(_ context.Context, code string, req fosite.Requester) error {
 	s.PKCES[code] = req
 	return nil
@@ -245,11 +240,6 @@ func (s *MemoryStore) GetRefreshTokenSession(_ context.Context, signature string
 
 func (s *MemoryStore) DeleteRefreshTokenSession(_ context.Context, signature string) error {
 	delete(s.RefreshTokens, signature)
-	return nil
-}
-
-func (s *MemoryStore) CreateImplicitAccessTokenSession(_ context.Context, code string, req fosite.Requester) error {
-	s.Implicit[code] = req
 	return nil
 }
 


### PR DESCRIPTION
#346  Proposed changes

`DeleteAuthorizeCodeSession` and `CreateImplicitAccessTokenSession` not part of any storage interface. So deleting them to not confuse people to think they have to implement them.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability. If this pull request addresses a security
vulnerability, I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)
