### PR TITLE
refactor: Use provided context

### DIFF
--- a/client_authentication.go
+++ b/client_authentication.go
@@ -162,7 +162,7 @@ func (f *Fosite) AuthenticateClient(ctx context.Context, r *http.Request, form u
 			return nil, errorsx.WithStack(ErrInvalidClient.WithHint("Claim 'sub' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
 		} else if jti, ok = (*claims)["jti"].(string); !ok || len(jti) == 0 {
 			return nil, errorsx.WithStack(ErrInvalidClient.WithHint("Claim 'jti' from 'client_assertion' must be set but is not."))
-		} else if f.Store.ClientAssertionJWTValid(context.Background(), jti) != nil {
+		} else if f.Store.ClientAssertionJWTValid(ctx, jti) != nil {
 			return nil, errorsx.WithStack(ErrJTIKnown.WithHint("Claim 'jti' from 'client_assertion' MUST only be used once."))
 		}
 
@@ -181,7 +181,7 @@ func (f *Fosite) AuthenticateClient(ctx context.Context, r *http.Request, form u
 		if err != nil {
 			return nil, errorsx.WithStack(err)
 		}
-		if err := f.Store.SetClientAssertionJWT(context.Background(), jti, time.Unix(expiry, 0)); err != nil {
+		if err := f.Store.SetClientAssertionJWT(ctx, jti, time.Unix(expiry, 0)); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
## Proposed changes

Context was not always passed through.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation within the code base (if appropriate).
