### PR TITLE
docs: Add some comments to the example code explaining empty session

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,10 @@ func authorizeHandlerFunc(rw http.ResponseWriter, req *http.Request) {
 // The token endpoint is usually at "https://mydomain.com/oauth2/token"
 func tokenHandlerFunc(rw http.ResponseWriter, req *http.Request) {
 	ctx := req.Context()
+
+	// Create an empty session object that will be passed to storage implementation to populate (unmarshal) the session into.
+	// By passing an empty session object as a "prototype" to the store, the store can use the underlying type to unmarshal the value into it.
+	// For an example of storage implementation that takes advantage of that, see SQL Store (fosite_store_sql.go) from ory/Hydra project.
 	mySessionData := new(fosite.DefaultSession)
 
 	// This will create an access request object and iterate through the registered TokenEndpointHandlers to validate the request.


### PR DESCRIPTION
## Related issue

Added some comments to the example code in `README.md` to explain the logic behind the empty session that appears in the token endpoint to hopefully avoid possible confusion such as in #448 and #256. Linking @aeneasr.

## Proposed changes

Just couple of lines of documentation and a reference to implementation of a real storage (SQL store) from ory/Hydra that should make it clearer why the empty session is needed (since example memory storage ignores it).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

