### PR TITLE
fix: Always return non-error response for inactive tokens

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -55,7 +55,8 @@ func (f *Fosite) WriteIntrospectionError(rw http.ResponseWriter, err error) {
 		return
 	}
 
-	if errors.Is(err, ErrInvalidRequest) || errors.Is(err, ErrRequestUnauthorized) {
+	// Inactive token errors should never written out as an error.
+	if !errors.Is(err, ErrInactiveToken) && (errors.Is(err, ErrInvalidRequest) || errors.Is(err, ErrRequestUnauthorized)) {
 		f.writeJsonError(rw, err)
 		return
 	}


### PR DESCRIPTION
## Proposed changes

One of our unit tests caught that after upgrade to latest fosite.

I introduced the regression with https://github.com/ory/fosite/pull/479 but existing fosite tests didn't catch it. The problem is that when returning `ErrInactiveToken` from `NewIntrospectionRequest` we now wrap underlying error, which can happen to be `ErrRequestUnauthorized`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).
