### PR TITLE
fix: Resetting more ID token claims on refresh

### DIFF
--- a/handler/openid/flow_refresh_token.go
+++ b/handler/openid/flow_refresh_token.go
@@ -62,6 +62,9 @@ func (c *OpenIDConnectRefreshHandler) HandleTokenEndpointRequest(ctx context.Con
 	// We need to reset the expires at value
 	sess.IDTokenClaims().ExpiresAt = time.Time{}
 	sess.IDTokenClaims().Nonce = ""
+	sess.IDTokenClaims().JTI = ""
+	sess.IDTokenClaims().AccessTokenHash = ""
+	sess.IDTokenClaims().CodeHash = ""
 	return nil
 }
 


### PR DESCRIPTION
## Proposed changes

I found this during code review. I am not sure if it is correct. I could not find any test testing this. Even if I remove existing lines resetting `Nonce` and `ExpiresAt` nothing fails. So where is a test which would make sure that refreshed tokens do not have same JIT?

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).
