### PR TITLE
fix: Make `amr` claim an array to match the OIDC spec

### DIFF
--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -40,7 +40,7 @@ type IDTokenClaims struct {
 	AuthTime                            time.Time
 	AccessTokenHash                     string
 	AuthenticationContextClassReference string
-	AuthenticationMethodsReference      []string
+	AuthenticationMethodsReferences     []string
 	CodeHash                            string
 	Extra                               map[string]interface{}
 }
@@ -121,8 +121,8 @@ func (c *IDTokenClaims) ToMap() map[string]interface{} {
 		delete(ret, "acr")
 	}
 
-	if len(c.AuthenticationMethodsReference) > 0 {
-		ret["amr"] = c.AuthenticationMethodsReference
+	if len(c.AuthenticationMethodsReferences) > 0 {
+		ret["amr"] = c.AuthenticationMethodsReferences
 	} else {
 		delete(ret, "amr")
 	}

--- a/token/jwt/claims_id_token.go
+++ b/token/jwt/claims_id_token.go
@@ -40,7 +40,7 @@ type IDTokenClaims struct {
 	AuthTime                            time.Time
 	AccessTokenHash                     string
 	AuthenticationContextClassReference string
-	AuthenticationMethodsReference      string
+	AuthenticationMethodsReference      []string
 	CodeHash                            string
 	Extra                               map[string]interface{}
 }

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -52,7 +52,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		AccessTokenHash:                     "foobar",
 		CodeHash:                            "barfoo",
 		AuthenticationContextClassReference: "acr",
-		AuthenticationMethodsReference:      []string{"amr"},
+		AuthenticationMethodsReferences:     []string{"amr"},
 		Extra: map[string]interface{}{
 			"foo": "bar",
 			"baz": "bar",
@@ -72,7 +72,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		"c_hash":    idTokenClaims.CodeHash,
 		"auth_time": idTokenClaims.AuthTime.Unix(),
 		"acr":       idTokenClaims.AuthenticationContextClassReference,
-		"amr":       idTokenClaims.AuthenticationMethodsReference,
+		"amr":       idTokenClaims.AuthenticationMethodsReferences,
 	}, idTokenClaims.ToMap())
 
 	idTokenClaims.Nonce = "foobar"
@@ -90,7 +90,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		"c_hash":    idTokenClaims.CodeHash,
 		"auth_time": idTokenClaims.AuthTime.Unix(),
 		"acr":       idTokenClaims.AuthenticationContextClassReference,
-		"amr":       idTokenClaims.AuthenticationMethodsReference,
+		"amr":       idTokenClaims.AuthenticationMethodsReferences,
 		"nonce":     idTokenClaims.Nonce,
 	}, idTokenClaims.ToMap())
 }

--- a/token/jwt/claims_id_token_test.go
+++ b/token/jwt/claims_id_token_test.go
@@ -52,7 +52,7 @@ func TestIDTokenClaimsToMap(t *testing.T) {
 		AccessTokenHash:                     "foobar",
 		CodeHash:                            "barfoo",
 		AuthenticationContextClassReference: "acr",
-		AuthenticationMethodsReference:      "amr",
+		AuthenticationMethodsReference:      []string{"amr"},
 		Extra: map[string]interface{}{
 			"foo": "bar",
 			"baz": "bar",


### PR DESCRIPTION
This change makes `amr` claim follow the spec and be of an array type.

See: https://openid.net/specs/openid-connect-core-1_0.html#IDToken

My team noticed that when trying to use `amr` claim with Hydra. 

Will follow up with Hydra PR to add support for `amr` claim as it is being dropped right now if used. Related issue: https://github.com/ory/hydra/issues/1756

Previous change: https://github.com/ory/fosite/pull/401

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

This is breaking change, migration path is to wrap single values into the `[]string` slice and use a different field.
