### PR TITLE
refactor: fix inconsistent spelling of revocation

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -161,9 +161,9 @@ var (
 		Hint:        "Token validation failed.",
 		Code:        http.StatusUnauthorized,
 	}
-	ErrRevokationClientMismatch = &RFC6749Error{
-		Name:        errRevokationClientMismatchName,
-		Description: "Token was not issued to the client making the revokation request",
+	ErrRevocationClientMismatch = &RFC6749Error{
+		Name:        errRevocationClientMismatchName,
+		Description: "Token was not issued to the client making the revocation request",
 		Code:        http.StatusBadRequest,
 	}
 	ErrLoginRequired = &RFC6749Error{
@@ -243,7 +243,7 @@ const (
 	errTokenInactiveName           = "token_inactive"
 	// errAuthorizaionCodeInactiveName = "authorization_code_inactive"
 	errUnknownErrorName             = "error"
-	errRevokationClientMismatchName = "revokation_client_mismatch"
+	errRevocationClientMismatchName = "revocation_client_mismatch"
 	errRequestNotSupportedName      = "request_not_supported"
 	errRequestURINotSupportedName   = "request_uri_not_supported"
 	errRegistrationNotSupportedName = "registration_not_supported"

--- a/errors_test.go
+++ b/errors_test.go
@@ -28,8 +28,8 @@ import (
 )
 
 func TestAddDebug(t *testing.T) {
-	err := ErrRevokationClientMismatch.WithDebug("debug")
-	assert.NotEqual(t, err, ErrRevokationClientMismatch)
-	assert.Empty(t, ErrRevokationClientMismatch.Debug)
+	err := ErrRevocationClientMismatch.WithDebug("debug")
+	assert.NotEqual(t, err, ErrRevocationClientMismatch)
+	assert.Empty(t, ErrRevocationClientMismatch.Debug)
 	assert.NotEmpty(t, err.Debug)
 }

--- a/handler/oauth2/flow_authorize_code_token.go
+++ b/handler/oauth2/flow_authorize_code_token.go
@@ -61,11 +61,11 @@ func (c *AuthorizeExplicitGrantHandler) HandleTokenEndpointRequest(ctx context.C
 		debug := ""
 		if revErr := c.TokenRevocationStorage.RevokeAccessToken(ctx, reqID); revErr != nil {
 			hint += " Additionally, an error occurred during processing the access token revocation."
-			debug += "Revokation of access_token lead to error " + revErr.Error() + "."
+			debug += "Revocation of access_token lead to error " + revErr.Error() + "."
 		}
 		if revErr := c.TokenRevocationStorage.RevokeRefreshToken(ctx, reqID); revErr != nil {
 			hint += " Additionally, an error occurred during processing the refresh token revocation."
-			debug += "Revokation of refresh_token lead to error " + revErr.Error() + "."
+			debug += "Revocation of refresh_token lead to error " + revErr.Error() + "."
 		}
 		return errors.WithStack(fosite.ErrInvalidGrant.WithHint(hint).WithDebug(debug))
 	} else if err != nil && errors.Cause(err).Error() == fosite.ErrNotFound.Error() {

--- a/handler/oauth2/revocation.go
+++ b/handler/oauth2/revocation.go
@@ -66,7 +66,7 @@ func (r *TokenRevocationHandler) RevokeToken(ctx context.Context, token string, 
 	}
 
 	if ar.GetClient().GetID() != client.GetID() {
-		return errors.WithStack(fosite.ErrRevokationClientMismatch)
+		return errors.WithStack(fosite.ErrRevocationClientMismatch)
 	}
 
 	requestID := ar.GetID()

--- a/handler/oauth2/revocation_test.go
+++ b/handler/oauth2/revocation_test.go
@@ -57,7 +57,7 @@ func TestRevokeToken(t *testing.T) {
 	}{
 		{
 			description: "should fail - token was issued to another client",
-			expectErr:   fosite.ErrRevokationClientMismatch,
+			expectErr:   fosite.ErrRevocationClientMismatch,
 			client:      &fosite.DefaultClient{ID: "bar"},
 			mock: func() {
 				token = "foo"


### PR DESCRIPTION
## Related issue
Not applicable

## Proposed changes
"revocation" is also spelled "revokation" in various place. Make it consistent - "revocation".
This changes some constant and/or variable names in the code, so I have made this a "refactor" PR.


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation within the code base (if appropriate)

## Further comments
