### PR TITLE
feat: Errors now wrap underlying errors

### DIFF
--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -61,7 +61,7 @@ func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session 
 	if r.Method != "POST" {
 		return accessRequest, errors.WithStack(ErrInvalidRequest.WithHintf("HTTP method is \"%s\", expected \"POST\".", r.Method))
 	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
-		return accessRequest, errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithDebug(err.Error()))
+		return accessRequest, errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithCause(err).WithDebug(err.Error()))
 	} else if len(r.PostForm) == 0 {
 		return accessRequest, errors.WithStack(ErrInvalidRequest.WithHint("The POST body can not be empty."))
 	}

--- a/access_response_writer_test.go
+++ b/access_response_writer_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -96,7 +95,7 @@ func TestNewAccessResponse(t *testing.T) {
 			ar, err := f.NewAccessResponse(nil, nil)
 
 			if c.expectErr != nil {
-				assert.EqualError(t, errors.Cause(err), c.expectErr.Error())
+				assert.EqualError(t, err, c.expectErr.Error())
 			} else {
 				require.NoError(t, err)
 				assert.Equal(t, ar, c.expect)

--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -20,14 +20,14 @@ func DefaultAudienceMatchingStrategy(haystack []string, needle []string) error {
 	for _, n := range needle {
 		nu, err := url.Parse(n)
 		if err != nil {
-			return errors.WithStack(ErrInvalidRequest.WithHintf(`Unable to parse requested audience "%s".`, n).WithDebug(err.Error()))
+			return errors.WithStack(ErrInvalidRequest.WithHintf(`Unable to parse requested audience "%s".`, n).WithCause(err).WithDebug(err.Error()))
 		}
 
 		var found bool
 		for _, h := range haystack {
 			hu, err := url.Parse(h)
 			if err != nil {
-				return errors.WithStack(ErrInvalidRequest.WithHintf(`Unable to parse whitelisted audience "%s".`, h).WithDebug(err.Error()))
+				return errors.WithStack(ErrInvalidRequest.WithHintf(`Unable to parse whitelisted audience "%s".`, h).WithCause(err).WithDebug(err.Error()))
 			}
 
 			allowedPath := strings.TrimRight(hu.Path, "/")

--- a/authorize_error.go
+++ b/authorize_error.go
@@ -70,7 +70,7 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 	query.Add("state", ar.GetState())
 
 	var redirectURIString string
-	if !(len(ar.GetResponseTypes()) == 0 || ar.GetResponseTypes().ExactOne("code")) && errors.Cause(err) != ErrUnsupportedResponseType {
+	if !(len(ar.GetResponseTypes()) == 0 || ar.GetResponseTypes().ExactOne("code")) && !errors.Is(err, ErrUnsupportedResponseType) {
 		redirectURIString = redirectURI.String() + "#" + query.Encode()
 	} else {
 		for key, values := range redirectURI.Query() {

--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -43,7 +43,7 @@ func GetRedirectURIFromRequestValues(values url.Values) (string, error) {
 	// The endpoint URI MAY include an "application/x-www-form-urlencoded" formatted (per Appendix B) query component
 	redirectURI, err := url.QueryUnescape(values.Get("redirect_uri"))
 	if err != nil {
-		return "", errors.WithStack(ErrInvalidRequest.WithHint(`The "redirect_uri" parameter is malformed or missing.`).WithDebug(err.Error()))
+		return "", errors.WithStack(ErrInvalidRequest.WithHint(`The "redirect_uri" parameter is malformed or missing.`).WithCause(err).WithDebug(err.Error()))
 	}
 	return redirectURI, nil
 }

--- a/authorize_request_handler_test.go
+++ b/authorize_request_handler_test.go
@@ -238,7 +238,7 @@ func TestNewAuthorizeRequest(t *testing.T) {
 
 			ar, err := c.conf.NewAuthorizeRequest(context.Background(), c.r)
 			if c.expectedError != nil {
-				assert.EqualError(t, errors.Cause(err), c.expectedError.Error())
+				assert.EqualError(t, err, c.expectedError.Error())
 				// https://github.com/ory/hydra/issues/1642
 				AssertObjectKeysEqual(t, &AuthorizeRequest{State: c.query.Get("state")}, ar, "State")
 			} else {

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -497,11 +497,12 @@ func TestAuthenticateClient(t *testing.T) {
 			}
 
 			if err != nil {
-				switch e := errors.Cause(err).(type) {
-				case *jwt.ValidationError:
-					t.Logf("Error is: %s", e.Inner)
-				case *RFC6749Error:
-					t.Logf("Debug is: %s", e.Debug)
+				var validationError *jwt.ValidationError
+				var rfcError *RFC6749Error
+				if errors.As(err, &validationError) {
+					t.Logf("Error is: %s", validationError.Inner)
+				} else if errors.As(err, &rfcError) {
+					t.Logf("Debug is: %s", rfcError.Debug)
 				}
 			}
 			require.NoError(t, err)

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -103,12 +103,12 @@ func (c *AuthorizeExplicitGrantHandler) HandleAuthorizeEndpointRequest(ctx conte
 func (c *AuthorizeExplicitGrantHandler) IssueAuthorizeCode(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.AuthorizeResponder) error {
 	code, signature, err := c.AuthorizeCodeStrategy.GenerateAuthorizeCode(ctx, ar)
 	if err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	ar.GetSession().SetExpiresAt(fosite.AuthorizeCode, time.Now().UTC().Add(c.AuthCodeLifespan))
 	if err := c.CoreStorage.CreateAuthorizeCodeSession(ctx, signature, ar.Sanitize(c.GetSanitationWhiteList())); err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	resp.AddQuery("code", code)

--- a/handler/oauth2/flow_authorize_code_auth_test.go
+++ b/handler/oauth2/flow_authorize_code_auth_test.go
@@ -27,7 +27,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -135,7 +134,7 @@ func TestAuthorizeCode_HandleAuthorizeEndpointRequest(t *testing.T) {
 					aresp := fosite.NewAuthorizeResponse()
 					err := h.HandleAuthorizeEndpointRequest(nil, c.areq, aresp)
 					if c.expectErr != nil {
-						require.EqualError(t, errors.Cause(err), c.expectErr.Error())
+						require.EqualError(t, err, c.expectErr.Error())
 					} else {
 						require.NoError(t, err)
 					}

--- a/handler/oauth2/flow_authorize_code_token_test.go
+++ b/handler/oauth2/flow_authorize_code_token_test.go
@@ -241,7 +241,7 @@ func TestAuthorizeCode_PopulateTokenEndpointResponse(t *testing.T) {
 					err := h.PopulateTokenEndpointResponse(nil, c.areq, aresp)
 
 					if c.expectErr != nil {
-						require.EqualError(t, errors.Cause(err), c.expectErr.Error(), "%+v", err)
+						require.EqualError(t, err, c.expectErr.Error(), "%+v", err)
 					} else {
 						require.NoError(t, err, "%+v", err)
 					}
@@ -443,7 +443,7 @@ func TestAuthorizeCode_HandleTokenEndpointRequest(t *testing.T) {
 
 					err := h.HandleTokenEndpointRequest(context.Background(), c.areq)
 					if c.expectErr != nil {
-						require.EqualError(t, errors.Cause(err), c.expectErr.Error(), "%+v", err)
+						require.EqualError(t, err, c.expectErr.Error(), "%+v", err)
 					} else {
 						require.NoError(t, err, "%+v", err)
 						if c.check != nil {
@@ -675,7 +675,7 @@ func TestAuthorizeCodeTransactional_HandleTokenEndpointRequest(t *testing.T) {
 			}
 
 			if err := handler.PopulateTokenEndpointResponse(propagatedContext, request, response); testCase.expectError != nil {
-				assert.EqualError(t, errors.Cause(err), testCase.expectError.Error())
+				assert.EqualError(t, err, testCase.expectError.Error())
 			}
 		})
 	}

--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -88,11 +88,11 @@ func (c *AuthorizeImplicitGrantTypeHandler) IssueImplicitAccessToken(ctx context
 	// Generate the code
 	token, signature, err := c.AccessTokenStrategy.GenerateAccessToken(ctx, ar)
 	if err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	if err := c.AccessTokenStorage.CreateAccessTokenSession(ctx, signature, ar.Sanitize([]string{})); err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	resp.AddFragment("access_token", token)

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -247,7 +247,7 @@ func TestRefreshFlow_HandleTokenEndpointRequest(t *testing.T) {
 
 					err := h.HandleTokenEndpointRequest(nil, areq)
 					if c.expectErr != nil {
-						require.EqualError(t, errors.Cause(err), c.expectErr.Error())
+						require.EqualError(t, err, c.expectErr.Error())
 					} else {
 						require.NoError(t, err)
 					}
@@ -331,7 +331,7 @@ func TestRefreshFlow_PopulateTokenEndpointResponse(t *testing.T) {
 
 					err := h.PopulateTokenEndpointResponse(nil, areq, aresp)
 					if c.expectErr != nil {
-						assert.EqualError(t, errors.Cause(err), c.expectErr.Error())
+						assert.EqualError(t, err, c.expectErr.Error())
 					} else {
 						assert.NoError(t, err)
 					}
@@ -869,7 +869,7 @@ func TestRefreshFlowTransactional_PopulateTokenEndpointResponse(t *testing.T) {
 			}
 
 			if err := handler.PopulateTokenEndpointResponse(propagatedContext, request, response); testCase.expectError != nil {
-				assert.EqualError(t, errors.Cause(err), testCase.expectError.Error())
+				assert.EqualError(t, err, testCase.expectError.Error())
 			}
 		})
 	}

--- a/handler/oauth2/introspector.go
+++ b/handler/oauth2/introspector.go
@@ -82,7 +82,7 @@ func (c *CoreValidator) introspectAccessToken(ctx context.Context, token string,
 	sig := c.CoreStrategy.AccessTokenSignature(token)
 	or, err := c.CoreStorage.GetAccessTokenSession(ctx, sig, accessRequest.GetSession())
 	if err != nil {
-		return errors.WithStack(fosite.ErrRequestUnauthorized.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrRequestUnauthorized.WithCause(err).WithDebug(err.Error()))
 	} else if err := c.CoreStrategy.ValidateAccessToken(ctx, or, token); err != nil {
 		return err
 	}
@@ -100,7 +100,7 @@ func (c *CoreValidator) introspectRefreshToken(ctx context.Context, token string
 	or, err := c.CoreStorage.GetRefreshTokenSession(ctx, sig, accessRequest.GetSession())
 
 	if err != nil {
-		return errors.WithStack(fosite.ErrRequestUnauthorized.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrRequestUnauthorized.WithCause(err).WithDebug(err.Error()))
 	} else if err := c.CoreStrategy.ValidateRefreshToken(ctx, or, token); err != nil {
 		return err
 	}

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -123,30 +123,31 @@ func (h *DefaultJWTStrategy) validate(ctx context.Context, token string) (t *jwt
 	}
 
 	if err != nil {
-		if e, ok := errors.Cause(err).(*jwtx.ValidationError); ok {
+		var e *jwtx.ValidationError
+		if errors.As(err, &e) {
 			switch e.Errors {
 			case jwtx.ValidationErrorMalformed:
-				err = errors.WithStack(fosite.ErrInvalidTokenFormat.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrInvalidTokenFormat.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorUnverifiable:
-				err = errors.WithStack(fosite.ErrTokenSignatureMismatch.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenSignatureMismatch.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorSignatureInvalid:
-				err = errors.WithStack(fosite.ErrTokenSignatureMismatch.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenSignatureMismatch.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorAudience:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorExpired:
-				err = errors.WithStack(fosite.ErrTokenExpired.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenExpired.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorIssuedAt:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorIssuer:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorNotValidYet:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorId:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			case jwtx.ValidationErrorClaimsInvalid:
-				err = errors.WithStack(fosite.ErrTokenClaim.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrTokenClaim.WithCause(err).WithDebug(err.Error()))
 			default:
-				err = errors.WithStack(fosite.ErrRequestUnauthorized.WithDebug(err.Error()))
+				err = errors.WithStack(fosite.ErrRequestUnauthorized.WithCause(err).WithDebug(err.Error()))
 			}
 		}
 	}

--- a/handler/openid/flow_explicit_auth.go
+++ b/handler/openid/flow_explicit_auth.go
@@ -63,7 +63,7 @@ func (c *OpenIDConnectExplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 	}
 
 	if err := c.OpenIDConnectRequestStorage.CreateOpenIDConnectSession(ctx, resp.GetCode(), ar.Sanitize(oidcParameters)); err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	// there is no need to check for https, because it has already been checked by core.explicit

--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -39,10 +39,10 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 	}
 
 	authorize, err := c.OpenIDConnectRequestStorage.GetOpenIDConnectSession(ctx, requester.GetRequestForm().Get("code"), requester)
-	if errors.Cause(err) == ErrNoSessionFound {
-		return errors.WithStack(fosite.ErrUnknownRequest.WithDebug(err.Error()))
+	if errors.Is(err, ErrNoSessionFound) {
+		return errors.WithStack(fosite.ErrUnknownRequest.WithCause(err).WithDebug(err.Error()))
 	} else if err != nil {
-		return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+		return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 	}
 
 	if !authorize.GetGrantedScopes().Has("openid") {

--- a/handler/openid/flow_hybrid.go
+++ b/handler/openid/flow_hybrid.go
@@ -94,7 +94,7 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 
 		code, signature, err := c.AuthorizeExplicitGrantHandler.AuthorizeCodeStrategy.GenerateAuthorizeCode(ctx, ar)
 		if err != nil {
-			return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+			return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 		}
 
 		// This is not required because the auth code flow is being handled by oauth2/flow_authorize_code_token which in turn
@@ -107,7 +107,7 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 		// This is required because we must limit the authorize code lifespan.
 		ar.GetSession().SetExpiresAt(fosite.AuthorizeCode, time.Now().UTC().Add(c.AuthorizeExplicitGrantHandler.AuthCodeLifespan).Round(time.Second))
 		if err := c.AuthorizeExplicitGrantHandler.CoreStorage.CreateAuthorizeCodeSession(ctx, signature, ar.Sanitize(c.AuthorizeExplicitGrantHandler.GetSanitationWhiteList())); err != nil {
-			return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+			return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 		}
 
 		resp.AddFragment("code", code)
@@ -121,7 +121,7 @@ func (c *OpenIDConnectHybridHandler) HandleAuthorizeEndpointRequest(ctx context.
 
 		if ar.GetGrantedScopes().Has("openid") {
 			if err := c.OpenIDConnectRequestStorage.CreateOpenIDConnectSession(ctx, resp.GetCode(), ar.Sanitize(oidcParameters)); err != nil {
-				return errors.WithStack(fosite.ErrServerError.WithDebug(err.Error()))
+				return errors.WithStack(fosite.ErrServerError.WithCause(err).WithDebug(err.Error()))
 			}
 		}
 	}

--- a/handler/openid/flow_refresh_token_test.go
+++ b/handler/openid/flow_refresh_token_test.go
@@ -25,7 +25,6 @@ import (
 	"testing"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -86,7 +85,7 @@ func TestOpenIDConnectRefreshHandler_HandleTokenEndpointRequest(t *testing.T) {
 		t.Run("case="+c.description, func(t *testing.T) {
 			err := h.HandleTokenEndpointRequest(nil, c.areq)
 			if c.expectedErr != nil {
-				require.EqualError(t, errors.Cause(err), c.expectedErr.Error(), "%v", err)
+				require.EqualError(t, err, c.expectedErr.Error(), "%v", err)
 			} else {
 				require.NoError(t, err)
 			}
@@ -208,7 +207,7 @@ func TestOpenIDConnectRefreshHandler_PopulateTokenEndpointResponse(t *testing.T)
 			aresp := fosite.NewAccessResponse()
 			err := h.PopulateTokenEndpointResponse(nil, c.areq, aresp)
 			if c.expectedErr != nil {
-				require.EqualError(t, errors.Cause(err), c.expectedErr.Error(), "%v", err)
+				require.EqualError(t, err, c.expectedErr.Error(), "%v", err)
 			} else {
 				require.NoError(t, err)
 			}

--- a/handler/openid/helper_test.go
+++ b/handler/openid/helper_test.go
@@ -80,7 +80,7 @@ func TestGenerateIDToken(t *testing.T) {
 	} {
 		c.setup()
 		token, err := h.generateIDToken(nil, ar)
-		assert.True(t, errors.Cause(err) == c.expectErr, "(%d) %s\n%s\n%s", k, c.description, err, c.expectErr)
+		assert.True(t, err == c.expectErr, "(%d) %s\n%s\n%s", k, c.description, err, c.expectErr)
 		if err == nil {
 			assert.NotEmpty(t, token, "(%d) %s", k, c.description)
 		}

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -189,7 +189,8 @@ func (h DefaultStrategy) GenerateIDToken(ctx context.Context, requester fosite.R
 
 		if tokenHintString := requester.GetRequestForm().Get("id_token_hint"); tokenHintString != "" {
 			tokenHint, err := h.JWTStrategy.Decode(ctx, tokenHintString)
-			if ve, ok := errors.Cause(err).(*jwtgo.ValidationError); ok && ve.Errors == jwtgo.ValidationErrorExpired {
+			var ve *jwtgo.ValidationError
+			if errors.As(err, &ve) && ve.Errors == jwtgo.ValidationErrorExpired {
 				// Expired ID Tokens are allowed as values to id_token_hint
 			} else if err != nil {
 				return "", errors.WithStack(fosite.ErrServerError.WithDebug(fmt.Sprintf("Unable to decode id token from id_token_hint parameter because %s.", err.Error())))

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -141,7 +141,8 @@ func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, req 
 	}
 
 	tokenHint, err := v.Strategy.Decode(ctx, idTokenHint)
-	if ve, ok := errors.Cause(err).(*jwtgo.ValidationError); ok && ve.Errors == jwtgo.ValidationErrorExpired {
+	var ve *jwtgo.ValidationError
+	if errors.As(err, &ve) && ve.Errors == jwtgo.ValidationErrorExpired {
 		// Expired tokens are ok
 	} else if err != nil {
 		return errors.WithStack(fosite.ErrInvalidRequest.WithHintf("Failed to validate OpenID Connect request as decoding id token from id_token_hint parameter failed because %s.", err.Error()))

--- a/integration/helper_endpoints_test.go
+++ b/integration/helper_endpoints_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"
@@ -68,7 +69,9 @@ func tokenInfoHandler(t *testing.T, oauth2 fosite.OAuth2Provider, session fosite
 		_, resp, err := oauth2.IntrospectToken(ctx, fosite.AccessTokenFromRequest(req), fosite.AccessToken, session)
 		if err != nil {
 			t.Logf("Info request failed because: %+v", err)
-			http.Error(rw, errors.Cause(err).(*fosite.RFC6749Error).Description, errors.Cause(err).(*fosite.RFC6749Error).Code)
+			var e *fosite.RFC6749Error
+			require.True(t, errors.As(err, &e))
+			http.Error(rw, e.Description, e.Code)
 			return
 		}
 

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -113,7 +113,7 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 	if r.Method != "POST" {
 		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithHintf("HTTP method is \"%s\", expected \"POST\".", r.Method))
 	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
-		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithDebug(err.Error()))
+		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithCause(err).WithDebug(err.Error()))
 	} else if len(r.PostForm) == 0 {
 		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInvalidRequest.WithHint("The POST body can not be empty."))
 	}
@@ -139,17 +139,17 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 
 		clientID, err := url.QueryUnescape(id)
 		if err != nil {
-			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to decode OAuth 2.0 Client ID from HTTP basic authorization header, make sure it is properly encoded.").WithDebug(err.Error()))
+			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to decode OAuth 2.0 Client ID from HTTP basic authorization header, make sure it is properly encoded.").WithCause(err).WithDebug(err.Error()))
 		}
 
 		clientSecret, err := url.QueryUnescape(secret)
 		if err != nil {
-			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to decode OAuth 2.0 Client Secret from HTTP basic authorization header, make sure it is properly encoded.").WithDebug(err.Error()))
+			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to decode OAuth 2.0 Client Secret from HTTP basic authorization header, make sure it is properly encoded.").WithCause(err).WithDebug(err.Error()))
 		}
 
 		client, err := f.Store.GetClient(ctx, clientID)
 		if err != nil {
-			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to find OAuth 2.0 Client from HTTP basic authorization header.").WithDebug(err.Error()))
+			return &IntrospectionResponse{Active: false}, errors.WithStack(ErrRequestUnauthorized.WithHint("Unable to find OAuth 2.0 Client from HTTP basic authorization header.").WithCause(err).WithDebug(err.Error()))
 		}
 
 		// Enforce client authentication
@@ -160,7 +160,7 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 
 	tt, ar, err := f.IntrospectToken(ctx, token, TokenType(tokenType), session, RemoveEmpty(strings.Split(scope, " "))...)
 	if err != nil {
-		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInactiveToken.WithHint("An introspection strategy indicated that the token is inactive.").WithDebug(err.Error()))
+		return &IntrospectionResponse{Active: false}, errors.WithStack(ErrInactiveToken.WithHint("An introspection strategy indicated that the token is inactive.").WithCause(err).WithDebug(err.Error()))
 	}
 
 	return &IntrospectionResponse{

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -55,8 +55,7 @@ func (f *Fosite) WriteIntrospectionError(rw http.ResponseWriter, err error) {
 		return
 	}
 
-	switch errors.Cause(err).Error() {
-	case ErrInvalidRequest.Error(), ErrRequestUnauthorized.Error():
+	if errors.Is(err, ErrInvalidRequest) || errors.Is(err, ErrRequestUnauthorized) {
 		f.writeJsonError(rw, err)
 		return
 	}

--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -51,7 +51,7 @@ func (f *Fosite) NewRevocationRequest(ctx context.Context, r *http.Request) erro
 	if r.Method != "POST" {
 		return errors.WithStack(ErrInvalidRequest.WithHintf("HTTP method is \"%s\", expected \"POST\".", r.Method))
 	} else if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
-		return errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithDebug(err.Error()))
+		return errors.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithCause(err).WithDebug(err.Error()))
 	} else if len(r.PostForm) == 0 {
 		return errors.WithStack(ErrInvalidRequest.WithHint("The POST body can not be empty."))
 	}
@@ -102,8 +102,7 @@ func (f *Fosite) WriteRevocationResponse(rw http.ResponseWriter, err error) {
 		return
 	}
 
-	switch errors.Cause(err).Error() {
-	case ErrInvalidRequest.Error():
+	if errors.Is(err, ErrInvalidRequest) {
 		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 
 		js, err := json.Marshal(ErrInvalidRequest)
@@ -114,7 +113,7 @@ func (f *Fosite) WriteRevocationResponse(rw http.ResponseWriter, err error) {
 
 		rw.WriteHeader(ErrInvalidRequest.Code)
 		rw.Write(js)
-	case ErrInvalidClient.Error():
+	} else if errors.Is(err, ErrInvalidClient) {
 		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 
 		js, err := json.Marshal(ErrInvalidClient)
@@ -125,7 +124,7 @@ func (f *Fosite) WriteRevocationResponse(rw http.ResponseWriter, err error) {
 
 		rw.WriteHeader(ErrInvalidClient.Code)
 		rw.Write(js)
-	default:
+	} else {
 		// 200 OK
 		rw.WriteHeader(http.StatusOK)
 	}

--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -106,7 +106,7 @@ func (c *HMACStrategy) Validate(token string) (err error) {
 	for _, key := range keys {
 		if err = c.validate(key, token); err == nil {
 			return nil
-		} else if errors.Cause(err) == fosite.ErrTokenSignatureMismatch {
+		} else if errors.Is(err, fosite.ErrTokenSignatureMismatch) {
 		} else {
 			return err
 		}


### PR DESCRIPTION
## Related issue

Fixes #458.

## Proposed changes

All errors wrap now underlying errors, when there is one available. This is not directly exposed through messages, but if you obtain such error in your code you have more information to inspect, log, and act upon.

I also changed around the codebase to remove hard-coded assumptions about the depth of a cause when inspecting errors and use `errors.Is` and `errors.As` instead.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
