### PR TITLE
feat: transit from jwt-go to go-jose

### DIFF
--- a/.github/workflows/oidc-conformity.yml
+++ b/.github/workflows/oidc-conformity.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-          repository: ory/hydra
-          ref: master
+          repository: narg95/hydra
+          ref: go-jose_migration
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.15.0'

--- a/.github/workflows/oidc-conformity.yml
+++ b/.github/workflows/oidc-conformity.yml
@@ -13,8 +13,8 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 2
-          repository: narg95/hydra
-          ref: go-jose_migration
+          repository: ory/hydra
+          ref: master
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.15.0'

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -112,6 +112,10 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequest(request *Aut
 			return nil, errorsx.WithStack(ErrInvalidRequestObject.WithHintf("The request object uses signing algorithm '%s', but the requested OAuth 2.0 Client enforces signing algorithm '%s'.", t.Header["alg"], oidcClient.GetRequestObjectSigningAlgorithm()))
 		}
 
+		if t.Method == jwt.SigningMethodNone {
+			return jwt.UnsafeAllowNoneSignatureType, nil
+		}
+
 		switch t.Method {
 		case jose.RS256, jose.RS384, jose.RS512:
 			key, err := f.findClientPublicJWK(oidcClient, t, true)

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -28,9 +28,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/x/errorsx"
+	"gopkg.in/square/go-jose.v2"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
 	"github.com/ory/go-convenience/stringslice"
@@ -101,7 +102,7 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequest(request *Aut
 		assertion = string(body)
 	}
 
-	token, err := jwt.ParseWithClaims(assertion, new(jwt.MapClaims), func(t *jwt.Token) (interface{}, error) {
+	token, err := jwt.ParseWithClaims(assertion, jwt.MapClaims{}, func(t *jwt.Token) (interface{}, error) {
 		// request_object_signing_alg - OPTIONAL.
 		//  JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects sent to the OP. All Request Objects from this Client MUST be rejected,
 		// 	if not signed with this algorithm. Request Objects are described in Section 6.1 of OpenID Connect Core 1.0 [OpenID.Core]. This algorithm MUST
@@ -111,26 +112,22 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequest(request *Aut
 			return nil, errorsx.WithStack(ErrInvalidRequestObject.WithHintf("The request object uses signing algorithm '%s', but the requested OAuth 2.0 Client enforces signing algorithm '%s'.", t.Header["alg"], oidcClient.GetRequestObjectSigningAlgorithm()))
 		}
 
-		if t.Method == jwt.SigningMethodNone {
-			return jwt.UnsafeAllowNoneSignatureType, nil
-		}
-
-		switch t.Method.(type) {
-		case *jwt.SigningMethodRSA:
+		switch t.Method {
+		case jose.RS256, jose.RS384, jose.RS512:
 			key, err := f.findClientPublicJWK(oidcClient, t, true)
 			if err != nil {
 				return nil, wrapSigningKeyFailure(
 					ErrInvalidRequestObject.WithHint("Unable to retrieve RSA signing key from OAuth 2.0 Client."), err)
 			}
 			return key, nil
-		case *jwt.SigningMethodECDSA:
+		case jose.ES256, jose.ES384, jose.ES512:
 			key, err := f.findClientPublicJWK(oidcClient, t, false)
 			if err != nil {
 				return nil, wrapSigningKeyFailure(
 					ErrInvalidRequestObject.WithHint("Unable to retrieve ECDSA signing key from OAuth 2.0 Client."), err)
 			}
 			return key, nil
-		case *jwt.SigningMethodRSAPSS:
+		case jose.PS256, jose.PS384, jose.PS512:
 			key, err := f.findClientPublicJWK(oidcClient, t, true)
 			if err != nil {
 				return nil, wrapSigningKeyFailure(
@@ -155,12 +152,8 @@ func (f *Fosite) authorizeRequestParametersFromOpenIDConnectRequest(request *Aut
 		return errorsx.WithStack(ErrInvalidRequestObject.WithHint("Unable to verify the request object because its claims could not be validated, check if the expiry time is set correctly.").WithWrap(err).WithDebug(err.Error()))
 	}
 
-	claims, ok := token.Claims.(*jwt.MapClaims)
-	if !ok {
-		return errorsx.WithStack(ErrInvalidRequestObject.WithHint("Unable to type assert claims from request object.").WithDebugf(`Got claims of type %T but expected type '*jwt.MapClaims'.`, token.Claims))
-	}
-
-	for k, v := range *claims {
+	claims := token.Claims
+	for k, v := range claims {
 		request.Form.Set(k, fmt.Sprintf("%s", v))
 	}
 

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -34,7 +34,7 @@ import (
 	"testing"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	"github.com/ory/fosite/token/jwt"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -46,7 +46,7 @@ import (
 )
 
 func mustGenerateRSAAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token := jwt.NewWithClaims(jose.RS256, claims)
 	token.Header["kid"] = kid
 	tokenString, err := token.SignedString(key)
 	require.NoError(t, err)
@@ -54,7 +54,7 @@ func mustGenerateRSAAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.Priva
 }
 
 func mustGenerateECDSAAssertion(t *testing.T, claims jwt.MapClaims, key *ecdsa.PrivateKey, kid string) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	token := jwt.NewWithClaims(jose.ES256, claims)
 	token.Header["kid"] = kid
 	tokenString, err := token.SignedString(key)
 	require.NoError(t, err)
@@ -62,15 +62,8 @@ func mustGenerateECDSAAssertion(t *testing.T, claims jwt.MapClaims, key *ecdsa.P
 }
 
 func mustGenerateHSAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	token := jwt.NewWithClaims(jose.HS256, claims)
 	tokenString, err := token.SignedString([]byte("aaaaaaaaaaaaaaabbbbbbbbbbbbbbbbbbbbbbbcccccccccccccccccccccddddddddddddddddddddddd"))
-	require.NoError(t, err)
-	return tokenString
-}
-
-func mustGenerateNoneAssertion(t *testing.T, claims jwt.MapClaims, key *rsa.PrivateKey, kid string) string {
-	token := jwt.NewWithClaims(jwt.SigningMethodNone, claims)
-	tokenString, err := token.SignedString(jwt.UnsafeAllowNoneSignatureType)
 	require.NoError(t, err)
 	return tokenString
 }
@@ -409,19 +402,6 @@ func TestAuthenticateClient(t *testing.T) {
 			expectErr: ErrInvalidClient,
 		},
 		{
-			d:      "should fail because JWT algorithm is none",
-			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeys: rsaJwks, TokenEndpointAuthMethod: "private_key_jwt"},
-			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateNoneAssertion(t, jwt.MapClaims{
-				"sub": "bar",
-				"exp": time.Now().Add(time.Hour).Unix(),
-				"iss": "bar",
-				"jti": "12345",
-				"aud": "token-url",
-			}, rsaKey, "kid-foo")}, "client_assertion_type": []string{at}},
-			r:         new(http.Request),
-			expectErr: ErrInvalidClient,
-		},
-		{
 			d:      "should pass with proper assertion when JWKs URI is set",
 			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret}, JSONWebKeysURI: ts.URL, TokenEndpointAuthMethod: "private_key_jwt"},
 			form: url.Values{"client_id": []string{"bar"}, "client_assertion": {mustGenerateRSAAssertion(t, jwt.MapClaims{
@@ -503,6 +483,7 @@ func TestAuthenticateClient(t *testing.T) {
 					t.Logf("Error is: %s", validationError.Inner)
 				} else if errors.As(err, &rfcError) {
 					t.Logf("DebugField is: %s", rfcError.DebugField)
+					t.Logf("HintField is: %s", rfcError.HintField)
 				}
 			}
 			require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -7,8 +7,6 @@ replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 require (
 	github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/form3tech-oss/jwt-go v3.2.2+incompatible // indirect
 	github.com/golang/mock v1.4.4
 	github.com/gorilla/mux v1.7.3
 	github.com/gorilla/websocket v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -113,10 +113,7 @@ github.com/fatih/structs v1.0.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
-github.com/form3tech-oss/jwt-go v3.2.1+incompatible h1:xdtqez379uWVJ9P3qQMX8W+F/nqsTdUvyMZB36tnacA=
 github.com/form3tech-oss/jwt-go v3.2.1+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=

--- a/handler/oauth2/introspector_jwt.go
+++ b/handler/oauth2/introspector_jwt.go
@@ -25,8 +25,6 @@ import (
 	"context"
 	"time"
 
-	jwtx "github.com/dgrijalva/jwt-go"
-
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/token/jwt"
 )
@@ -37,8 +35,8 @@ type StatelessJWTValidator struct {
 }
 
 // AccessTokenJWTToRequest tries to reconstruct fosite.Request from a JWT.
-func AccessTokenJWTToRequest(token *jwtx.Token) fosite.Requester {
-	mapClaims := token.Claims.(jwtx.MapClaims)
+func AccessTokenJWTToRequest(token *jwt.Token) fosite.Requester {
+	mapClaims := token.Claims
 	claims := jwt.JWTClaims{}
 	claims.FromMapClaims(mapClaims)
 

--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/ory/x/errorsx"
 
-	jwtx "github.com/dgrijalva/jwt-go"
 	"github.com/pkg/errors"
 
 	"github.com/ory/fosite"
@@ -99,7 +98,7 @@ func (h *DefaultJWTStrategy) ValidateAuthorizeCode(ctx context.Context, req fosi
 	return h.HMACSHAStrategy.ValidateAuthorizeCode(ctx, req, token)
 }
 
-func validate(ctx context.Context, jwtStrategy jwt.JWTStrategy, token string) (t *jwtx.Token, err error) {
+func validate(ctx context.Context, jwtStrategy jwt.JWTStrategy, token string) (t *jwt.Token, err error) {
 	t, err = jwtStrategy.Decode(ctx, token)
 
 	if err == nil {
@@ -107,28 +106,28 @@ func validate(ctx context.Context, jwtStrategy jwt.JWTStrategy, token string) (t
 	}
 
 	if err != nil {
-		var e *jwtx.ValidationError
+		var e *jwt.ValidationError
 		if errors.As(err, &e) {
 			switch e.Errors {
-			case jwtx.ValidationErrorMalformed:
+			case jwt.ValidationErrorMalformed:
 				err = errorsx.WithStack(fosite.ErrInvalidTokenFormat.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorUnverifiable:
+			case jwt.ValidationErrorUnverifiable:
 				err = errorsx.WithStack(fosite.ErrTokenSignatureMismatch.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorSignatureInvalid:
+			case jwt.ValidationErrorSignatureInvalid:
 				err = errorsx.WithStack(fosite.ErrTokenSignatureMismatch.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorAudience:
+			case jwt.ValidationErrorAudience:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorExpired:
+			case jwt.ValidationErrorExpired:
 				err = errorsx.WithStack(fosite.ErrTokenExpired.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorIssuedAt:
+			case jwt.ValidationErrorIssuedAt:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorIssuer:
+			case jwt.ValidationErrorIssuer:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorNotValidYet:
+			case jwt.ValidationErrorNotValidYet:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorId:
+			case jwt.ValidationErrorId:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
-			case jwtx.ValidationErrorClaimsInvalid:
+			case jwt.ValidationErrorClaimsInvalid:
 				err = errorsx.WithStack(fosite.ErrTokenClaim.WithWrap(err).WithDebug(err.Error()))
 			default:
 				err = errorsx.WithStack(fosite.ErrRequestUnauthorized.WithWrap(err).WithDebug(err.Error()))

--- a/handler/openid/flow_explicit_token_test.go
+++ b/handler/openid/flow_explicit_token_test.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"testing"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
 	"github.com/golang/mock/gomock"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
@@ -124,10 +123,11 @@ func TestExplicit_PopulateTokenEndpointResponse(t *testing.T) {
 			check: func(t *testing.T, aresp *fosite.AccessResponse) {
 				assert.NotEmpty(t, aresp.GetExtra("id_token"))
 				idToken, _ := aresp.GetExtra("id_token").(string)
-				decodedIdToken, _ := jwtgo.Parse(idToken, func(token *jwtgo.Token) (interface{}, error) {
+				decodedIdToken, err := jwt.Parse(idToken, func(token *jwt.Token) (interface{}, error) {
 					return key.PublicKey, nil
 				})
-				claims, _ := decodedIdToken.Claims.(jwtgo.MapClaims)
+				require.NoError(t, err)
+				claims := decodedIdToken.Claims
 				assert.NotEmpty(t, claims["at_hash"])
 			},
 		},

--- a/handler/openid/flow_refresh_token_test.go
+++ b/handler/openid/flow_refresh_token_test.go
@@ -24,7 +24,6 @@ package openid
 import (
 	"testing"
 
-	jwtgo "github.com/dgrijalva/jwt-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -164,10 +163,11 @@ func TestOpenIDConnectRefreshHandler_PopulateTokenEndpointResponse(t *testing.T)
 			check: func(t *testing.T, aresp *fosite.AccessResponse) {
 				assert.NotEmpty(t, aresp.GetExtra("id_token"))
 				idToken, _ := aresp.GetExtra("id_token").(string)
-				decodedIdToken, _ := jwtgo.Parse(idToken, func(token *jwtgo.Token) (interface{}, error) {
+				decodedIdToken, err := jwt.Parse(idToken, func(token *jwt.Token) (interface{}, error) {
 					return key.PublicKey, nil
 				})
-				claims, _ := decodedIdToken.Claims.(jwtgo.MapClaims)
+				require.NoError(t, err)
+				claims := decodedIdToken.Claims
 				assert.NotEmpty(t, claims["at_hash"])
 			},
 		},

--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -24,7 +24,6 @@ package jwt
 import (
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 )
 
@@ -146,6 +145,6 @@ func (c *IDTokenClaims) Get(key string) interface{} {
 }
 
 // ToMapClaims will return a jwt-go MapClaims representation
-func (c IDTokenClaims) ToMapClaims() jwt.MapClaims {
+func (c IDTokenClaims) ToMapClaims() MapClaims {
 	return c.ToMap()
 }

--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/pborman/uuid"
 )
 
@@ -58,7 +57,7 @@ type JWTClaimsContainer interface {
 	WithScopeField(scopeField JWTScopeFieldEnum) JWTClaimsContainer
 
 	// ToMapClaims returns the claims as a github.com/dgrijalva/jwt-go.MapClaims type.
-	ToMapClaims() jwt.MapClaims
+	ToMapClaims() MapClaims
 }
 
 // JWTClaims represent a token's claims.
@@ -255,11 +254,11 @@ func (c JWTClaims) Get(key string) interface{} {
 }
 
 // ToMapClaims will return a jwt-go MapClaims representation
-func (c JWTClaims) ToMapClaims() jwt.MapClaims {
+func (c JWTClaims) ToMapClaims() MapClaims {
 	return c.ToMap()
 }
 
 // FromMapClaims will populate claims from a jwt-go MapClaims representation
-func (c *JWTClaims) FromMapClaims(mc jwt.MapClaims) {
+func (c *JWTClaims) FromMapClaims(mc MapClaims) {
 	c.FromMap(mc)
 }

--- a/token/jwt/header.go
+++ b/token/jwt/header.go
@@ -21,8 +21,6 @@
 
 package jwt
 
-import jwt "github.com/dgrijalva/jwt-go"
-
 // Headers is the jwt headers
 type Headers struct {
 	Extra map[string]interface{}
@@ -61,6 +59,6 @@ func (h *Headers) Get(key string) interface{} {
 }
 
 // ToMapClaims will return a jwt-go MapClaims representation
-func (h Headers) ToMapClaims() jwt.MapClaims {
+func (h Headers) ToMapClaims() MapClaims {
 	return h.ToMap()
 }

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -30,8 +30,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/ory/fosite/internal"
 )
 
 var header = &Headers{
@@ -48,13 +46,13 @@ func TestHash(t *testing.T) {
 		{
 			d: "RS256JWTStrategy",
 			strategy: &RS256JWTStrategy{
-				PrivateKey: internal.MustRSAKey(),
+				PrivateKey: MustRSAKey(),
 			},
 		},
 		{
 			d: "ES256JWTStrategy",
 			strategy: &ES256JWTStrategy{
-				PrivateKey: internal.MustECDSAKey(),
+				PrivateKey: MustECDSAKey(),
 			},
 		},
 	} {
@@ -103,19 +101,19 @@ func TestGenerateJWT(t *testing.T) {
 		{
 			d: "RS256JWTStrategy",
 			strategy: &RS256JWTStrategy{
-				PrivateKey: internal.MustRSAKey(),
+				PrivateKey: MustRSAKey(),
 			},
 			resetKey: func(strategy JWTStrategy) {
-				strategy.(*RS256JWTStrategy).PrivateKey = internal.MustRSAKey()
+				strategy.(*RS256JWTStrategy).PrivateKey = MustRSAKey()
 			},
 		},
 		{
 			d: "ES256JWTStrategy",
 			strategy: &ES256JWTStrategy{
-				PrivateKey: internal.MustECDSAKey(),
+				PrivateKey: MustECDSAKey(),
 			},
 			resetKey: func(strategy JWTStrategy) {
-				strategy.(*ES256JWTStrategy).PrivateKey = internal.MustECDSAKey()
+				strategy.(*ES256JWTStrategy).PrivateKey = MustECDSAKey()
 			},
 		},
 	} {
@@ -149,7 +147,6 @@ func TestGenerateJWT(t *testing.T) {
 			token, sig, err = tc.strategy.Generate(context.TODO(), claims.ToMapClaims(), header)
 			require.NoError(t, err)
 			require.NotNil(t, token)
-			//t.Logf("%s.%s", token, sig)
 
 			sig, err = tc.strategy.Validate(context.TODO(), token)
 			require.Error(t, err)
@@ -177,13 +174,13 @@ func TestValidateSignatureRejectsJWT(t *testing.T) {
 		{
 			d: "RS256JWTStrategy",
 			strategy: &RS256JWTStrategy{
-				PrivateKey: internal.MustRSAKey(),
+				PrivateKey: MustRSAKey(),
 			},
 		},
 		{
 			d: "ES256JWTStrategy",
 			strategy: &ES256JWTStrategy{
-				PrivateKey: internal.MustECDSAKey(),
+				PrivateKey: MustECDSAKey(),
 			},
 		},
 	} {

--- a/token/jwt/key_test.go
+++ b/token/jwt/key_test.go
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright 	2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+// REMARK: Copied here from fosite/internal to avoid circular dependencies only for test data
+
+package jwt
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+)
+
+func MustRSAKey() *rsa.PrivateKey {
+	// #nosec
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}
+
+func MustECDSAKey() *ecdsa.PrivateKey {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		panic(err)
+	}
+	return key
+}

--- a/token/jwt/map_claims.go
+++ b/token/jwt/map_claims.go
@@ -1,0 +1,154 @@
+package jwt
+
+import (
+	"crypto/subtle"
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// MapClaims provides backwards compatible validations not available in `go-jose`.
+// It was taken from [here](https://github.com/dgrijalva/jwt-go/blob/master/map_claims.go).
+//
+// > Claims type that uses the map[string]interface{} for JSON decoding
+// This is the default claims type if you don't supply one
+type MapClaims map[string]interface{}
+
+// Compares the aud claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
+	aud, ok := m["aud"].([]string)
+	if !ok {
+		strAud, ok := m["aud"].(string)
+		if !ok {
+			return false
+		}
+		aud = append(aud, strAud)
+	}
+
+	return verifyAud(aud, cmp, req)
+}
+
+// Compares the exp claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
+	switch exp := m["exp"].(type) {
+	case float64:
+		return verifyExp(int64(exp), cmp, req)
+	case json.Number:
+		v, _ := exp.Int64()
+		return verifyExp(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iat claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
+	switch iat := m["iat"].(type) {
+	case float64:
+		return verifyIat(int64(iat), cmp, req)
+	case json.Number:
+		v, _ := iat.Int64()
+		return verifyIat(v, cmp, req)
+	}
+	return req == false
+}
+
+// Compares the iss claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
+	iss, _ := m["iss"].(string)
+	return verifyIss(iss, cmp, req)
+}
+
+// Compares the nbf claim against cmp.
+// If required is false, this method will return true if the value matches or is unset
+func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
+	switch nbf := m["nbf"].(type) {
+	case float64:
+		return verifyNbf(int64(nbf), cmp, req)
+	case json.Number:
+		v, _ := nbf.Int64()
+		return verifyNbf(v, cmp, req)
+	}
+	return req == false
+}
+
+var TimeFunc = time.Now
+
+// Validates time based claims "exp, iat, nbf".
+// There is no accounting for clock skew.
+// As well, if any of the above claims are not in the token, it will still
+// be considered a valid claim.
+func (m MapClaims) Valid() error {
+	vErr := new(ValidationError)
+	now := TimeFunc().Unix()
+
+	if !m.VerifyExpiresAt(now, false) {
+		vErr.Inner = errors.New("Token is expired")
+		vErr.Errors |= ValidationErrorExpired
+	}
+
+	if !m.VerifyIssuedAt(now, false) {
+		vErr.Inner = errors.New("Token used before issued")
+		vErr.Errors |= ValidationErrorIssuedAt
+	}
+
+	if !m.VerifyNotBefore(now, false) {
+		vErr.Inner = errors.New("Token is not valid yet")
+		vErr.Errors |= ValidationErrorNotValidYet
+	}
+
+	if vErr.valid() {
+		return nil
+	}
+
+	return vErr
+}
+
+func verifyAud(aud []string, cmp string, required bool) bool {
+	if len(aud) == 0 {
+		return !required
+	}
+
+	for _, a := range aud {
+		if subtle.ConstantTimeCompare([]byte(a), []byte(cmp)) != 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func verifyExp(exp int64, now int64, required bool) bool {
+	if exp == 0 {
+		return !required
+	}
+	return now <= exp
+}
+
+func verifyIat(iat int64, now int64, required bool) bool {
+	if iat == 0 {
+		return !required
+	}
+	return now >= iat
+}
+
+func verifyIss(iss string, cmp string, required bool) bool {
+	if iss == "" {
+		return !required
+	}
+	if subtle.ConstantTimeCompare([]byte(iss), []byte(cmp)) != 0 {
+		return true
+	} else {
+		return false
+	}
+}
+
+func verifyNbf(nbf int64, now int64, required bool) bool {
+	if nbf == 0 {
+		return !required
+	}
+	return now >= nbf
+}

--- a/token/jwt/map_claims_test.go
+++ b/token/jwt/map_claims_test.go
@@ -1,0 +1,95 @@
+package jwt
+
+import "testing"
+
+// Test taken from taken from [here](https://raw.githubusercontent.com/form3tech-oss/jwt-go/master/map_claims_test.go).
+func Test_mapClaims_list_aud(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": []string{"foo"},
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+// This is a custom test to check that an empty
+// list with require == false returns valid
+func Test_mapClaims_empty_list_aud(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": []string{},
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", false)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_list_interface_aud(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": []interface{}{"foo"},
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_string_aud(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": "foo",
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_list_aud_no_match(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": []string{"bar"},
+	}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_string_aud_fail(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": "bar",
+	}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_string_aud_no_claim(t *testing.T) {
+	mapClaims := MapClaims{}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T) {
+	mapClaims := MapClaims{}
+	want := false
+	got := mapClaims.VerifyAudience("foo", false)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}

--- a/token/jwt/token.go
+++ b/token/jwt/token.go
@@ -173,10 +173,9 @@ func ParseWithClaims(rawToken string, claims MapClaims, keyFunc Keyfunc) (*Token
 	// with jwt-go library behavior
 	if err := claims.Valid(); err != nil {
 		if e, ok := err.(*ValidationError); !ok {
-			return nil, &ValidationError{Inner: e, Errors: ValidationErrorClaimsInvalid}
-		} else {
-			return nil, err
+			err = &ValidationError{Inner: e, Errors: ValidationErrorClaimsInvalid}
 		}
+		return token, err
 	}
 
 	// set token as verified and validated

--- a/token/jwt/token.go
+++ b/token/jwt/token.go
@@ -1,0 +1,196 @@
+package jwt
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/ory/x/errorsx"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// Token represets a JWT Token
+// This token provide an adaptation to
+// transit from [jwt-go](https://github.com/dgrijalva/jwt-go)
+// to [go-jose](https://github.com/square/go-jose)
+// It provides method signatures compatible with jwt-go but implemented
+// using go-json
+type Token struct {
+	Header map[string]interface{} // The first segment of the token
+	Claims MapClaims              // The second segment of the token
+	Method jose.SignatureAlgorithm
+	valid  bool
+}
+
+// Valid informs if the token was verified against a given verification key
+// and claims are valid
+func (t *Token) Valid() bool {
+	return t.valid
+}
+
+// Claims is a port from https://github.com/dgrijalva/jwt-go/blob/master/claims.go
+// including its validation methods, which are not available in go-jose library
+//
+// > For a type to be a Claims object, it must just have a Valid method that determines
+// if the token is invalid for any supported reason
+type Claims interface {
+	Valid() error
+}
+
+// NewWithClaims creates an unverified Token with the given claims and signing method
+func NewWithClaims(method jose.SignatureAlgorithm, claims MapClaims) *Token {
+	return &Token{
+		Claims: claims,
+		Method: method,
+		Header: map[string]interface{}{},
+	}
+}
+
+func (t *Token) toJoseHeader() map[jose.HeaderKey]interface{} {
+	h := map[jose.HeaderKey]interface{}{}
+	for k, v := range t.Header {
+		h[jose.HeaderKey(k)] = v
+	}
+	return h
+}
+
+// SignedString provides a compatible `jwt-go` Token.SignedString method
+//
+// > Get the complete, signed token
+func (t *Token) SignedString(k interface{}) (rawToken string, err error) {
+	var signer jose.Signer
+	key := jose.SigningKey{
+		Algorithm: t.Method,
+		Key:       k,
+	}
+	opts := &jose.SignerOptions{ExtraHeaders: t.toJoseHeader()}
+	signer, err = jose.NewSigner(key, opts)
+	if err != nil {
+		err = errorsx.WithStack(err)
+		return
+	}
+
+	// A explicit conversion from type alias MapClaims
+	// to map[string]interface{} is required because the
+	// go-jose CompactSerialize() only support explicit maps
+	// as claims or structs but not type aliases from maps.
+	claims := map[string]interface{}(t.Claims)
+	rawToken, err = jwt.Signed(signer).Claims(claims).CompactSerialize()
+	if err != nil {
+		err = &ValidationError{Errors: ValidationErrorClaimsInvalid, Inner: err}
+		return
+	}
+	return
+}
+
+func newToken(parsedToken *jwt.JSONWebToken, claims MapClaims) (*Token, error) {
+	token := &Token{Claims: claims}
+	if len(parsedToken.Headers) != 1 {
+		return nil, &ValidationError{text: fmt.Sprintf("only one header supported, got %v", len(parsedToken.Headers)), Errors: ValidationErrorMalformed}
+	}
+
+	// copy headers
+	h := parsedToken.Headers[0]
+	token.Header = map[string]interface{}{
+		"alg": h.Algorithm,
+	}
+	if h.KeyID != "" {
+		token.Header["kid"] = h.KeyID
+	}
+	for k, v := range h.ExtraHeaders {
+		token.Header[string(k)] = v
+	}
+
+	token.Method = jose.SignatureAlgorithm(h.Algorithm)
+
+	return token, nil
+}
+
+// Parse methods use this callback function to supply
+// the key for verification.  The function receives the parsed,
+// but unverified Token.  This allows you to use properties in the
+// Header of the token (such as `kid`) to identify which key to use.
+type Keyfunc func(*Token) (interface{}, error)
+
+func Parse(tokenString string, keyFunc Keyfunc) (*Token, error) {
+	return ParseWithClaims(tokenString, MapClaims{}, keyFunc)
+}
+
+// Parse, validate, and return a token.
+// keyFunc will receive the parsed token and should return the key for validating.
+// If everything is kosher, err will be nil
+func ParseWithClaims(rawToken string, claims MapClaims, keyFunc Keyfunc) (*Token, error) {
+	// Parse the token.
+	parsedToken, err := jwt.ParseSigned(rawToken)
+	if err != nil {
+		return nil, &ValidationError{Errors: ValidationErrorMalformed, text: err.Error()}
+	}
+
+	// fill unverified claims
+	// This conversion is required because go-jose supports
+	// only marshalling structs or maps but not alias types from maps
+	//
+	// The KeyFunc(*Token) function requires the claims to be set into the
+	// Token, that is an unverified token, therefore an UnsafeClaimsWithoutVerification is done first
+	// then with the returned key, the claims gets verified.
+	if err := parsedToken.UnsafeClaimsWithoutVerification(&claims); err != nil {
+		return nil, &ValidationError{Errors: ValidationErrorClaimsInvalid, text: err.Error()}
+	}
+
+	// creates an usafe token
+	token, err := newToken(parsedToken, claims)
+	if err != nil {
+		return nil, err
+	}
+
+	if keyFunc == nil {
+		// keyFunc was not provided.  short circuiting validation
+		return token, &ValidationError{Errors: ValidationErrorUnverifiable, text: "no Keyfunc was provided."}
+	}
+
+	// Call keyFunc callback to get verification key
+	verificationKey, err := keyFunc(token)
+	if err != nil {
+		// keyFunc returned an error
+		if ve, ok := err.(*ValidationError); ok {
+			return token, ve
+		}
+		return token, &ValidationError{Errors: ValidationErrorUnverifiable, Inner: err}
+	}
+	// To verify signature go-jose requires a pointer to
+	// public key instead of the public key value.
+	// The pointer values provides that pointer.
+	// E.g. transform rsa.PublicKey -> *rsa.PublicKey
+	verificationKey = pointer(verificationKey)
+
+	// verify signature with returned key
+	if err := parsedToken.Claims(verificationKey, &claims); err != nil {
+		return nil, &ValidationError{Errors: ValidationErrorSignatureInvalid, text: err.Error()}
+	}
+
+	// Validate claims
+	// This validation is performed to be backwards compatible
+	// with jwt-go library behavior
+	if err := claims.Valid(); err != nil {
+		if e, ok := err.(*ValidationError); !ok {
+			return nil, &ValidationError{Inner: e, Errors: ValidationErrorClaimsInvalid}
+		} else {
+			return nil, err
+		}
+	}
+
+	// set token as verified and validated
+	token.valid = true
+	return token, nil
+}
+
+// if underline value of v is not a pointer
+// it creates a pointer of it and returns it
+func pointer(v interface{}) interface{} {
+	if reflect.ValueOf(v).Kind() != reflect.Ptr {
+		value := reflect.New(reflect.ValueOf(v).Type())
+		value.Elem().Set(reflect.ValueOf(v))
+		return value.Interface()
+	}
+	return v
+}

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -1,0 +1,30 @@
+package jwt
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/square/go-jose.v2"
+)
+
+func TestParseInvalidReturnsToken(t *testing.T) {
+	key := MustRSAKey()
+	token, _, err := generateToken(MapClaims{
+		"aud": "foo",
+		"exp": time.Now().UTC().Add(-time.Hour).Unix(),
+		"iat": time.Now().UTC().Add(-2 * time.Hour).Unix(),
+		"sub": "nestor",
+	}, NewHeaders(), jose.RS256, key)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, token)
+
+	ptoken, err := Parse(token, func(*Token) (interface{}, error) { return &key.PublicKey, nil })
+	require.Error(t, err)
+	var verr *ValidationError
+	require.True(t, errors.As(err, &verr))
+	require.NotZero(t, verr.Errors&ValidationErrorExpired, "%+v", verr)
+	require.NotEmpty(t, ptoken)
+}

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -1,34 +1,20 @@
 package jwt
 
 import (
-	"errors"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/square/go-jose.v2"
+
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 )
-
-func TestParseInvalidReturnsToken(t *testing.T) {
-	key := MustRSAKey()
-	token, _, err := generateToken(MapClaims{
-		"aud": "foo",
-		"exp": time.Now().UTC().Add(-time.Hour).Unix(),
-		"iat": time.Now().UTC().Add(-2 * time.Hour).Unix(),
-		"sub": "nestor",
-	}, NewHeaders(), jose.RS256, key)
-
-	require.NoError(t, err)
-	require.NotEmpty(t, token)
-
-	ptoken, err := Parse(token, func(*Token) (interface{}, error) { return &key.PublicKey, nil })
-	require.Error(t, err)
-	var verr *ValidationError
-	require.True(t, errors.As(err, &verr))
-	require.NotZero(t, verr.Errors&ValidationErrorExpired, "%+v", verr)
-	require.NotEmpty(t, ptoken)
-}
 
 func TestUnsignedToken(t *testing.T) {
 	key := UnsafeAllowNoneSignatureType
@@ -45,3 +31,349 @@ func TestUnsignedToken(t *testing.T) {
 	require.Len(t, parts, 3)
 	require.Empty(t, parts[2])
 }
+
+var keyFuncError error = fmt.Errorf("error loading key")
+var (
+	jwtTestDefaultKey *rsa.PublicKey = parseRSAPublicKeyFromPEM(defaultPubKeyPEM)
+	defaultKeyFunc    Keyfunc        = func(t *Token) (interface{}, error) { return jwtTestDefaultKey, nil }
+	emptyKeyFunc      Keyfunc        = func(t *Token) (interface{}, error) { return nil, nil }
+	errorKeyFunc      Keyfunc        = func(t *Token) (interface{}, error) { return nil, keyFuncError }
+	nilKeyFunc        Keyfunc        = nil
+)
+
+// Many test cases where taken from https://github.com/dgrijalva/jwt-go/blob/master/parser_test.go
+// Test cases related to json.Number where excluded because that is not supported by go-jose,
+// it is not used in fosite and therefore not supported.
+func TestParser_Parse(t *testing.T) {
+	var (
+		defaultES256PrivateKey = MustECDSAKey()
+		defaultSigningKey      = parseRSAPrivateKeyFromPEM(defaultPrivateKeyPEM)
+		publicECDSAKey         = func(*Token) (interface{}, error) { return &defaultES256PrivateKey.PublicKey, nil }
+		noneKey                = func(*Token) (interface{}, error) { return UnsafeAllowNoneSignatureType, nil }
+		randomKey              = func(*Token) (interface{}, error) {
+			k, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			return &k.PublicKey, nil
+		}
+	)
+	var jwtTestData = []struct {
+		name        string
+		tokenString string
+		keyfunc     Keyfunc
+		claims      MapClaims
+		valid       bool
+		errors      uint32
+		signingKey  interface{}             // defaultSigningKey
+		method      jose.SignatureAlgorithm // default RS256
+	}{
+		{
+			name:        "basic",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       true,
+			errors:      0,
+		},
+		{
+			name:        "basic expired",
+			tokenString: "", // autogen
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar", "exp": float64(time.Now().Unix() - 100)},
+			valid:       false,
+			errors:      ValidationErrorExpired,
+		},
+		{
+			name:        "basic nbf",
+			tokenString: "", // autogen
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100)},
+			valid:       false,
+			errors:      ValidationErrorNotValidYet,
+		},
+		{
+			name:        "expired and nbf",
+			tokenString: "", // autogen
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar", "nbf": float64(time.Now().Unix() + 100), "exp": float64(time.Now().Unix() - 100)},
+			valid:       false,
+			errors:      ValidationErrorNotValidYet | ValidationErrorExpired,
+		},
+		{
+			name:        "basic invalid",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.EhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+		},
+		{
+			name:        "basic nokeyfunc",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     nilKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorUnverifiable,
+		},
+		{
+			name:        "basic nokey",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     emptyKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+		},
+		{
+			name:        "basic errorkey",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     errorKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorUnverifiable,
+		},
+		{
+			name:        "valid signing method",
+			tokenString: "",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       true,
+			errors:      0,
+		},
+		{
+			name:        "invalid",
+			tokenString: "foo_invalid_token",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims(nil),
+			valid:       false,
+			errors:      ValidationErrorMalformed,
+		},
+		{
+			name:        "valid format invalid content",
+			tokenString: "foo.bar.baz",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims(nil),
+			valid:       false,
+			errors:      ValidationErrorMalformed,
+		},
+		{
+			name:        "wrong key, expected RSA got ECDSA",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     publicECDSAKey,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+		},
+		{
+			name:        "nokey, expected RSA got ECDSA",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     emptyKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+		},
+		{
+			name:        "key does not match",
+			tokenString: "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJmb28iOiJiYXIifQ.FhkiHkoESI_cG3NPigFrxEk9Z60_oXrOT2vGm9Pn6RDgYNovYORQmmA0zs1AoAOf09ly2Nx2YAg6ABqAYga1AcMFkJljwxTT5fYphTuqpWdy4BELeSYJx5Ty2gmr8e7RonuUztrdD5WfPqLKMm1Ozp_T6zALpRmwTIW0QPnaBXaQD90FplAg46Iy1UlDKr-Eupy0i5SLch5Q-p2ZpaL_5fnTIUDlxC3pWhJTyx_71qDI-mAA_5lE_VdroOeflG56sSmDxopPEG3bFlSu1eowyBfxtu0_CuVd-M42RU75Zc4Gsj6uV77MBtbMrf4_7M_NUTSgoIF3fRqxrj0NzihIBg",
+			keyfunc:     randomKey,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+		},
+		{
+			name:        "used before issued",
+			tokenString: "", // autogen
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar", "iat": float64(time.Now().Unix() + 500)},
+			valid:       false,
+			errors:      ValidationErrorIssuedAt,
+		},
+		{
+			name:        "valid ECDSA signing method",
+			tokenString: "",
+			keyfunc:     publicECDSAKey,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       true,
+			errors:      0,
+			signingKey:  defaultES256PrivateKey,
+			method:      jose.ES256,
+		},
+		{
+			name:        "valid NONE signing method",
+			tokenString: "",
+			keyfunc:     noneKey,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       true,
+			errors:      0,
+			signingKey:  UnsafeAllowNoneSignatureType,
+			method:      SigningMethodNone,
+		},
+		{
+			name:        "should fail, valid NONE token with invalid verification key",
+			tokenString: "",
+			keyfunc:     defaultKeyFunc,
+			claims:      MapClaims{"foo": "bar"},
+			valid:       false,
+			errors:      ValidationErrorSignatureInvalid,
+			signingKey:  UnsafeAllowNoneSignatureType,
+			method:      SigningMethodNone,
+		},
+	}
+
+	// Iterate over test data set and run tests
+	for _, data := range jwtTestData {
+		t.Run(data.name, func(t *testing.T) {
+			// If the token string is blank, use helper function to generate string
+			if data.tokenString == "" {
+				signingKey := data.signingKey
+				method := data.method
+				if signingKey == nil {
+					// use test defaults
+					signingKey = defaultSigningKey
+					method = jose.RS256
+				}
+				data.tokenString = makeSampleToken(data.claims, method, signingKey)
+			}
+
+			// Parse the token
+			var token *Token
+			var err error
+
+			// Figure out correct claims type
+			token, err = ParseWithClaims(data.tokenString, MapClaims{}, data.keyfunc)
+			// Verify result matches expectation
+			assert.EqualValues(t, data.claims, token.Claims)
+			if data.valid && err != nil {
+				t.Errorf("[%v] Error while verifying token: %T:%v", data.name, err, err)
+			}
+
+			if !data.valid && err == nil {
+				t.Errorf("[%v] Invalid token passed validation", data.name)
+			}
+
+			if (err == nil && !token.Valid()) || (err != nil && token.Valid()) {
+				t.Errorf("[%v] Inconsistent behavior between returned error and token.Valid", data.name)
+			}
+
+			if data.errors != 0 {
+				if err == nil {
+					t.Errorf("[%v] Expecting error.  Didn't get one.", data.name)
+				} else {
+
+					ve := err.(*ValidationError)
+					// compare the bitfield part of the error
+					if e := ve.Errors; e != data.errors {
+						t.Errorf("[%v] Errors don't match expectation.  %v != %v", data.name, e, data.errors)
+					}
+
+					if err.Error() == keyFuncError.Error() && ve.Inner != keyFuncError {
+						t.Errorf("[%v] Inner error does not match expectation.  %v != %v", data.name, ve.Inner, keyFuncError)
+					}
+				}
+			}
+		})
+	}
+}
+
+func makeSampleToken(c MapClaims, m jose.SignatureAlgorithm, key interface{}) string {
+	token := NewWithClaims(m, c)
+	s, e := token.SignedString(key)
+
+	if e != nil {
+		panic(e.Error())
+	}
+
+	return s
+}
+
+func parseRSAPublicKeyFromPEM(key []byte) *rsa.PublicKey {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		panic("not possible to decode")
+	}
+
+	// Parse the key
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKIXPublicKey(block.Bytes); err != nil {
+		if cert, err := x509.ParseCertificate(block.Bytes); err == nil {
+			parsedKey = cert.PublicKey
+		} else {
+			panic(err)
+		}
+	}
+
+	var pkey *rsa.PublicKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PublicKey); !ok {
+		panic("not an *rsa.PublicKey")
+	}
+
+	return pkey
+}
+
+func parseRSAPrivateKeyFromPEM(key []byte) *rsa.PrivateKey {
+	var err error
+
+	// Parse PEM block
+	var block *pem.Block
+	if block, _ = pem.Decode(key); block == nil {
+		panic("unable to decode")
+	}
+
+	var parsedKey interface{}
+	if parsedKey, err = x509.ParsePKCS1PrivateKey(block.Bytes); err != nil {
+		if parsedKey, err = x509.ParsePKCS8PrivateKey(block.Bytes); err != nil {
+			panic(err)
+		}
+	}
+
+	var pkey *rsa.PrivateKey
+	var ok bool
+	if pkey, ok = parsedKey.(*rsa.PrivateKey); !ok {
+		panic("not an rsa private key")
+	}
+
+	return pkey
+}
+
+var (
+	defaultPubKeyPEM = []byte(`
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4f5wg5l2hKsTeNem/V41
+fGnJm6gOdrj8ym3rFkEU/wT8RDtnSgFEZOQpHEgQ7JL38xUfU0Y3g6aYw9QT0hJ7
+mCpz9Er5qLaMXJwZxzHzAahlfA0icqabvJOMvQtzD6uQv6wPEyZtDTWiQi9AXwBp
+HssPnpYGIn20ZZuNlX2BrClciHhCPUIIZOQn/MmqTD31jSyjoQoV7MhhMTATKJx2
+XrHhR+1DcKJzQBSTAGnpYVaqpsARap+nwRipr3nUTuxyGohBTSmjJ2usSeQXHI3b
+ODIRe1AuTyHceAbewn8b462yEWKARdpd9AjQW5SIVPfdsz5B6GlYQ5LdYKtznTuy
+7wIDAQAB
+-----END PUBLIC KEY-----`)
+	defaultPrivateKeyPEM = []byte(`
+-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEA4f5wg5l2hKsTeNem/V41fGnJm6gOdrj8ym3rFkEU/wT8RDtn
+SgFEZOQpHEgQ7JL38xUfU0Y3g6aYw9QT0hJ7mCpz9Er5qLaMXJwZxzHzAahlfA0i
+cqabvJOMvQtzD6uQv6wPEyZtDTWiQi9AXwBpHssPnpYGIn20ZZuNlX2BrClciHhC
+PUIIZOQn/MmqTD31jSyjoQoV7MhhMTATKJx2XrHhR+1DcKJzQBSTAGnpYVaqpsAR
+ap+nwRipr3nUTuxyGohBTSmjJ2usSeQXHI3bODIRe1AuTyHceAbewn8b462yEWKA
+Rdpd9AjQW5SIVPfdsz5B6GlYQ5LdYKtznTuy7wIDAQABAoIBAQCwia1k7+2oZ2d3
+n6agCAbqIE1QXfCmh41ZqJHbOY3oRQG3X1wpcGH4Gk+O+zDVTV2JszdcOt7E5dAy
+MaomETAhRxB7hlIOnEN7WKm+dGNrKRvV0wDU5ReFMRHg31/Lnu8c+5BvGjZX+ky9
+POIhFFYJqwCRlopGSUIxmVj5rSgtzk3iWOQXr+ah1bjEXvlxDOWkHN6YfpV5ThdE
+KdBIPGEVqa63r9n2h+qazKrtiRqJqGnOrHzOECYbRFYhexsNFz7YT02xdfSHn7gM
+IvabDDP/Qp0PjE1jdouiMaFHYnLBbgvlnZW9yuVf/rpXTUq/njxIXMmvmEyyvSDn
+FcFikB8pAoGBAPF77hK4m3/rdGT7X8a/gwvZ2R121aBcdPwEaUhvj/36dx596zvY
+mEOjrWfZhF083/nYWE2kVquj2wjs+otCLfifEEgXcVPTnEOPO9Zg3uNSL0nNQghj
+FuD3iGLTUBCtM66oTe0jLSslHe8gLGEQqyMzHOzYxNqibxcOZIe8Qt0NAoGBAO+U
+I5+XWjWEgDmvyC3TrOSf/KCGjtu0TSv30ipv27bDLMrpvPmD/5lpptTFwcxvVhCs
+2b+chCjlghFSWFbBULBrfci2FtliClOVMYrlNBdUSJhf3aYSG2Doe6Bgt1n2CpNn
+/iu37Y3NfemZBJA7hNl4dYe+f+uzM87cdQ214+jrAoGAXA0XxX8ll2+ToOLJsaNT
+OvNB9h9Uc5qK5X5w+7G7O998BN2PC/MWp8H+2fVqpXgNENpNXttkRm1hk1dych86
+EunfdPuqsX+as44oCyJGFHVBnWpm33eWQw9YqANRI+pCJzP08I5WK3osnPiwshd+
+hR54yjgfYhBFNI7B95PmEQkCgYBzFSz7h1+s34Ycr8SvxsOBWxymG5zaCsUbPsL0
+4aCgLScCHb9J+E86aVbbVFdglYa5Id7DPTL61ixhl7WZjujspeXZGSbmq0Kcnckb
+mDgqkLECiOJW2NHP/j0McAkDLL4tysF8TLDO8gvuvzNC+WQ6drO2ThrypLVZQ+ry
+eBIPmwKBgEZxhqa0gVvHQG/7Od69KWj4eJP28kq13RhKay8JOoN0vPmspXJo1HY3
+CKuHRG+AP579dncdUnOMvfXOtkdM4vk0+hWASBQzM9xzVcztCa+koAugjVaLS9A+
+9uQoqEeVNTckxx0S2bYevRy7hGQmUJTyQm3j1zEUR5jpdbL83Fbq
+-----END RSA PRIVATE KEY-----`)
+)

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -2,6 +2,7 @@ package jwt
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,4 +28,20 @@ func TestParseInvalidReturnsToken(t *testing.T) {
 	require.True(t, errors.As(err, &verr))
 	require.NotZero(t, verr.Errors&ValidationErrorExpired, "%+v", verr)
 	require.NotEmpty(t, ptoken)
+}
+
+func TestUnsignedToken(t *testing.T) {
+	key := UnsafeAllowNoneSignatureType
+	token := NewWithClaims(SigningMethodNone, MapClaims{
+		"aud": "foo",
+		"exp": time.Now().UTC().Add(time.Hour).Unix(),
+		"iat": time.Now().UTC().Unix(),
+		"sub": "nestor",
+	})
+	rawToken, err := token.SignedString(key)
+	require.NoError(t, err)
+	require.NotEmpty(t, rawToken)
+	parts := strings.Split(rawToken, ".")
+	require.Len(t, parts, 3)
+	require.Empty(t, parts[2])
 }

--- a/token/jwt/validation_error.go
+++ b/token/jwt/validation_error.go
@@ -1,0 +1,44 @@
+package jwt
+
+// Validation provides a backwards compatible error definition
+// from `jwt-go` to `go-jose`.
+// The sourcecode was taken from https://github.com/dgrijalva/jwt-go/blob/master/errors.go
+//
+// > The errors that might occur when parsing and validating a token
+const (
+	ValidationErrorMalformed        uint32 = 1 << iota // Token is malformed
+	ValidationErrorUnverifiable                        // Token could not be verified because of signing problems
+	ValidationErrorSignatureInvalid                    // Signature validation failed
+
+	// Standard Claim validation errors
+	ValidationErrorAudience      // AUD validation failed
+	ValidationErrorExpired       // EXP validation failed
+	ValidationErrorIssuedAt      // IAT validation failed
+	ValidationErrorIssuer        // ISS validation failed
+	ValidationErrorNotValidYet   // NBF validation failed
+	ValidationErrorId            // JTI validation failed
+	ValidationErrorClaimsInvalid // Generic claims validation error
+)
+
+// The error from Parse if token is not valid
+type ValidationError struct {
+	Inner  error  // stores the error returned by external dependencies, i.e.: KeyFunc
+	Errors uint32 // bitfield.  see ValidationError... constants
+	text   string // errors that do not have a valid error just have text
+}
+
+// Validation error is an error type
+func (e ValidationError) Error() string {
+	if e.Inner != nil {
+		return e.Inner.Error()
+	} else if e.text != "" {
+		return e.text
+	} else {
+		return "token is invalid"
+	}
+}
+
+// No errors
+func (e *ValidationError) valid() bool {
+	return e.Errors == 0
+}


### PR DESCRIPTION
## Related issue

#514 

## Proposed changes

This pull request migrates from `jwt-go` to `go-jose`. The following are the key considerations for this transition:

- `go-jose` [does not support](https://github.com/square/go-jose/issues/185) `alg:none` therefore tests trying to check this functionality where removed
- `JWTStrategy` interface was kept almost identical to provide an easy migration, except for the following changes:
    * `jwt.Token` struct type from `jwt-go` was replaced by a local and simplified type definition `Token` that covers all `fosite` use cases
    *   `jwt.MapClaims` was replaced by a local copy of that data type
    * `jwt.Claims` interface dependency to `jwt-go` was replaced by the local `MapClaims` struct type and not by another interface because it simplified the adaptation and `fosite` always type casted `jwt.Claims` to `*jwt.MapClaims`. Source code performing this type cast was therefore not needed and removed
- `jwt.ValidationErrors` from `jwt-go` was replaced by a local copy in order to keep backwards compatibility with jwt validation errors
 - `jwt.SigningMethod{Family}` from `jwt-go` has not equivalence to `go-jose` signing methods, therefore it was updated by using concrete signing method names e.g. `jwt.SigningMethodRSA` -> `jose.RS256, jose.RS384, jose.RS512`
- `RS256JWTStrategy` and `ES256JWTStrategy` types were kept to stay backwards compatible, but they are just the same implementation calling under the hood the same helper functions with some minor difference in parameters. This is so because `go-jose` makes no distinction on signing methods, this is hidden from callers and it is inferred based on the private/public key provided.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

As mentioned in the issue, this is a first step in a full migration to `go-jose`. This step aims to remove `jwt-go` but keeping best-effort-backwards-compatible methods and behaviors using underneaths `go-jose`. This way simplifies the transition process. It is known that `go-jose` offer other benefits, but those need to be addressed in further pull requests.