### PR TITLE
chore: update repository template to b66d1cbe

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -198,7 +198,7 @@ request, go through this checklist:
 1. Ensure that each commit has a descriptive prefix. This ensures a uniform
    commit history and helps structure the changelog.  
    Please refer to this
-   [list of prefixes for Fosite](https://github.com/ory/ory/fosite/blob/master/.github/semantic.yml).
+   [list of prefixes for Fosite](https://github.com/ory/fosite/blob/master/.github/semantic.yml).
 
 Pull requests will be treated as "review requests," and maintainers will give
 feedback on the style and substance of the patch.


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/b66d1cbe843bbf0e72e40d066190c0fe5451e2b5.