### PR TITLE
fix: revert float64 auth_time claim

### DIFF
--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -110,7 +110,7 @@ func (c *IDTokenClaims) ToMap() map[string]interface{} {
 	}
 
 	if !c.AuthTime.IsZero() {
-		ret["auth_time"] = float64(c.AuthTime.Unix()) // jwt-go does not support int64 as datatype
+		ret["auth_time"] = c.AuthTime.Unix()
 	} else {
 		delete(ret, "auth_time")
 	}

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -70,7 +70,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		"baz":       idTokenClaims.Extra["baz"],
 		"at_hash":   idTokenClaims.AccessTokenHash,
 		"c_hash":    idTokenClaims.CodeHash,
-		"auth_time": float64(idTokenClaims.AuthTime.Unix()),
+		"auth_time": idTokenClaims.AuthTime.Unix(),
 		"acr":       idTokenClaims.AuthenticationContextClassReference,
 		"amr":       idTokenClaims.AuthenticationMethodsReference,
 	}, idTokenClaims.ToMap())
@@ -88,7 +88,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		"baz":       idTokenClaims.Extra["baz"],
 		"at_hash":   idTokenClaims.AccessTokenHash,
 		"c_hash":    idTokenClaims.CodeHash,
-		"auth_time": float64(idTokenClaims.AuthTime.Unix()),
+		"auth_time": idTokenClaims.AuthTime.Unix(),
 		"acr":       idTokenClaims.AuthenticationContextClassReference,
 		"amr":       idTokenClaims.AuthenticationMethodsReference,
 		"nonce":     idTokenClaims.Nonce,


### PR DESCRIPTION
## Related issue
#598 

## Proposed changes
Revert `auth_time` claim data type to `int64` in `id_token`. 
It was changed to `float64` in PR #595

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

In another PR timestamp claims for access tokens and id tokens can be transformed to `int64`. 
This is no longer a limitation since `fosite` now uses `go-jose`