### PR TITLE
refactor: Generate claims in the same way

### DIFF
--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -49,14 +49,37 @@ type IDTokenClaims struct {
 // ToMap will transform the headers to a map structure
 func (c *IDTokenClaims) ToMap() map[string]interface{} {
 	var ret = Copy(c.Extra)
-	ret["sub"] = c.Subject
-	ret["iss"] = c.Issuer
-	ret["jti"] = c.JTI
+
+	if c.Subject != "" {
+		ret["sub"] = c.Subject
+	}
+
+	if c.Issuer != "" {
+		ret["iss"] = c.Issuer
+	}
+
+	if c.JTI != "" {
+		ret["jti"] = c.JTI
+	} else {
+		ret["jti"] = uuid.New()
+	}
 
 	if len(c.Audience) > 0 {
 		ret["aud"] = c.Audience
 	} else {
 		ret["aud"] = []string{}
+	}
+
+	if !c.IssuedAt.IsZero() {
+		ret["iat"] = float64(c.IssuedAt.Unix()) // jwt-go does not support int64 as datatype
+	}
+
+	if !c.ExpiresAt.IsZero() {
+		ret["exp"] = float64(c.ExpiresAt.Unix()) // jwt-go does not support int64 as datatype
+	}
+
+	if !c.RequestedAt.IsZero() {
+		ret["rat"] = float64(c.RequestedAt.Unix()) // jwt-go does not support int64 as datatype
 	}
 
 	if len(c.Nonce) >= 0 {
@@ -67,16 +90,12 @@ func (c *IDTokenClaims) ToMap() map[string]interface{} {
 		ret["at_hash"] = c.AccessTokenHash
 	}
 
-	if len(c.JTI) == 0 {
-		ret["jti"] = uuid.New()
-	}
-
 	if len(c.CodeHash) > 0 {
 		ret["c_hash"] = c.CodeHash
 	}
 
 	if !c.AuthTime.IsZero() {
-		ret["auth_time"] = c.AuthTime.Unix()
+		ret["auth_time"] = float64(c.AuthTime.Unix()) // jwt-go does not support int64 as datatype
 	}
 
 	if len(c.AuthenticationContextClassReference) > 0 {
@@ -87,9 +106,6 @@ func (c *IDTokenClaims) ToMap() map[string]interface{} {
 		ret["amr"] = c.AuthenticationMethodsReference
 	}
 
-	ret["iat"] = float64(c.IssuedAt.Unix())
-	ret["exp"] = float64(c.ExpiresAt.Unix())
-	ret["rat"] = float64(c.RequestedAt.Unix())
 	return ret
 
 }

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -72,7 +72,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		"baz":       idTokenClaims.Extra["baz"],
 		"at_hash":   idTokenClaims.AccessTokenHash,
 		"c_hash":    idTokenClaims.CodeHash,
-		"auth_time": idTokenClaims.AuthTime.Unix(),
+		"auth_time": float64(idTokenClaims.AuthTime.Unix()),
 		"acr":       idTokenClaims.AuthenticationContextClassReference,
 		"amr":       idTokenClaims.AuthenticationMethodsReference,
 	}, idTokenClaims.ToMap())

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -102,14 +102,25 @@ func (c *JWTClaims) WithScopeField(scopeField JWTScopeFieldEnum) JWTClaimsContai
 func (c *JWTClaims) ToMap() map[string]interface{} {
 	var ret = Copy(c.Extra)
 
-	ret["jti"] = c.JTI
-	if c.JTI == "" {
+	if c.Subject != "" {
+		ret["sub"] = c.Subject
+	}
+
+	if c.Issuer != "" {
+		ret["iss"] = c.Issuer
+	}
+
+	if c.JTI != "" {
+		ret["jti"] = c.JTI
+	} else {
 		ret["jti"] = uuid.New()
 	}
 
-	ret["sub"] = c.Subject
-	ret["iss"] = c.Issuer
-	ret["aud"] = c.Audience
+	if len(c.Audience) > 0 {
+		ret["aud"] = c.Audience
+	} else {
+		ret["aud"] = []string{}
+	}
 
 	if !c.IssuedAt.IsZero() {
 		ret["iat"] = float64(c.IssuedAt.Unix()) // jwt-go does not support int64 as datatype
@@ -119,7 +130,9 @@ func (c *JWTClaims) ToMap() map[string]interface{} {
 		ret["nbf"] = float64(c.NotBefore.Unix()) // jwt-go does not support int64 as datatype
 	}
 
-	ret["exp"] = float64(c.ExpiresAt.Unix()) // jwt-go does not support int64 as datatype
+	if !c.ExpiresAt.IsZero() {
+		ret["exp"] = float64(c.ExpiresAt.Unix()) // jwt-go does not support int64 as datatype
+	}
 
 	if c.Scope != nil {
 		// ScopeField default (when value is JWTScopeFieldUnset) is the list for backwards compatibility with old versions of fosite.

--- a/token/jwt/claims_jwt_test.go
+++ b/token/jwt/claims_jwt_test.go
@@ -75,7 +75,7 @@ func TestAssert(t *testing.T) {
 		ToMapClaims().Valid())
 	assert.NotNil(t, (&JWTClaims{NotBefore: time.Now().UTC().Add(time.Hour)}).
 		ToMapClaims().Valid())
-	assert.NotNil(t, (&JWTClaims{NotBefore: time.Now().UTC().Add(-time.Hour)}).
+	assert.Nil(t, (&JWTClaims{NotBefore: time.Now().UTC().Add(-time.Hour)}).
 		ToMapClaims().Valid())
 	assert.Nil(t, (&JWTClaims{ExpiresAt: time.Now().UTC().Add(time.Hour),
 		NotBefore: time.Now().UTC().Add(-time.Hour)}).ToMapClaims().Valid())


### PR DESCRIPTION
## Proposed changes

Just a bit of refactoring/code cleanup. Made sure that both OAuth JWT and OpenID JWT claims are generated in the same way. Also made order of field processing in the code the same so it is easier to compare.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).
