### PR TITLE
feat: Token Reuse Detection

### DIFF
--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -111,7 +111,7 @@ var fositeStore = &storage.MemoryStore{
 	AuthorizeCodes:         map[string]storage.StoreAuthorizeCode{},
 	PKCES:                  map[string]fosite.Requester{},
 	AccessTokens:           map[string]fosite.Requester{},
-	RefreshTokens:          map[string]fosite.Requester{},
+	RefreshTokens:          map[string]storage.StoreRefreshToken{},
 	IDSessions:             map[string]fosite.Requester{},
 	AccessTokenRequestIDs:  map[string]string{},
 	RefreshTokenRequestIDs: map[string]string{},


### PR DESCRIPTION
## Related issue

https://github.com/ory/hydra/issues/2022

## Proposed changes

This change makes `refresh_token` grant handler to check if we received `fosite.ErrInactiveToken` error from storage, which means there is an attempt to refresh access token using previously-used or revoked refresh token.

This is similar to what is done in Authorization Code Flow. 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

These are changes just for fosite. I have another PR to make for hydra, so its persistent storage stops deleting refresh tokens from database on revocation. Instead it will mark them as inactive similar to what's done for auth codes.
