### PR TITLE
fix: Uniform audience parsing

### DIFF
--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -49,7 +49,7 @@ func DefaultAudienceMatchingStrategy(haystack []string, needle []string) error {
 }
 
 func (f *Fosite) validateAuthorizeAudience(r *http.Request, request *AuthorizeRequest) error {
-	audience := stringsx.Splitx(request.Form.Get("audience"), " ")
+	audience := RemoveEmpty(stringsx.Splitx(request.Form.Get("audience"), " "))
 
 	if err := f.AudienceMatchingStrategy(request.Client.GetAudience(), audience); err != nil {
 		return err

--- a/audience_strategy.go
+++ b/audience_strategy.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
-
-	"github.com/ory/go-convenience/stringsx"
 )
 
 type AudienceMatchingStrategy func(haystack []string, needle []string) error
@@ -49,7 +47,7 @@ func DefaultAudienceMatchingStrategy(haystack []string, needle []string) error {
 }
 
 func (f *Fosite) validateAuthorizeAudience(r *http.Request, request *AuthorizeRequest) error {
-	audience := RemoveEmpty(stringsx.Splitx(request.Form.Get("audience"), " "))
+	audience := RemoveEmpty(strings.Split(request.Form.Get("audience"), " "))
 
 	if err := f.AudienceMatchingStrategy(request.Client.GetAudience(), audience); err != nil {
 		return err

--- a/authorize_validators_test.go
+++ b/authorize_validators_test.go
@@ -25,12 +25,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ory/go-convenience/stringsx"
 )
 
 func TestValidateResponseTypes(t *testing.T) {
@@ -96,7 +95,7 @@ func TestValidateResponseTypes(t *testing.T) {
 				require.Error(t, err)
 			} else {
 				require.NoError(t, err)
-				assert.EqualValues(t, stringsx.Splitx(tc.rt, " "), ar.GetResponseTypes())
+				assert.EqualValues(t, RemoveEmpty(strings.Split(tc.rt, " ")), ar.GetResponseTypes())
 			}
 		})
 	}

--- a/handler/openid/validator.go
+++ b/handler/openid/validator.go
@@ -24,6 +24,7 @@ package openid
 import (
 	"context"
 	"strconv"
+	"strings"
 	"time"
 
 	jwtgo "github.com/dgrijalva/jwt-go"
@@ -32,7 +33,6 @@ import (
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/go-convenience/stringslice"
-	"github.com/ory/go-convenience/stringsx"
 )
 
 type OpenIDConnectRequestValidator struct {
@@ -53,7 +53,7 @@ func NewOpenIDConnectRequestValidator(prompt []string, strategy jwt.JWTStrategy)
 
 func (v *OpenIDConnectRequestValidator) ValidatePrompt(ctx context.Context, req fosite.AuthorizeRequester) error {
 	// prompt is case sensitive!
-	prompt := stringsx.Splitx(req.GetRequestForm().Get("prompt"), " ")
+	prompt := fosite.RemoveEmpty(strings.Split(req.GetRequestForm().Get("prompt"), " "))
 
 	if req.GetClient().IsPublic() {
 		// Threat: Malicious Client Obtains Existing Authorization by Fraud


### PR DESCRIPTION
## Proposed changes

Making sure audience parsing in authorize flow is the [same as in access flow](https://github.com/ory/fosite/blob/master/access_request_handler.go#L75). Consistency.

Edit: I extended that with few other cases and made it consistent across the board. Also `stringx.Splitx` is not used anymore now because calling `RemoveEmpty` is equivalent (but does more).

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
- [x] I have read the [security policy](../security/policy)
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation within the code base (if appropriate)