### PR TITLE
test: fix typo of authorization_code in test

### DIFF
--- a/handler/oauth2/flow_resource_owner_test.go
+++ b/handler/oauth2/flow_resource_owner_test.go
@@ -88,7 +88,7 @@ func TestResourceOwnerFlow_HandleTokenEndpointRequest(t *testing.T) {
 			description: "should fail because invalid grant_type specified",
 			setup: func() {
 				areq.GrantTypes = fosite.Arguments{"password"}
-				areq.Client = &fosite.DefaultClient{GrantTypes: fosite.Arguments{"authoriation_code"}, Scopes: []string{"foo-scope"}}
+				areq.Client = &fosite.DefaultClient{GrantTypes: fosite.Arguments{"authorization_code"}, Scopes: []string{"foo-scope"}}
 			},
 			expectErr: fosite.ErrUnauthorizedClient,
 		},


### PR DESCRIPTION
## Related issue
Not applicable

## Proposed changes
There is a typo of "authoriation_code" in a test. Fix it.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments

