### PR TITLE
fix: Modernized JWT stateless introspection

### DIFF
--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -23,6 +23,7 @@ package compose
 
 import (
 	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/token/jwt"
 )
 
 // OAuth2AuthorizeExplicitFactory creates an OAuth2 authorize code grant ("authorize explicit flow") handler and registers
@@ -132,7 +133,7 @@ func OAuth2TokenIntrospectionFactory(config *Config, storage interface{}, strate
 // If you need revocation, you can validate JWTs statefully, using the other factories.
 func OAuth2StatelessJWTIntrospectionFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.StatelessJWTValidator{
-		JWTAccessTokenStrategy: strategy.(oauth2.JWTAccessTokenStrategy),
-		ScopeStrategy:          config.GetScopeStrategy(),
+		JWTStrategy:   strategy.(jwt.JWTStrategy),
+		ScopeStrategy: config.GetScopeStrategy(),
 	}
 }

--- a/handler/oauth2/introspector_jwt_test.go
+++ b/handler/oauth2/introspector_jwt_test.go
@@ -43,8 +43,8 @@ func TestIntrospectJWT(t *testing.T) {
 	}
 
 	v := &StatelessJWTValidator{
-		JWTAccessTokenStrategy: strat,
-		ScopeStrategy:          fosite.HierarchicScopeStrategy,
+		JWTStrategy:   strat,
+		ScopeStrategy: fosite.HierarchicScopeStrategy,
 	}
 
 	for k, c := range []struct {
@@ -137,7 +137,7 @@ func BenchmarkIntrospectJWT(b *testing.B) {
 	}
 
 	v := &StatelessJWTValidator{
-		JWTAccessTokenStrategy: strat,
+		JWTStrategy: strat,
 	}
 
 	jwt := jwtValidCase(fosite.AccessToken)

--- a/handler/oauth2/strategy.go
+++ b/handler/oauth2/strategy.go
@@ -33,10 +33,6 @@ type CoreStrategy interface {
 	AuthorizeCodeStrategy
 }
 
-type JWTStrategy interface {
-	ValidateJWT(ctx context.Context, tokenType fosite.TokenType, token string) (requester fosite.Requester, err error)
-}
-
 type AccessTokenStrategy interface {
 	AccessTokenSignature(token string) string
 	GenerateAccessToken(ctx context.Context, requester fosite.Requester) (token string, signature string, err error)


### PR DESCRIPTION
## Related issue

Fixes: https://github.com/ory/fosite/issues/445

## Proposed changes

This makes it so that you can:

```
compose.OAuth2TokenRevocationFactory,
compose.OAuth2TokenIntrospectionFactory,
```

replace with:

```
compose.OAuth2StatelessJWTIntrospectionFactory,
```

and it just works. From looking at the code it looked to me like this was done long time ago where some other current interfaces were not yet around. So I modernized the code to use existing interfaces and removed a specialized interface used just by previous implementation.

All tests still pass. But I am not 100% sure if everything is correct (I have some doubts about original code). I also have few TODOs around the code so input there would be appreciated.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).
