### PR TITLE
Fix: Only check verifier isn't empty when determining whether to do PKCE auth and ignore challenge

### DIFF
--- a/handler/pkce/handler.go
+++ b/handler/pkce/handler.go
@@ -158,8 +158,8 @@ func (c *Handler) HandleTokenEndpointRequest(ctx context.Context, request fosite
 	if err := c.validate(challenge, method, client); err != nil {
 		return err
 	}
-
-	if !c.Force && challenge == "" && verifier == "" {
+	
+	if !c.Force && verifier == "" {
 		return nil
 	}
 


### PR DESCRIPTION
I was attempting to use oryd/hydra with a [Matrix Synapse](https://github.com/matrix-org/synapse) as well as [Grafana](https://github.com/grafana/grafana).

These projects implement server-side auth, but do not follow [this recommendation](https://github.com/ory/hydra/issues/1512#issuecomment-520413192):

>Note: although PKCE so far was recommended as a mechanism to protect
native apps, this advice applies to all kinds of OAuth clients,
including web applications.

However, they do include a "challenge" parameter, which appears to be included to try to maximize compatibility with generic OAuth.

This would cause the code below this logic to attempt PKCE verification, even though PKCE is not enforced or expected to be by the client.

Figured out that Synapse uses [`authlib`](https://github.com/lepture/authlib) underneath, which means it probably represents quite a few apps.

This change makes this logic only consider `verifier`, and ignores `challenge` in order to address this.



## Related issue(s)

I think this discussion may have actually been related to this -> https://github.com/ory/hydra/discussions/2671



## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
