### PR TITLE
feat: Add a flag to enforce PKCE only for public clients

### DIFF
--- a/compose/compose_pkce.go
+++ b/compose/compose_pkce.go
@@ -32,6 +32,7 @@ func OAuth2PKCEFactory(config *Config, storage interface{}, strategy interface{}
 		AuthorizeCodeStrategy:      strategy.(oauth2.AuthorizeCodeStrategy),
 		Storage:                    storage.(pkce.PKCERequestStorage),
 		Force:                      config.EnforcePKCE,
+		ForceForPublicClients:      config.EnforcePKCEForPublicClients,
 		EnablePlainChallengeMethod: config.EnablePKCEPlainChallengeMethod,
 	}
 }

--- a/compose/config.go
+++ b/compose/config.go
@@ -65,6 +65,9 @@ type Config struct {
 	// EnforcePKCE, if set to true, requires clients to perform authorize code flows with PKCE. Defaults to false.
 	EnforcePKCE bool
 
+	// EnforcePKCEForPublicClients requires only public clients to use PKCE with the authorize code flow. Defaults to false.
+	EnforcePKCEForPublicClients bool
+
 	// EnablePKCEPlainChallengeMethod sets whether or not to allow the plain challenge method (S256 should be used whenever possible, plain is really discouraged). Defaults to false.
 	EnablePKCEPlainChallengeMethod bool
 


### PR DESCRIPTION
## Related issue

Alternative proposal for the issue discussed in #389 and #391, where enforcement of PKCE is wanted only for certain clients.

## Proposed changes

Add a new flag `EnforcePKCEForPublicClients` which enforces PKCE only for public clients. The error hint is slightly different, as it mentions PKCE is enforced for "this client" rather than "clients". (It intentionally does not mention why it's enforced, as I think basing it on public clients is an implementation detail that servers may want to change without adding to the error hints)

I didn't use an enum, as suggested in #391, because I imagine it would be a backwards compatibility problem. I could be convinced otherwise.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)