### PR TITLE
fix: sha alg name in error message and go doc

### DIFF
--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -115,7 +115,7 @@ func (c *HMACStrategy) Validate(token string) (err error) {
 	}
 
 	if err == nil {
-		return errors.New("a secret for signing HMAC-SHA256 is expected to be defined, but none were")
+		return errors.New("a secret for signing HMAC-SHA512/256 is expected to be defined, but none were")
 	}
 
 	return err
@@ -123,7 +123,7 @@ func (c *HMACStrategy) Validate(token string) (err error) {
 
 func (c *HMACStrategy) validate(secret []byte, token string) error {
 	if len(secret) < minimumSecretLength {
-		return errors.Errorf("secret for signing HMAC-SHA256 is expected to be 32 byte long, got %d byte", len(secret))
+		return errors.Errorf("secret for signing HMAC-SHA512/256 is expected to be 32 byte long, got %d byte", len(secret))
 	}
 
 	var signingKey [32]byte

--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -19,7 +19,7 @@
  *
  */
 
-// Package hmac is the default implementation for generating and validating challenges. It uses HMAC-SHA256 to
+// Package hmac is the default implementation for generating and validating challenges. It uses HMAC-SHA512_256 to
 // generate and validate challenges.
 
 package hmac

--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -64,7 +64,7 @@ func (c *HMACStrategy) Generate() (string, string, error) {
 	defer c.Unlock()
 
 	if len(c.GlobalSecret) < minimumSecretLength {
-		return "", "", errors.Errorf("secret for signing HMAC-SHA256 is expected to be 32 byte long, got %d byte", len(c.GlobalSecret))
+		return "", "", errors.Errorf("secret for signing HMAC-SHA512_256 is expected to be 32 byte long, got %d byte", len(c.GlobalSecret))
 	}
 
 	var signingKey [32]byte

--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -19,7 +19,7 @@
  *
  */
 
-// Package hmac is the default implementation for generating and validating challenges. It uses HMAC-SHA512_256 to
+// Package hmac is the default implementation for generating and validating challenges. It uses SHA-512/256 to
 // generate and validate challenges.
 
 package hmac


### PR DESCRIPTION
## Related issue

<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->
N/A

## Proposed changes

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->
Update the messages and document with new algorithm name. The algorithm was changed earlier and it seems the references were not updated.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [ x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ x] I have read the [security policy](../security/policy).
- [x ] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
