### PR TITLE
feat: Set default issuer in JWT tokens

### DIFF
--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -58,6 +58,16 @@ func NewOAuth2JWTStrategy(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy)
 	}
 }
 
+func NewOAuth2JWTStrategyWithIssuer(key *rsa.PrivateKey, strategy *oauth2.HMACSHAStrategy, issuer string) *oauth2.DefaultJWTStrategy {
+	return &oauth2.DefaultJWTStrategy{
+		JWTStrategy: &jwt.RS256JWTStrategy{
+			PrivateKey: key,
+		},
+		HMACSHAStrategy: strategy,
+		Issuer: issuer,
+	}
+}
+
 func NewOpenIDConnectStrategy(config *Config, key *rsa.PrivateKey) *openid.DefaultStrategy {
 	return &openid.DefaultStrategy{
 		JWTStrategy: &jwt.RS256JWTStrategy{


### PR DESCRIPTION
## Proposed changes

This is backwards incompatible change, but it allows one to set default issuer which seems to not be possible otherwise, despite being existing in the `DefaultJWTStrategy` struct.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
