### PR TITLE
fix: Full JSON escaping

### DIFF
--- a/access_error.go
+++ b/access_error.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 )
 
 func (f *Fosite) WriteAccessError(rw http.ResponseWriter, _ AccessRequester, err error) {
@@ -45,10 +44,7 @@ func (f *Fosite) writeJsonError(rw http.ResponseWriter, err error) {
 	js, err := json.Marshal(rfcerr)
 	if err != nil {
 		if f.SendDebugMessagesToClients {
-			// Poor man's JSON encoding. We do not want to use full JSON encoding because we just had an error.
-			errorMessage := err.Error()
-			errorMessage = strings.ReplaceAll(errorMessage, `\`, `\\`)
-			errorMessage = strings.ReplaceAll(errorMessage, `"`, `\"`)
+			errorMessage := EscapeJSONString(err.Error())
 			http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
 		} else {
 			http.Error(rw, `{"error":"server_error"}`, http.StatusInternalServerError)

--- a/authorize_error.go
+++ b/authorize_error.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -45,10 +44,7 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 		js, err := json.Marshal(rfcerr)
 		if err != nil {
 			if f.SendDebugMessagesToClients {
-				// Poor man's JSON encoding. We do not want to use full JSON encoding because we just had an error.
-				errorMessage := err.Error()
-				errorMessage = strings.ReplaceAll(errorMessage, `\`, `\\`)
-				errorMessage = strings.ReplaceAll(errorMessage, `"`, `\"`)
+				errorMessage := EscapeJSONString(err.Error())
 				http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
 			} else {
 				http.Error(rw, `{"error":"server_error"}`, http.StatusInternalServerError)

--- a/helper.go
+++ b/helper.go
@@ -22,6 +22,7 @@
 package fosite
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -43,4 +44,20 @@ func RemoveEmpty(args []string) (ret []string) {
 		}
 	}
 	return
+}
+
+// EscapeJSONString does a poor man's JSON encoding. Useful when we do not want to use full JSON encoding
+// because we just had an error doing the JSON encoding. The characters that MUST be escaped: quotation mark,
+// reverse solidus, and the control characters (U+0000 through U+001F).
+// See: https://tools.ietf.org/html/std90#section-7
+func EscapeJSONString(str string) string {
+	// Escape reverse solidus.
+	str = strings.ReplaceAll(str, `\`, `\\`)
+	// Escape control characters.
+	for r := rune(0); r < ' '; r++ {
+		str = strings.ReplaceAll(str, string(r), fmt.Sprintf(`\u%04x`, r))
+	}
+	// Escape quotation mark.
+	str = strings.ReplaceAll(str, `"`, `\"`)
+	return str
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -22,9 +22,11 @@
 package fosite
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStringInSlice(t *testing.T) {
@@ -42,5 +44,15 @@ func TestStringInSlice(t *testing.T) {
 	} {
 		assert.Equal(t, c.ok, StringInSlice(c.needle, c.haystack), "%d", k)
 		t.Logf("Passed test case %d", k)
+	}
+}
+
+func TestEscapeJSONString(t *testing.T) {
+	for _, str := range []string{"", "foobar", `foo"bar`, `foo\bar`, "foo\n\tbar"} {
+		escaped := EscapeJSONString(str)
+		var unmarshaled string
+		err := json.Unmarshal([]byte(`"` + escaped + `"`), &unmarshaled)
+		require.NoError(t, err, str)
+		assert.Equal(t, str, unmarshaled, str)
 	}
 }


### PR DESCRIPTION
## Related issue

This is a followup to https://github.com/ory/fosite/pull/460.

## Proposed changes

This makes the escaping complete and not just partial. I think this is good enough because this code path should really never be called. But it does, we should do proper escaping which this now does.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)
