### PR TITLE
feat: Allow extra fields in introspect response

### DIFF
--- a/handler/oauth2/strategy_jwt_session.go
+++ b/handler/oauth2/strategy_jwt_session.go
@@ -103,3 +103,14 @@ func (s *JWTSession) Clone() fosite.Session {
 
 	return deepcopy.Copy(s).(fosite.Session)
 }
+
+// GetExtraClaims implements ExtraClaimsSession for JWTSession.
+// The returned value is a copy of JWTSession claims.
+func (s *JWTSession) GetExtraClaims() map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+
+	// We make a clone so that WithScopeField does not change the original value.
+	return s.Clone().(*JWTSession).GetJWTClaims().WithScopeField(jwt.JWTScopeFieldString).ToMapClaims()
+}

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -24,7 +24,6 @@ package fosite
 import (
 	"encoding/json"
 	"net/http"
-	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -214,7 +213,11 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		extraClaims := extraClaimsSession.GetExtraClaims()
 		if extraClaims != nil {
 			for name, value := range extraClaims {
-				if !reflect.ValueOf(value).IsZero() {
+				switch name {
+				// We do not allow these to be set through extra claims.
+				case "exp", "client_id", "scope", "iat", "sub", "aud", "username":
+					break
+				default:
 					response[name] = value
 				}
 			}

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -24,6 +24,7 @@ package fosite
 import (
 	"encoding/json"
 	"net/http"
+	"reflect"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -204,35 +205,46 @@ func (f *Fosite) WriteIntrospectionResponse(rw http.ResponseWriter, r Introspect
 		return
 	}
 
-	expiresAt := int64(0)
+	response := map[string]interface{}{
+		"active": true,
+	}
+
+	extraClaimsSession, ok := r.GetAccessRequester().GetSession().(ExtraClaimsSession)
+	if ok {
+		extraClaims := extraClaimsSession.GetExtraClaims()
+		if extraClaims != nil {
+			for name, value := range extraClaims {
+				if !reflect.ValueOf(value).IsZero() {
+					response[name] = value
+				}
+			}
+		}
+	}
+
 	if !r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).IsZero() {
-		expiresAt = r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix()
+		response["exp"] = r.GetAccessRequester().GetSession().GetExpiresAt(AccessToken).Unix()
+	}
+	if r.GetAccessRequester().GetClient().GetID() != "" {
+		response["client_id"] = r.GetAccessRequester().GetClient().GetID()
+	}
+	if len(r.GetAccessRequester().GetGrantedScopes()) > 0 {
+		response["scope"] = strings.Join(r.GetAccessRequester().GetGrantedScopes(), " ")
+	}
+	if !r.GetAccessRequester().GetRequestedAt().IsZero() {
+		response["iat"] = r.GetAccessRequester().GetRequestedAt().Unix()
+	}
+	if r.GetAccessRequester().GetSession().GetSubject() != "" {
+		response["sub"] = r.GetAccessRequester().GetSession().GetSubject()
+	}
+	if len(r.GetAccessRequester().GetGrantedAudience()) > 0 {
+		response["aud"] = r.GetAccessRequester().GetGrantedAudience()
+	}
+	if r.GetAccessRequester().GetSession().GetUsername() != "" {
+		response["username"] = r.GetAccessRequester().GetSession().GetUsername()
 	}
 
 	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
 	rw.Header().Set("Cache-Control", "no-store")
 	rw.Header().Set("Pragma", "no-cache")
-	_ = json.NewEncoder(rw).Encode(struct {
-		Active    bool     `json:"active"`
-		ClientID  string   `json:"client_id,omitempty"`
-		Scope     string   `json:"scope,omitempty"`
-		Audience  []string `json:"aud,omitempty"`
-		ExpiresAt int64    `json:"exp,omitempty"`
-		IssuedAt  int64    `json:"iat,omitempty"`
-		Subject   string   `json:"sub,omitempty"`
-		Username  string   `json:"username,omitempty"`
-		// Session is not included per default because it might expose sensitive information.
-		// Session   Session  `json:"sess,omitempty"`
-	}{
-		Active:    true,
-		ClientID:  r.GetAccessRequester().GetClient().GetID(),
-		Scope:     strings.Join(r.GetAccessRequester().GetGrantedScopes(), " "),
-		ExpiresAt: expiresAt,
-		IssuedAt:  r.GetAccessRequester().GetRequestedAt().Unix(),
-		Subject:   r.GetAccessRequester().GetSession().GetSubject(),
-		Audience:  r.GetAccessRequester().GetGrantedAudience(),
-		Username:  r.GetAccessRequester().GetSession().GetUsername(),
-		// Session is not included because it might expose sensitive information.
-		// Session:   r.GetAccessRequester().GetSession(),
-	})
+	_ = json.NewEncoder(rw).Encode(response)
 }

--- a/session.go
+++ b/session.go
@@ -55,6 +55,7 @@ type DefaultSession struct {
 	ExpiresAt map[TokenType]time.Time
 	Username  string
 	Subject   string
+	Extra     map[string]interface{}
 }
 
 func (s *DefaultSession) SetExpiresAt(key TokenType, exp time.Time) {
@@ -96,4 +97,25 @@ func (s *DefaultSession) Clone() Session {
 	}
 
 	return deepcopy.Copy(s).(Session)
+}
+
+// ExtraClaimsSession provides an interface for session to store any extra claims.
+type ExtraClaimsSession interface {
+	// GetExtraClaims returns a map to store extra claims.
+	// The returned value can be modified in-place.
+	GetExtraClaims() map[string]interface{}
+}
+
+// GetExtraClaims implements ExtraClaimsSession for DefaultSession.
+// The returned value can be modified in-place.
+func (s *DefaultSession) GetExtraClaims() map[string]interface{} {
+	if s == nil {
+		return nil
+	}
+
+	if s.Extra == nil {
+		s.Extra = make(map[string]interface{})
+	}
+
+	return s.Extra
 }


### PR DESCRIPTION
## Related issue

Fixes #441.

## Proposed changes

Sessions can now implement `GetExtraClaims` to control extra claims in token's introspect output.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).

## Further comments

I am not completely satisfied with tests here. For example, there is no test which would check which all fields are really output from introspect for regular access token and for JWT access token. Any suggestion where to add it is welcome.