### PR TITLE
chore: update repository template to 92ae8b93

### DIFF
--- a/.github/workflows/closed_references.yml
+++ b/.github/workflows/closed_references.yml
@@ -2,7 +2,7 @@ name: Closed Reference Notifier
 
 on:
   schedule:
-    - cron: '0 7 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       issueLimit:
@@ -19,6 +19,6 @@ jobs:
       - uses: ory/closed-reference-notifier@v1.1.4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          ignore: '.git,**/node_modules,docs,CHANGELOG.md,.bin'
+          ignore: '.git,**/node_modules,docs,CHANGELOG.md,.bin,*.md'
           issueLabels: upstream
           issueLimit: ${{ github.event.inputs.issueLimit || '5' }}


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/92ae8b93c03738d00573f229a412f9eac7a71a99.