### PR TITLE
feat: Add rotation support for client secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ import "github.com/ory/fosite/compose"
 import "github.com/ory/fosite/storage"
 
 // This is the example storage that contains:
-// * an OAuth2 Client with id "my-client" and secret "foobar" capable of all oauth2 and open id connect grant and response types.
+// * an OAuth2 Client with id "my-client" and secrets "foobar" and "foobaz" capable of all oauth2 and open id connect grant and response types.
 // * a User for the resource owner password credentials grant type with username "peter" and password "secret".
 //
 // You will most likely replace this with your own logic once you set up a real world application.

--- a/client.go
+++ b/client.go
@@ -52,6 +52,13 @@ type Client interface {
 	GetAudience() Arguments
 }
 
+// ClientWithSecretRotation extends Client interface by a method providing a slice of rotated secrets.
+type ClientWithSecretRotation interface {
+	Client
+	// GetRotatedHashes returns a slice of hashed secrets used for secrets rotation.
+	GetRotatedHashes() [][]byte
+}
+
 // OpenIDConnectClient represents a client capable of performing OpenID Connect requests.
 type OpenIDConnectClient interface {
 	// GetRequestURIs is an array of request_uri values that are pre-registered by the RP for use at the OP. Servers MAY
@@ -88,14 +95,15 @@ type ResponseModeClient interface {
 
 // DefaultClient is a simple default implementation of the Client interface.
 type DefaultClient struct {
-	ID            string   `json:"id"`
-	Secret        []byte   `json:"client_secret,omitempty"`
-	RedirectURIs  []string `json:"redirect_uris"`
-	GrantTypes    []string `json:"grant_types"`
-	ResponseTypes []string `json:"response_types"`
-	Scopes        []string `json:"scopes"`
-	Audience      []string `json:"audience"`
-	Public        bool     `json:"public"`
+	ID             string   `json:"id"`
+	Secret         []byte   `json:"client_secret,omitempty"`
+	RotatedSecrets [][]byte `json:"rotated_secrets,omitempty"`
+	RedirectURIs   []string `json:"redirect_uris"`
+	GrantTypes     []string `json:"grant_types"`
+	ResponseTypes  []string `json:"response_types"`
+	Scopes         []string `json:"scopes"`
+	Audience       []string `json:"audience"`
+	Public         bool     `json:"public"`
 }
 
 type DefaultOpenIDConnectClient struct {
@@ -131,6 +139,10 @@ func (c *DefaultClient) GetRedirectURIs() []string {
 
 func (c *DefaultClient) GetHashedSecret() []byte {
 	return c.Secret
+}
+
+func (c *DefaultClient) GetRotatedHashes() [][]byte {
+	return c.RotatedSecrets
 }
 
 func (c *DefaultClient) GetScopes() Arguments {

--- a/client_test.go
+++ b/client_test.go
@@ -29,17 +29,19 @@ import (
 
 func TestDefaultClient(t *testing.T) {
 	sc := &DefaultClient{
-		ID:            "1",
-		Secret:        []byte("foobar-"),
-		RedirectURIs:  []string{"foo", "bar"},
-		ResponseTypes: []string{"foo", "bar"},
-		GrantTypes:    []string{"foo", "bar"},
-		Scopes:        []string{"fooscope"},
+		ID:             "1",
+		Secret:         []byte("foobar-"),
+		RotatedSecrets: [][]byte{[]byte("foobar-1"), []byte("foobar-2")},
+		RedirectURIs:   []string{"foo", "bar"},
+		ResponseTypes:  []string{"foo", "bar"},
+		GrantTypes:     []string{"foo", "bar"},
+		Scopes:         []string{"fooscope"},
 	}
 
 	assert.Equal(t, sc.ID, sc.GetID())
 	assert.Equal(t, sc.RedirectURIs, sc.GetRedirectURIs())
 	assert.Equal(t, sc.Secret, sc.GetHashedSecret())
+	assert.Equal(t, sc.RotatedSecrets, sc.GetRotatedHashes())
 	assert.EqualValues(t, sc.ResponseTypes, sc.GetResponseTypes())
 	assert.EqualValues(t, sc.GrantTypes, sc.GetGrantTypes())
 	assert.EqualValues(t, sc.Scopes, sc.GetScopes())
@@ -48,6 +50,8 @@ func TestDefaultClient(t *testing.T) {
 	sc.ResponseTypes = []string{}
 	assert.Equal(t, "code", sc.GetResponseTypes()[0])
 	assert.Equal(t, "authorization_code", sc.GetGrantTypes()[0])
+
+	var _ ClientWithSecretRotation = sc
 }
 
 func TestDefaultResponseModeClient_GetResponseMode(t *testing.T) {

--- a/internal/client.go
+++ b/internal/client.go
@@ -77,6 +77,20 @@ func (mr *MockClientMockRecorder) GetHashedSecret() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHashedSecret", reflect.TypeOf((*MockClient)(nil).GetHashedSecret))
 }
 
+// GetHashedSecret mocks base method
+func (m *MockClient) GetRotatedHashes() [][]byte {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRotatedHashes")
+	ret0, _ := ret[0].([][]byte)
+	return ret0
+}
+
+// GetHashedSecret indicates an expected call of GetHashedSecret
+func (mr *MockClientMockRecorder) GetRotatedHashes() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRotatedHashes", reflect.TypeOf((*MockClient)(nil).GetRotatedHashes))
+}
+
 // GetID mocks base method
 func (m *MockClient) GetID() string {
 	m.ctrl.T.Helper()

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -155,7 +155,7 @@ func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, s
 		}
 
 		// Enforce client authentication
-		if err := f.Hasher.Compare(ctx, client.GetHashedSecret(), []byte(clientSecret)); err != nil {
+		if err := f.checkClientSecret(ctx, client, []byte(clientSecret)); err != nil {
 			return &IntrospectionResponse{Active: false}, errorsx.WithStack(ErrRequestUnauthorized.WithHint("OAuth 2.0 Client credentials are invalid."))
 		}
 	}

--- a/introspection_request_handler_test.go
+++ b/introspection_request_handler_test.go
@@ -203,6 +203,24 @@ func TestNewIntrospectionRequest(t *testing.T) {
 			},
 			isActive: true,
 		},
+		{
+			description: "should pass with basic auth if username and password not encoded",
+			setup: func() {
+				f.TokenIntrospectionHandlers = TokenIntrospectionHandlers{validator}
+				httpreq = &http.Request{
+					Method: "POST",
+					Header: http.Header{
+						//Basic Authorization with username=my-client and password=foobaz
+						"Authorization": []string{"Basic bXktY2xpZW50OmZvb2Jheg=="},
+					},
+					PostForm: url.Values{
+						"token": []string{"introspect-token"},
+					},
+				}
+				validator.EXPECT().IntrospectToken(ctx, "introspect-token", gomock.Any(), gomock.Any(), gomock.Any()).Return(TokenUse(""), nil)
+			},
+			isActive: true,
+		},
 	} {
 		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
 			c.setup()

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -110,20 +110,22 @@ func NewExampleStore() *MemoryStore {
 		IDSessions: make(map[string]fosite.Requester),
 		Clients: map[string]fosite.Client{
 			"my-client": &fosite.DefaultClient{
-				ID:            "my-client",
-				Secret:        []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`), // = "foobar"
-				RedirectURIs:  []string{"http://localhost:3846/callback"},
-				ResponseTypes: []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
-				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
-				Scopes:        []string{"fosite", "openid", "photos", "offline"},
+				ID:             "my-client",
+				Secret:         []byte(`$2a$10$IxMdI6d.LIRZPpSfEwNoeu4rY3FhDREsxFJXikcgdRRAStxUlsuEO`),            // = "foobar"
+				RotatedSecrets: [][]byte{[]byte(`$2y$10$X51gLxUQJ.hGw1epgHTE5u0bt64xM0COU7K9iAp.OFg8p2pUd.1zC `)}, // = "foobaz",
+				RedirectURIs:   []string{"http://localhost:3846/callback"},
+				ResponseTypes:  []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
+				GrantTypes:     []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+				Scopes:         []string{"fosite", "openid", "photos", "offline"},
 			},
 			"encoded:client": &fosite.DefaultClient{
-				ID:            "encoded:client",
-				Secret:        []byte(`$2a$10$A7M8b65dSSKGHF0H2sNkn.9Z0hT8U1Nv6OWPV3teUUaczXkVkxuDS`), // = "encoded&password"
-				RedirectURIs:  []string{"http://localhost:3846/callback"},
-				ResponseTypes: []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
-				GrantTypes:    []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
-				Scopes:        []string{"fosite", "openid", "photos", "offline"},
+				ID:             "encoded:client",
+				Secret:         []byte(`$2a$10$A7M8b65dSSKGHF0H2sNkn.9Z0hT8U1Nv6OWPV3teUUaczXkVkxuDS`), // = "encoded&password"
+				RotatedSecrets: nil,
+				RedirectURIs:   []string{"http://localhost:3846/callback"},
+				ResponseTypes:  []string{"id_token", "code", "token", "id_token token", "code id_token", "code token", "code id_token token"},
+				GrantTypes:     []string{"implicit", "refresh_token", "authorization_code", "password", "client_credentials"},
+				Scopes:         []string{"fosite", "openid", "photos", "offline"},
 			},
 		},
 		Users: map[string]MemoryUserRelation{


### PR DESCRIPTION
## Related issue
Issue: #590
Discussed with: @aeneasr

## Proposed changes
The aim of this PR is to introduce support for rotation of client's secrets.
New interface is created that extends `fosite.Client` so as not to break compatibility of custom clients. The `fosite.DefaultClient` implements this interface by introducing `RotatedSecrets` field. When not set (nil), the functionality stays the same as before.

## Checklist
- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments
Detail of how the change above is utilized in the fosite code:
1. check regular (main, current) secret by using `GetHashedSecret` method
2. if 1. fails, try to see if provided client implements `fosite.ClientWithSecretRotation`
3. if 2. succeeds, call `GetRotatedHashes` and loop over provided hashes to compare the secret 

Some questions I have:
- I'm not sure if the addition of this feature is documented enough, or if there is some other place I could add it to?
- By having the `checkClientSecret` method be private, I'm unable to test it directly, so only a few basic scenarios were added testing it via the methods that use it. Should I opt for public method just in order to test it better? Any other preference?