### PR TITLE
fix(arguments): fixes a logic bug in MatchesExact and adds documentation

### DIFF
--- a/arguments.go
+++ b/arguments.go
@@ -25,7 +25,16 @@ import "strings"
 
 type Arguments []string
 
+// Matches performs an case-insensitive, out-of-order check that the items
+// provided exist and equal all of the args in arguments.
+// Note:
+// - Providing a list that includes duplicate string-case items will return not
+//   matched.
 func (r Arguments) Matches(items ...string) bool {
+	if len(r) != len(items) {
+		return false
+	}
+
 	found := make(map[string]bool)
 	for _, item := range items {
 		if !StringInSlice(item, r) {
@@ -34,9 +43,11 @@ func (r Arguments) Matches(items ...string) bool {
 		found[item] = true
 	}
 
-	return len(found) == len(r) && len(r) == len(items)
+	return len(found) == len(r)
 }
 
+// HasOneOf checks, in a case-insensitive manner, that all of the items
+// provided exists in arguments.
 func (r Arguments) Has(items ...string) bool {
 	for _, item := range items {
 		if !StringInSlice(item, r) {
@@ -47,6 +58,8 @@ func (r Arguments) Has(items ...string) bool {
 	return true
 }
 
+// HasOneOf checks, in a case-insensitive manner, that one of the items
+// provided exists in arguments.
 func (r Arguments) HasOneOf(items ...string) bool {
 	for _, item := range items {
 		if StringInSlice(item, r) {
@@ -62,18 +75,24 @@ func (r Arguments) Exact(name string) bool {
 	return name == strings.Join(r, " ")
 }
 
+// ExactOne checks, by string case, that a single argument equals the provided
+// string.
 func (r Arguments) ExactOne(name string) bool {
 	return len(r) == 1 && r[0] == name
 }
 
+// MatchesExact checks, by order and string case, that the items provided equal
+// those in arguments.
 func (r Arguments) MatchesExact(items ...string) bool {
 	if len(r) != len(items) {
 		return false
 	}
+
 	for i, item := range items {
 		if item != r[i] {
 			return false
 		}
 	}
-	return false
+
+	return true
 }

--- a/arguments.go
+++ b/arguments.go
@@ -46,7 +46,7 @@ func (r Arguments) Matches(items ...string) bool {
 	return len(found) == len(r)
 }
 
-// HasOneOf checks, in a case-insensitive manner, that all of the items
+// Has checks, in a case-insensitive manner, that all of the items
 // provided exists in arguments.
 func (r Arguments) Has(items ...string) bool {
 	for _, item := range items {

--- a/arguments_test.go
+++ b/arguments_test.go
@@ -151,6 +151,21 @@ type matchesTestCase struct {
 
 var matchesTests = []matchesTestCase{
 	{
+		args:   Arguments{},
+		is:     []string{},
+		expect: true,
+	},
+	{
+		args:   Arguments{"foo", "bar"},
+		is:     []string{"foo", "bar"},
+		expect: true,
+	},
+	{
+		args:   Arguments{"Foo", "Bar"},
+		is:     []string{"Foo", "Bar"},
+		expect: true,
+	},
+	{
 		args:   Arguments{"foo", "foo"},
 		is:     []string{"foo"},
 		expect: false,
@@ -189,10 +204,23 @@ var matchesTests = []matchesTestCase{
 
 func TestArgumentsMatchesExact(t *testing.T) {
 	testCases := append(matchesTests, []matchesTestCase{
+		// should fail if items are out of order
 		{
 			args:   Arguments{"foo", "bar"},
 			is:     []string{"bar", "foo"},
 			expect: false,
+		},
+		// should fail due to case-sensitivity.
+		{
+			args:   Arguments{"fOo", "bar"},
+			is:     []string{"foo", "BaR"},
+			expect: false,
+		},
+		// duplicate items should return allowed.
+		{
+			args:   Arguments{"foo", "foo"},
+			is:     []string{"foo", "foo"},
+			expect: true,
 		},
 	}...)
 	for k, c := range testCases {
@@ -203,15 +231,28 @@ func TestArgumentsMatchesExact(t *testing.T) {
 
 func TestArgumentsMatches(t *testing.T) {
 	testCases := append(matchesTests, []matchesTestCase{
-		{
-			args:   Arguments{"foo", "bar"},
-			is:     []string{"foo", "bar"},
-			expect: true,
-		},
+		// should match if items are out of order.
 		{
 			args:   Arguments{"foo", "bar"},
 			is:     []string{"bar", "foo"},
 			expect: true,
+		},
+		// should allow case-insensitive matching.
+		{
+			args:   Arguments{"fOo", "bar"},
+			is:     []string{"foo", "BaR"},
+			expect: true,
+		},
+		// should return non-matching if duplicate items exist.
+		{
+			args:   Arguments{"foo", "bar"},
+			is:     []string{"FOO", "FOO", "bar"},
+			expect: false,
+		},
+		{
+			args:   Arguments{"foo", "foo"},
+			is:     []string{"foo", "foo"},
+			expect: false,
 		},
 	}...)
 	for k, c := range testCases {


### PR DESCRIPTION
Signed-off-by: Matthew Hartstonge <matt@mykro.co.nz>

## Proposed changes

There was a logic bug in `Arguments.MatchesExact(...items)`, where it would never return true and was untested.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

I also shortcut the processing of `Matches`, so you don't have to process a match if the lengths of arguments and items differ.