### PR TITLE
feat: add ResponseModeHandler to support custom response modes

### DIFF
--- a/authorize_error.go
+++ b/authorize_error.go
@@ -31,6 +31,11 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 	rw.Header().Set("Cache-Control", "no-store")
 	rw.Header().Set("Pragma", "no-cache")
 
+	if f.ResponseModeHandler().ResponseModes().Has(ar.GetResponseMode()) {
+		f.ResponseModeHandler().WriteAuthorizeError(rw, ar, err)
+		return
+	}
+
 	rfcerr := ErrorToRFC6749Error(err).WithLegacyFormat(f.UseLegacyErrorFormat).WithExposeDebug(f.SendDebugMessagesToClients)
 	if !ar.IsRedirectURIValid() {
 		rw.Header().Set("Content-Type", "application/json;charset=UTF-8")

--- a/authorize_error_test.go
+++ b/authorize_error_test.go
@@ -72,6 +72,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 			err: ErrInvalidGrant,
 			mock: func(rw *MockResponseWriter, req *MockAuthorizeRequester) {
 				req.EXPECT().IsRedirectURIValid().Return(false)
+				req.EXPECT().GetResponseMode().Return(ResponseModeDefault)
 				rw.EXPECT().Header().Times(3).Return(header)
 				rw.EXPECT().WriteHeader(http.StatusBadRequest)
 				rw.EXPECT().Write(gomock.Any())
@@ -427,7 +428,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetRedirectURI().Return(copyUrl(purls[1]))
 				req.EXPECT().GetState().Return("foostate")
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"token"}))
-				req.EXPECT().GetResponseMode().Return(ResponseModeFormPost).Times(1)
+				req.EXPECT().GetResponseMode().Return(ResponseModeFormPost).Times(2)
 				rw.EXPECT().Header().Times(3).Return(header)
 				rw.EXPECT().Write(gomock.Any()).AnyTimes()
 			},

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -238,6 +238,11 @@ func (f *Fosite) ParseResponseMode(r *http.Request, request *AuthorizeRequest) e
 	case string(ResponseModeFormPost):
 		request.ResponseMode = ResponseModeFormPost
 	default:
+		rm := ResponseModeType(responseMode)
+		if f.ResponseModeHandler().ResponseModes().Has(rm) {
+			request.ResponseMode = ResponseModeType(rm)
+			break
+		}
 		return errorsx.WithStack(ErrUnsupportedResponseMode.WithHintf("Request with unsupported response_mode \"%s\".", responseMode))
 	}
 

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -37,7 +37,7 @@ func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 	wh.Set("Pragma", "no-cache")
 
 	redir := ar.GetRedirectURI()
-	switch ar.GetResponseMode() {
+	switch rm := ar.GetResponseMode(); rm {
 	case ResponseModeFormPost:
 		//form_post
 		rw.Header().Add("Content-Type", "text/html;charset=UTF-8")
@@ -60,6 +60,11 @@ func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 		URLSetFragment(redir, resp.GetParameters())
 		sendRedirect(redir.String(), rw)
 		return
+	default:
+		if f.ResponseModeHandler().ResponseModes().Has(rm) {
+			f.ResponseModeHandler().WriteAuthorizeResponse(rw, ar, resp)
+			return
+		}
 	}
 }
 

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -72,6 +72,7 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 		MinParameterEntropy:          config.GetMinParameterEntropy(),
 		UseLegacyErrorFormat:         config.UseLegacyErrorFormat,
 		ClientAuthenticationStrategy: config.GetClientAuthenticationStrategy(),
+		ResponseModeHandlerExtension: config.ResponseModeHandlerExtension,
 	}
 
 	for _, factory := range factories {

--- a/compose/config.go
+++ b/compose/config.go
@@ -114,6 +114,9 @@ type Config struct {
 
 	// ClientAuthenticationStrategy indicates the Strategy to authenticate client requests
 	ClientAuthenticationStrategy fosite.ClientAuthenticationStrategy
+
+	// ResponseModeHandlerExtension provides a handler for custom response modes
+	ResponseModeHandlerExtension fosite.ResponseModeHandler
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.

--- a/fosite.go
+++ b/fosite.go
@@ -113,6 +113,8 @@ type Fosite struct {
 
 	// ClientAuthenticationStrategy provides an extension point to plug a strategy to authenticate clients
 	ClientAuthenticationStrategy ClientAuthenticationStrategy
+
+	ResponseModeHandlerExtension ResponseModeHandler
 }
 
 const MinParameterEntropy = 8
@@ -124,4 +126,13 @@ func (f *Fosite) GetMinParameterEntropy() int {
 	} else {
 		return f.MinParameterEntropy
 	}
+}
+
+var defaultResponseModeHandler = &DefaultResponseModeHandler{}
+
+func (f *Fosite) ResponseModeHandler() ResponseModeHandler {
+	if f.ResponseModeHandlerExtension == nil {
+		return defaultResponseModeHandler
+	}
+	return f.ResponseModeHandlerExtension
 }

--- a/response_handler.go
+++ b/response_handler.go
@@ -1,0 +1,28 @@
+package fosite
+
+import "net/http"
+
+type ResponseModeHandler interface {
+	ResponseModes() ResponseModeTypes
+	WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder)
+	WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error)
+}
+
+type ResponseModeTypes []ResponseModeType
+
+func (rs ResponseModeTypes) Has(item ResponseModeType) bool {
+	for _, r := range rs {
+		if r == item {
+			return true
+		}
+	}
+	return false
+}
+
+type DefaultResponseModeHandler struct{}
+
+func (d *DefaultResponseModeHandler) ResponseModes() ResponseModeTypes { return nil }
+func (d *DefaultResponseModeHandler) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder) {
+}
+func (d *DefaultResponseModeHandler) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error) {
+}

--- a/response_handler.go
+++ b/response_handler.go
@@ -2,9 +2,28 @@ package fosite
 
 import "net/http"
 
+// ResponseModeHandler provides a contract for handling custom response modes
 type ResponseModeHandler interface {
+	// ResponseModes returns a set of supported response modes handled
+	// by the interface implementation.
+	//
+	// In an authorize request with any of the provide response modes
+	// methods `WriteAuthorizeResponse` and `WriteAuthorizeError` will be
+	// invoked to write the successful or error authorization responses respectively.
 	ResponseModes() ResponseModeTypes
+
+	// WriteAuthorizeResponse writes successful responses
+	//
+	// Following headers are expected to be set by default:
+	// header.Set("Cache-Control", "no-store")
+	// header.Set("Pragma", "no-cache")
 	WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp AuthorizeResponder)
+
+	// WriteAuthorizeError writes error responses
+	//
+	// Following headers are expected to be set by default:
+	// header.Set("Cache-Control", "no-store")
+	// header.Set("Pragma", "no-cache")
 	WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error)
 }
 


### PR DESCRIPTION
## Related issue

#591 

## Proposed changes

This is a *draft/preview* PR of the proposed change described in issue #591 

**Status**

* Main functionality is implemented
* Existing Unit tests pass
* Missing: 
    * Add `ResponseModeHandler` in `compose.Config` package
    * Add extra unit test 
    * Document public interface and source code

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x ] I have added tests that prove my fix is effective or that my feature
      works.
- [x ] I have added necessary documentation within the code base (if
      appropriate).
