### PR TITLE
feat: add client authentication strategy

### DIFF
--- a/compose/compose.go
+++ b/compose/compose.go
@@ -58,19 +58,20 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 	}
 
 	f := &fosite.Fosite{
-		Store:                      storage.(fosite.Storage),
-		AuthorizeEndpointHandlers:  fosite.AuthorizeEndpointHandlers{},
-		TokenEndpointHandlers:      fosite.TokenEndpointHandlers{},
-		TokenIntrospectionHandlers: fosite.TokenIntrospectionHandlers{},
-		RevocationHandlers:         fosite.RevocationHandlers{},
-		Hasher:                     hasher,
-		ScopeStrategy:              config.GetScopeStrategy(),
-		AudienceMatchingStrategy:   config.GetAudienceStrategy(),
-		SendDebugMessagesToClients: config.SendDebugMessagesToClients,
-		TokenURL:                   config.TokenURL,
-		JWKSFetcherStrategy:        config.GetJWKSFetcherStrategy(),
-		MinParameterEntropy:        config.GetMinParameterEntropy(),
-		UseLegacyErrorFormat:       config.UseLegacyErrorFormat,
+		Store:                        storage.(fosite.Storage),
+		AuthorizeEndpointHandlers:    fosite.AuthorizeEndpointHandlers{},
+		TokenEndpointHandlers:        fosite.TokenEndpointHandlers{},
+		TokenIntrospectionHandlers:   fosite.TokenIntrospectionHandlers{},
+		RevocationHandlers:           fosite.RevocationHandlers{},
+		Hasher:                       hasher,
+		ScopeStrategy:                config.GetScopeStrategy(),
+		AudienceMatchingStrategy:     config.GetAudienceStrategy(),
+		SendDebugMessagesToClients:   config.SendDebugMessagesToClients,
+		TokenURL:                     config.TokenURL,
+		JWKSFetcherStrategy:          config.GetJWKSFetcherStrategy(),
+		MinParameterEntropy:          config.GetMinParameterEntropy(),
+		UseLegacyErrorFormat:         config.UseLegacyErrorFormat,
+		ClientAuthenticationStrategy: config.GetClientAuthenticationStrategy(),
 	}
 
 	for _, factory := range factories {

--- a/compose/config.go
+++ b/compose/config.go
@@ -111,6 +111,9 @@ type Config struct {
 
 	// GrantTypeJWTBearerMaxDuration sets the maximum time after JWT issued date, during which the JWT is considered valid.
 	GrantTypeJWTBearerMaxDuration time.Duration
+
+	// ClientAuthenticationStrategy indicates the Strategy to authenticate client requests
+	ClientAuthenticationStrategy fosite.ClientAuthenticationStrategy
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.
@@ -220,4 +223,12 @@ func (c *Config) GetJWTMaxDuration() time.Duration {
 		return time.Hour * 24
 	}
 	return c.GrantTypeJWTBearerMaxDuration
+}
+
+// GetClientAuthenticationStrategy returns the configured client authentication strategy.
+// Defaults to nil.
+// Note that on a nil strategy `fosite.Fosite` fallbacks to its default client authentication strategy
+// `fosite.Fosite.DefaultClientAuthenticationStrategy`
+func (c *Config) GetClientAuthenticationStrategy() fosite.ClientAuthenticationStrategy {
+	return c.ClientAuthenticationStrategy
 }

--- a/fosite.go
+++ b/fosite.go
@@ -110,6 +110,9 @@ type Fosite struct {
 
 	// FormPostHTMLTemplate sets html template for rendering the authorization response when the request has response_mode=form_post. Defaults to fosite.FormPostDefaultTemplate
 	FormPostHTMLTemplate *template.Template
+
+	// ClientAuthenticationStrategy provides an extension point to plug a strategy to authenticate clients
+	ClientAuthenticationStrategy ClientAuthenticationStrategy
 }
 
 const MinParameterEntropy = 8


### PR DESCRIPTION
## Related issue

#564 

## Proposed changes

- Add a `ClientAuthenticationStrategy` type to provide an extension point for custom client authentication methods
- Add `Fosite.DefaultClientAuthentication` as fosite's default and backward compatible client authentication strategy. Its content is 100% the current fosite's client authentication logic
- Add method `Fosite.WithDefaultClientAuthentication` to use fosite's default client authentication strategy

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ x] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added necessary documentation within the code base (if
      appropriate).


