### PR TITLE
feat: Added support for ES256 token strategy and client authentication

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -103,21 +103,21 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequest(request *Aut
 
 		switch t.Method.(type) {
 		case *jwt.SigningMethodRSA:
-			key, err := f.findClientPublicJWK(oidcClient, t)
+			key, err := f.findClientPublicJWK(oidcClient, t, true)
 			if err != nil {
-				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve signing key from OAuth 2.0 Client because %s.", err))
+				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve RSA signing key from OAuth 2.0 Client because %s.", err))
 			}
 			return key, nil
 		case *jwt.SigningMethodECDSA:
-			key, err := f.findClientPublicJWK(oidcClient, t)
+			key, err := f.findClientPublicJWK(oidcClient, t, false)
 			if err != nil {
-				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve signing key from OAuth 2.0 Client because %s.", err))
+				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve ECDSA signing key from OAuth 2.0 Client because %s.", err))
 			}
 			return key, nil
 		case *jwt.SigningMethodRSAPSS:
-			key, err := f.findClientPublicJWK(oidcClient, t)
+			key, err := f.findClientPublicJWK(oidcClient, t, true)
 			if err != nil {
-				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve signing key from OAuth 2.0 Client because %s.", err))
+				return nil, errors.WithStack(ErrInvalidRequestObject.WithHintf("Unable to retrieve RSA signing key from OAuth 2.0 Client because %s.", err))
 			}
 			return key, nil
 		default:

--- a/client.go
+++ b/client.go
@@ -94,11 +94,12 @@ type DefaultClient struct {
 
 type DefaultOpenIDConnectClient struct {
 	*DefaultClient
-	JSONWebKeysURI                string              `json:"jwks_uri"`
-	JSONWebKeys                   *jose.JSONWebKeySet `json:"jwks"`
-	TokenEndpointAuthMethod       string              `json:"token_endpoint_auth_method"`
-	RequestURIs                   []string            `json:"request_uris"`
-	RequestObjectSigningAlgorithm string              `json:"request_object_signing_alg"`
+	JSONWebKeysURI                    string              `json:"jwks_uri"`
+	JSONWebKeys                       *jose.JSONWebKeySet `json:"jwks"`
+	TokenEndpointAuthMethod           string              `json:"token_endpoint_auth_method"`
+	RequestURIs                       []string            `json:"request_uris"`
+	RequestObjectSigningAlgorithm     string              `json:"request_object_signing_alg"`
+	TokenEndpointAuthSigningAlgorithm string              `json:"token_endpoint_auth_signing_alg"`
 }
 
 func (c *DefaultClient) GetID() string {
@@ -158,7 +159,11 @@ func (c *DefaultOpenIDConnectClient) GetJSONWebKeys() *jose.JSONWebKeySet {
 }
 
 func (c *DefaultOpenIDConnectClient) GetTokenEndpointAuthSigningAlgorithm() string {
-	return "RS256"
+	if c.TokenEndpointAuthSigningAlgorithm == "" {
+		return "RS256"
+	} else {
+		return c.TokenEndpointAuthSigningAlgorithm
+	}
 }
 
 func (c *DefaultOpenIDConnectClient) GetRequestObjectSigningAlgorithm() string {

--- a/internal/key.go
+++ b/internal/key.go
@@ -22,6 +22,8 @@
 package internal
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 )
@@ -29,6 +31,14 @@ import (
 func MustRSAKey() *rsa.PrivateKey {
 	// #nosec
 	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func MustECDSAKey() *ecdsa.PrivateKey {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		panic(err)
 	}

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -26,6 +26,7 @@ package jwt
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/sha256"
 	"fmt"
@@ -124,6 +125,86 @@ func (j *RS256JWTStrategy) Hash(ctx context.Context, in []byte) ([]byte, error) 
 // GetSigningMethodLength will return the length of the signing method
 func (j *RS256JWTStrategy) GetSigningMethodLength() int {
 	return jwt.SigningMethodRS256.Hash.Size()
+}
+
+// ES256JWTStrategy is responsible for generating and validating JWT challenges
+type ES256JWTStrategy struct {
+	PrivateKey *ecdsa.PrivateKey
+}
+
+// Generate generates a new authorize code or returns an error. set secret
+func (j *ES256JWTStrategy) Generate(ctx context.Context, claims jwt.Claims, header Mapper) (string, string, error) {
+	if header == nil || claims == nil {
+		return "", "", errors.New("Either claims or header is nil.")
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token.Header = assign(token.Header, header.ToMap())
+
+	var sig, sstr string
+	var err error
+	if sstr, err = token.SigningString(); err != nil {
+		return "", "", errors.WithStack(err)
+	}
+
+	if sig, err = token.Method.Sign(sstr, j.PrivateKey); err != nil {
+		return "", "", errors.WithStack(err)
+	}
+
+	return fmt.Sprintf("%s.%s", sstr, sig), sig, nil
+}
+
+// Validate validates a token and returns its signature or an error if the token is not valid.
+func (j *ES256JWTStrategy) Validate(ctx context.Context, token string) (string, error) {
+	if _, err := j.Decode(ctx, token); err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return j.GetSignature(ctx, token)
+}
+
+// Decode will decode a JWT token
+func (j *ES256JWTStrategy) Decode(ctx context.Context, token string) (*jwt.Token, error) {
+	// Parse the token.
+	parsedToken, err := jwt.Parse(token, func(t *jwt.Token) (interface{}, error) {
+		if _, ok := t.Method.(*jwt.SigningMethodECDSA); !ok {
+			return nil, errors.Errorf("Unexpected signing method: %v", t.Header["alg"])
+		}
+		return &j.PrivateKey.PublicKey, nil
+	})
+
+	if err != nil {
+		return parsedToken, errors.WithStack(err)
+	} else if !parsedToken.Valid {
+		return parsedToken, errors.WithStack(fosite.ErrInactiveToken)
+	}
+
+	return parsedToken, err
+}
+
+// GetSignature will return the signature of a token
+func (j *ES256JWTStrategy) GetSignature(ctx context.Context, token string) (string, error) {
+	split := strings.Split(token, ".")
+	if len(split) != 3 {
+		return "", errors.New("Header, body and signature must all be set")
+	}
+	return split[2], nil
+}
+
+// Hash will return a given hash based on the byte input or an error upon fail
+func (j *ES256JWTStrategy) Hash(ctx context.Context, in []byte) ([]byte, error) {
+	// SigningMethodES256
+	hash := sha256.New()
+	_, err := hash.Write(in)
+	if err != nil {
+		return []byte{}, errors.WithStack(err)
+	}
+	return hash.Sum([]byte{}), nil
+}
+
+// GetSigningMethodLength will return the length of the signing method
+func (j *ES256JWTStrategy) GetSigningMethodLength() int {
+	return jwt.SigningMethodES256.Hash.Size()
 }
 
 func assign(a, b map[string]interface{}) map[string]interface{} {


### PR DESCRIPTION
## Related issue

Fixes: https://github.com/ory/fosite/issues/429

## Proposed changes

I added to `DefaultOpenIDConnectClient` a field `TokenEndpointAuthSigningAlgorithm` to be able to configure what `GetTokenEndpointAuthSigningAlgorithm` returns. I also cleaned some other places where there were assumptions about only RSA keys.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
