### PR TITLE
fix: Align error returned when a grant_type was requested that's not allowed for a client.

### DIFF
--- a/authorize_error_test.go
+++ b/authorize_error_test.go
@@ -70,12 +70,12 @@ func TestWriteAuthorizeError(t *testing.T) {
 			err: ErrInvalidGrant,
 			mock: func(rw *MockResponseWriter, req *MockAuthorizeRequester) {
 				req.EXPECT().IsRedirectURIValid().Return(false)
-				rw.EXPECT().Header().Return(header)
+				rw.EXPECT().Header().AnyTimes().Return(header)
 				rw.EXPECT().WriteHeader(http.StatusBadRequest)
 				rw.EXPECT().Write(gomock.Any())
 			},
 			checkHeader: func(t *testing.T, k int) {
-				assert.Equal(t, "application/json", header.Get("Content-Type"))
+				assert.Equal(t, "application/json;charset=UTF-8", header.Get("Content-Type"))
 			},
 		},
 		{

--- a/authorize_error_test.go
+++ b/authorize_error_test.go
@@ -70,12 +70,12 @@ func TestWriteAuthorizeError(t *testing.T) {
 			err: ErrInvalidGrant,
 			mock: func(rw *MockResponseWriter, req *MockAuthorizeRequester) {
 				req.EXPECT().IsRedirectURIValid().Return(false)
-				rw.EXPECT().Header().AnyTimes().Return(header)
+				rw.EXPECT().Header().Return(header)
 				rw.EXPECT().WriteHeader(http.StatusBadRequest)
 				rw.EXPECT().Write(gomock.Any())
 			},
 			checkHeader: func(t *testing.T, k int) {
-				assert.Equal(t, "application/json;charset=UTF-8", header.Get("Content-Type"))
+				assert.Equal(t, "application/json", header.Get("Content-Type"))
 			},
 		},
 		{

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -42,7 +42,7 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 	}
 
 	if !request.GetClient().GetGrantTypes().Has("authorization_code") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"authorization_code\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"authorization_code\"."))
 	}
 
 	code := request.GetRequestForm().Get("code")

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -295,7 +295,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 						},
 					},
 					description: "should fail because client is not granted this grant type",
-					expectErr:   fosite.ErrInvalidGrant,
+					expectErr:   fosite.ErrUnauthorizedClient,
 				},
 				{
 					areq: &fosite.AccessRequest{

--- a/handler/oauth2/flow_client_credentials.go
+++ b/handler/oauth2/flow_client_credentials.go
@@ -74,7 +74,7 @@ func (c *ClientCredentialsGrantHandler) PopulateTokenEndpointResponse(ctx contex
 	}
 
 	if !request.GetClient().GetGrantTypes().Has("client_credentials") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"client_credentials\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"client_credentials\"."))
 	}
 
 	return c.IssueAccessToken(ctx, request, response)

--- a/handler/oauth2/flow_client_credentials_test.go
+++ b/handler/oauth2/flow_client_credentials_test.go
@@ -144,11 +144,11 @@ func TestClientCredentials_PopulateTokenEndpointResponse(t *testing.T) {
 			},
 		},
 		{
-			description: "should fail because client not allowed",
-			expectErr:   fosite.ErrInvalidGrant,
+			description: "should fail because grant_type not allowed",
+			expectErr:   fosite.ErrUnauthorizedClient,
 			mock: func() {
 				areq.GrantTypes = fosite.Arguments{"client_credentials"}
-				areq.Client = &fosite.DefaultClient{GrantTypes: fosite.Arguments{"foo"}}
+				areq.Client = &fosite.DefaultClient{GrantTypes: fosite.Arguments{"authorization_code"}}
 			},
 		},
 		{

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -58,7 +58,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 	}
 
 	if !request.GetClient().GetGrantTypes().Has("refresh_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"refresh_token\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use authorization grant \"refresh_token\"."))
 	}
 
 	refresh := request.GetRequestForm().Get("refresh_token")

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -51,7 +51,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 	}
 
 	if !request.GetClient().GetGrantTypes().Has("password") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The client is not allowed to use authorization grant \"password\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The client is not allowed to use authorization grant \"password\"."))
 	}
 
 	client := request.GetClient()
@@ -70,7 +70,7 @@ func (c *ResourceOwnerPasswordCredentialsGrantHandler) HandleTokenEndpointReques
 	if username == "" || password == "" {
 		return errors.WithStack(fosite.ErrInvalidRequest.WithHint("Username or password are missing from the POST body."))
 	} else if err := c.ResourceOwnerPasswordCredentialsGrantStorage.Authenticate(ctx, username, password); errors.Cause(err) == fosite.ErrNotFound {
-		return errors.WithStack(fosite.ErrRequestUnauthorized.WithHint("Unable to authenticate the provided username and password credentials.").WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("Unable to authenticate the provided username and password credentials.").WithDebug(err.Error()))
 	} else if err != nil {
 		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
 	}

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -50,7 +50,7 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 	}
 
 	if !requester.GetClient().GetGrantTypes().Has("authorization_code") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant \"authorization_code\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant \"authorization_code\"."))
 	}
 
 	sess, ok := requester.GetSession().(Session)

--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -44,7 +44,7 @@ func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Con
 	}
 
 	if !request.GetClient().GetGrantTypes().Has("refresh_token") {
-		return errors.WithStack(fosite.ErrInvalidGrant.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant \"refresh_token\"."))
+		return errors.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant \"refresh_token\"."))
 	}
 
 	// Refresh tokens can only be issued by an authorize_code which in turn disables the need to check if the id_token

--- a/handler/openid/flow_refresh_token_test.go
+++ b/handler/openid/flow_refresh_token_test.go
@@ -66,7 +66,7 @@ func TestOpenIDConnectRefreshHandler_HandleTokenEndpointRequest(t *testing.T) {
 					Client:       &fosite.DefaultClient{},
 				},
 			},
-			expectedErr: fosite.ErrInvalidGrant,
+			expectedErr: fosite.ErrUnauthorizedClient,
 		},
 		{
 			description: "should pass",


### PR DESCRIPTION
## Related issue

None.

## Proposed changes

This fixes a minor difference between Ory Fosite and the OAuth2.0 specification on errors to be returned.

According to https://tools.ietf.org/html/rfc6749#section-5.2 the error to be returned if a client requests a grant_type it's not allowed to is 'unauthorized_client'.
The current implementation returns 'invalid_grant'.

This PR changes that behaviour and also adds or adapts tests where needed.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)

## Further comments

No.
