### PR TITLE
fix: Use correct error code for expired token

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -245,7 +245,7 @@ const (
 	errInsufficientEntropyName     = "insufficient_entropy"
 	errInvalidTokenFormatName      = "invalid_token"
 	errTokenSignatureMismatchName  = "token_signature_mismatch"
-	errTokenExpiredName            = "token_expired"
+	errTokenExpiredName            = "invalid_token" // https://tools.ietf.org/html/rfc6750#section-3.1
 	errScopeNotGrantedName         = "scope_not_granted"
 	errTokenClaimName              = "token_claim"
 	errTokenInactiveName           = "token_inactive"


### PR DESCRIPTION
## Related issue

#559

## Proposed changes

Rather than reusing the existing `errInvalidTokenFormatName` variable which is specific to an invalid token format, I've chosen to change the underlying string of `errTokenExpiredName`. This feels semantically correct as you refer to the error that's occurring (the token is expired) but the error code that's returned is the correct error code according to the spec. Happy to take an alternative approach if it's required.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

I couldn't sign the CLA due to this issue

![image](https://user-images.githubusercontent.com/115958/107261171-dc1c7c80-6aa3-11eb-977c-32a929ccc8e1.png)

