### PR TITLE
fix: Change sha algorithm name acc to standard naming

### DIFF
--- a/token/hmac/hmacsha.go
+++ b/token/hmac/hmacsha.go
@@ -64,7 +64,7 @@ func (c *HMACStrategy) Generate() (string, string, error) {
 	defer c.Unlock()
 
 	if len(c.GlobalSecret) < minimumSecretLength {
-		return "", "", errors.Errorf("secret for signing HMAC-SHA512_256 is expected to be 32 byte long, got %d byte", len(c.GlobalSecret))
+		return "", "", errors.Errorf("secret for signing HMAC-SHA512/256 is expected to be 32 byte long, got %d byte", len(c.GlobalSecret))
 	}
 
 	var signingKey [32]byte

--- a/token/hmac/hmacsha_test.go
+++ b/token/hmac/hmacsha_test.go
@@ -127,7 +127,7 @@ func TestValidateWithRotatedKeyInvalid(t *testing.T) {
 	token, _, err := old.Generate()
 	require.NoError(t, err)
 
-	require.EqualError(t, now.Validate(token), "secret for signing HMAC-SHA256 is expected to be 32 byte long, got 31 byte")
+	require.EqualError(t, now.Validate(token), "secret for signing HMAC-SHA512/256 is expected to be 32 byte long, got 31 byte")
 
-	require.EqualError(t, new(HMACStrategy).Validate(token), "a secret for signing HMAC-SHA256 is expected to be defined, but none were")
+	require.EqualError(t, new(HMACStrategy).Validate(token), "a secret for signing HMAC-SHA512/256 is expected to be defined, but none were")
 }


### PR DESCRIPTION
Left in previous commit.

## Related issue
N/A
<!--
Please link the GitHub issue this pull request resolves in the format of `#1234`. If you discussed this change
with a maintainer, please mention her/him using the `@` syntax (e.g. `@aeneasr`).

If this change neither resolves an existing issue nor has sign-off from one of the maintainers, there is a
chance substantial changes will be requested or that the changes will be rejected.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [ORY Chat](https://www.ory.sh/chat).
-->

## Proposed changes
One occurrence of non-standard algorithm name left in previous commit.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ x] I have read the [security policy](../security/policy).
- [ x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ x] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
