### PR TITLE
chore: update repository template to e424c0a0

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,13 +13,21 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: |
-            Thank you for opening this issue. It appears that the request for more information (e.g. providing the software version, providing logs, ...) has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the issue has been resolved.
-          stale-pr-message: |
-            Thank you for opening this pull request. It appears that a request for e.g. information has not yet been completed. Therefore this issue will be automatically
-            closed in 7 days, assuming that the proposed change is no longer required or has otherwise been resolved.
+            I am marking this issue as stale as it has not received any engagement from the community or maintainers in over half a year. That does not imply that the issue has no merit! If you feel strongly about this issue
+
+            - open a PR referencing and resolving the issue;
+            - leave a comment on it and discuss ideas how you could contribute towards resolving it;
+            - open a new issue with updated details and a plan on resolving the issue.
+
+            We are cleaning up issues every now and then, primarily to keep the 4000+ issues in our backlog in check and to [prevent](https://www.jeffgeerling.com/blog/2020/saying-no-burnout-open-source-maintainer) [maintainer](https://www.jeffgeerling.com/blog/2016/why-i-close-prs-oss-project-maintainer-notes) [burnout](https://docs.brew.sh/Maintainers-Avoiding-Burnout). Burnout in open source maintainership is a [widespread](https://opensource.guide/best-practices/#its-okay-to-hit-pause) and serious issue. It can lead to severe personal and health issues as well as [enabling catastrophic](https://haacked.com/archive/2019/05/28/maintainer-burnout/) [attack vectors](https://www.gradiant.org/en/blog/open-source-maintainer-burnout-as-an-attack-surface/).
+
+            Thank you for your understanding and to anyone who participated in the issue! 🙏✌️
+
+            If you feel strongly about this issues and have ideas on resolving it, please comment. Otherwise it will be closed in 30 days!
           stale-issue-label: 'stale'
-          stale-pr-label: 'stale'
-          only-labels: 'needs more info'
-          days-before-stale: 7
-          days-before-close: 7
+          exempt-issue-labels: 'bug,blocking,docs'
+          days-before-stale: 180
+          days-before-close: 30
+          exempt-milestones: true
+          exempt-assignees: true
+          only-pr-labels: 'stale'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@ of this document is to provide a high-level overview of how you can get
 involved.
 
 _Please note_: We take Ory Fosite's security and our users' trust very
-seriously. If you believe you have found a security issue in Ory Fosite, please
-responsibly disclose by contacting us at security@ory.sh.
+seriously. If you believe you have found a security issue in Ory Fosite,
+please responsibly disclose by contacting us at security@ory.sh.
 
 First: As a potential contributor, your changes and ideas are welcome at any
 hour of the day or night, weekdays, weekends, and holidays. Please do not ever
@@ -47,9 +47,11 @@ contributions, and don't want a wall of rules to get in the way of that.
 
 That said, if you want to ensure that a pull request is likely to be merged,
 talk to us! You can find out our thoughts and ensure that your contribution
-won't clash or be obviated by Ory Fosite's normal direction. A great way to do
-this is via [Ory Fosite Discussions](https://github.com/ory/meta/discussions) or
-the [Ory Chat](https://www.ory.sh/chat).
+won't clash or be obviated by Ory
+Fosite's normal direction. A great way to
+do this is via
+[Ory Fosite Discussions](https://github.com/ory/meta/discussions)
+or the [Ory Chat](https://www.ory.sh/chat).
 
 ## FAQ
 
@@ -66,7 +68,8 @@ the [Ory Chat](https://www.ory.sh/chat).
 - I want to talk to other Ory Fosite users.
   [How can I become a part of the community?](#communication)
 
-- I would like to know what I am agreeing to when I contribute to Ory Fosite.
+- I would like to know what I am agreeing to when I contribute to Ory
+  Fosite.
   Does Ory have
   [a Contributors License Agreement?](https://cla-assistant.io/ory/fosite)
 
@@ -90,8 +93,8 @@ a few things you can do to help out:
   look at discussions in the forum and take part in our weekly hangout. More
   info on this in [Communication](#communication).
 
-- **Helping with open issues.** We have a lot of open issues for Ory Fosite and
-  some of them may lack necessary information, some are duplicates of older
+- **Helping with open issues.** We have a lot of open issues for Ory Fosite
+  and some of them may lack necessary information, some are duplicates of older
   issues. You can help out by guiding people through the process of filling out
   the issue template, asking for clarifying information, or pointing them to
   existing issues that match their description of the problem.
@@ -109,9 +112,8 @@ a few things you can do to help out:
 We use [Slack](https://www.ory.sh/chat). You are welcome to drop in and ask
 questions, discuss bugs and feature requests, talk to other users of Ory, etc.
 
-Check out [Ory Fosite Discussions](https://github.com/ory/meta/discussions).
-This is a great place for in-depth discussions and lots of code examples, logs
-and similar data.
+Check out [Ory Fosite Discussions](https://github.com/ory/meta/discussions). This is a great place for
+in-depth discussions and lots of code examples, logs and similar data.
 
 You can also join our community hangout, if you want to speak to the Ory team
 directly or ask some questions. You can find more info on the hangouts in


### PR DESCRIPTION
Updated repository templates to https://github.com/ory/meta/commit/e424c0a0a2dd85c585c0be32e8ada257c3fe8021.