### PR TITLE
feat: allow omitting scope in authorization redirect uri

### DIFF
--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -62,6 +62,10 @@ type AuthorizeExplicitGrantHandler struct {
 	IsRedirectURISecure func(*url.URL) bool
 
 	RefreshTokenScopes []string
+
+	// OmitRedirectScopeParam must be set to true if the scope query param is to be omitted
+	// in the authorization's redirect URI
+	OmitRedirectScopeParam bool
 }
 
 func (c *AuthorizeExplicitGrantHandler) secureChecker() func(*url.URL) bool {
@@ -115,7 +119,9 @@ func (c *AuthorizeExplicitGrantHandler) IssueAuthorizeCode(ctx context.Context, 
 
 	resp.AddParameter("code", code)
 	resp.AddParameter("state", ar.GetState())
-	resp.AddParameter("scope", strings.Join(ar.GetGrantedScopes(), " "))
+	if !c.OmitRedirectScopeParam {
+		resp.AddParameter("scope", strings.Join(ar.GetGrantedScopes(), " "))
+	}
 
 	ar.SetResponseTypeHandled("code")
 	return nil


### PR DESCRIPTION
## Related issue

As discussed with@demonsthere, in the project's Slack Channel: https://ory-community.slack.com/archives/C012USDT5QQ/p1619102732018300


> I have a question / PR suggestion though regarding Fosite's implementation of the authorization code oauth2 flow (I couldn't find a Fosite-specific channel):
is it possible to omit the scope query param from the URL which contains the authorization code ? CF: https://github.com/ory/fosite/blob/master/handler/oauth2/flow_authorize_code_auth.go#L118
I have checked the RFC, it doesn't seem to require the scope parameter. I only see the code and state parameters as requirements
Our issue is that our scope list is quite long, and URL length does have a limitation on certain systems



## Proposed changes

Allow the omission of the `scope` query parameter in the authorization redirect URI by configuring the `AuthorizeExplicitGrantHandler` with a boolean field


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).
