### PR TITLE
fix: double-decoding of client credentials in request body

### DIFF
--- a/client_authentication.go
+++ b/client_authentication.go
@@ -274,11 +274,5 @@ func clientCredentialsFromRequestBody(form url.Values, forceID bool) (clientID, 
 		return "", "", errors.WithStack(ErrInvalidRequest.WithHint("Client credentials missing or malformed in both HTTP Authorization header and HTTP POST body."))
 	}
 
-	if clientID, err = url.QueryUnescape(clientID); err != nil {
-		return "", "", errors.WithStack(ErrInvalidRequest.WithHint(`The client id in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded".`).WithDebug(err.Error()))
-	} else if clientSecret, err = url.QueryUnescape(clientSecret); err != nil {
-		return "", "", errors.WithStack(ErrInvalidRequest.WithHint(`The client secret in the HTTP authorization header could not be decoded from "application/x-www-form-urlencoded".`).WithDebug(err.Error()))
-	}
-
 	return clientID, clientSecret, nil
 }

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -80,8 +80,9 @@ func TestAuthenticateClient(t *testing.T) {
 	barSecret, err := hasher.Hash(context.TODO(), []byte("bar"))
 	require.NoError(t, err)
 
-	// a secret containing literal characters that would be affected by double-URL-decoding.
-	percentSecret, err := hasher.Hash(context.TODO(), []byte("%66%6F%6F"))
+	// a secret containing various special characters
+	complexSecretRaw := "foo %66%6F%6F@$<§!✓"
+	complexSecret, err := hasher.Hash(context.TODO(), []byte(complexSecretRaw))
 	require.NoError(t, err)
 
 	key := internal.MustRSAKey()
@@ -132,9 +133,9 @@ func TestAuthenticateClient(t *testing.T) {
 			r:      new(http.Request),
 		},
 		{
-			d:      "should pass with client ID and secret containing literal % characters",
-			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo%20bar", Secret: percentSecret}, TokenEndpointAuthMethod: "client_secret_post"},
-			form:   url.Values{"client_id": []string{"foo%20bar"}, "client_secret": []string{"%66%6F%6F"}},
+			d:      "should pass with client credentials containing special characters",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "!foo%20bar", Secret: complexSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:   url.Values{"client_id": []string{"!foo%20bar"}, "client_secret": []string{complexSecretRaw}},
 			r:      new(http.Request),
 		},
 		{

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -139,6 +139,12 @@ func TestAuthenticateClient(t *testing.T) {
 			r:      new(http.Request),
 		},
 		{
+			d:      "should pass with client credentials containing special characters via basic auth",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo — bar! +<&>*", Secret: complexSecret}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:   url.Values{},
+			r:      &http.Request{Header: http.Header{"Authorization": {"Basic " + base64.StdEncoding.EncodeToString([]byte(url.QueryEscape("foo — bar! +<&>*")+":"+url.QueryEscape(complexSecretRaw)))}}},
+		},
+		{
 			d:         "should fail because auth method is not none",
 			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "client_secret_basic"},
 			form:      url.Values{"client_id": []string{"foo"}},

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -80,6 +80,10 @@ func TestAuthenticateClient(t *testing.T) {
 	barSecret, err := hasher.Hash(context.TODO(), []byte("bar"))
 	require.NoError(t, err)
 
+	// a secret containing literal characters that would be affected by double-URL-decoding.
+	percentSecret, err := hasher.Hash(context.TODO(), []byte("%66%6F%6F"))
+	require.NoError(t, err)
+
 	key := internal.MustRSAKey()
 	jwks := &jose.JSONWebKeySet{
 		Keys: []jose.JSONWebKey{
@@ -125,6 +129,12 @@ func TestAuthenticateClient(t *testing.T) {
 			d:      "should pass because client is public and authentication requirements are met",
 			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "none"},
 			form:   url.Values{"client_id": []string{"foo"}},
+			r:      new(http.Request),
+		},
+		{
+			d:      "should pass with client ID and secret containing literal % characters",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo%20bar", Secret: percentSecret}, TokenEndpointAuthMethod: "client_secret_post"},
+			form:   url.Values{"client_id": []string{"foo%20bar"}, "client_secret": []string{"%66%6F%6F"}},
 			r:      new(http.Request),
 		},
 		{


### PR DESCRIPTION
I noticed that client credentials are URL-decoded after being extracted from the POST body form, which was already URL-decoded by Go. The accompanying error message suggests this was copied and pasted from the HTTP basic authorization header handling, which is the only place where the extra URL-decoding was needed (as per the OAuth 2.0 spec). The result is that client credentials containing `%`-prefixed sequences, whether valid sequences or not, are going to fail validation.

## Proposed changes

Remove the extra URL decoding. Add tests that ensure client credentials work with special characters in both the HTTP basic auth header and in the request body.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security vulnerability.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)