### PR TITLE
fix: added missing factory to compose

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -117,6 +117,7 @@ func ComposeAllEnabled(config *Config, storage interface{}, secret []byte, key *
 		OpenIDConnectRefreshFactory,
 
 		OAuth2TokenIntrospectionFactory,
+		OAuth2TokenRevocationFactory,
 
 		OAuth2PKCEFactory,
 	)


### PR DESCRIPTION
## Related issue

Reported the issue on the fosite-example repo [#32](https://github.com/ory/fosite-example/issues/32)

## Proposed changes

Currently revoke access or refresh token functionality is not working in the fosite-example repo because of the missing `OAuth2TokenRevocationFactory` as part of the OAuth provider initialisation so when loading the factories it didn't load and append the revoke handlers.


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

No further comments, it's a tiny PR and self explanatory
