### PR TITLE
feat: [#628] PAR implementation

### DIFF
--- a/authorize_request.go
+++ b/authorize_request.go
@@ -114,3 +114,11 @@ func (d *AuthorizeRequest) SetDefaultResponseMode(defaultResponseMode ResponseMo
 func (d *AuthorizeRequest) GetDefaultResponseMode() ResponseModeType {
 	return d.DefaultResponseMode
 }
+
+func (d *AuthorizeRequest) MergeAuthorizeRequester(request AuthorizeRequester) {
+	d.Request.Merge(request)
+	d.RedirectURI = request.GetRedirectURI()
+	d.ResponseTypes = request.GetResponseTypes()
+	d.State = request.GetState()
+	d.ResponseMode = request.GetResponseMode()
+}

--- a/authorize_request.go
+++ b/authorize_request.go
@@ -115,10 +115,12 @@ func (d *AuthorizeRequest) GetDefaultResponseMode() ResponseModeType {
 	return d.DefaultResponseMode
 }
 
-func (d *AuthorizeRequest) MergeAuthorizeRequester(request AuthorizeRequester) {
+func (d *AuthorizeRequest) Merge(request Requester) {
 	d.Request.Merge(request)
-	d.RedirectURI = request.GetRedirectURI()
-	d.ResponseTypes = request.GetResponseTypes()
-	d.State = request.GetState()
-	d.ResponseMode = request.GetResponseMode()
+	if r, ok := request.(AuthorizeRequester); ok {
+		d.RedirectURI = r.GetRedirectURI()
+		d.ResponseTypes = r.GetResponseTypes()
+		d.State = r.GetState()
+		d.ResponseMode = r.GetResponseMode()
+	}
 }

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -58,21 +58,23 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 	}
 
 	f := &fosite.Fosite{
-		Store:                        storage.(fosite.Storage),
-		AuthorizeEndpointHandlers:    fosite.AuthorizeEndpointHandlers{},
-		TokenEndpointHandlers:        fosite.TokenEndpointHandlers{},
-		TokenIntrospectionHandlers:   fosite.TokenIntrospectionHandlers{},
-		RevocationHandlers:           fosite.RevocationHandlers{},
-		Hasher:                       hasher,
-		ScopeStrategy:                config.GetScopeStrategy(),
-		AudienceMatchingStrategy:     config.GetAudienceStrategy(),
-		SendDebugMessagesToClients:   config.SendDebugMessagesToClients,
-		TokenURL:                     config.TokenURL,
-		JWKSFetcherStrategy:          config.GetJWKSFetcherStrategy(),
-		MinParameterEntropy:          config.GetMinParameterEntropy(),
-		UseLegacyErrorFormat:         config.UseLegacyErrorFormat,
-		ClientAuthenticationStrategy: config.GetClientAuthenticationStrategy(),
-		ResponseModeHandlerExtension: config.ResponseModeHandlerExtension,
+		Store:                               storage.(fosite.Storage),
+		AuthorizeEndpointHandlers:           fosite.AuthorizeEndpointHandlers{},
+		TokenEndpointHandlers:               fosite.TokenEndpointHandlers{},
+		TokenIntrospectionHandlers:          fosite.TokenIntrospectionHandlers{},
+		RevocationHandlers:                  fosite.RevocationHandlers{},
+		Hasher:                              hasher,
+		ScopeStrategy:                       config.GetScopeStrategy(),
+		AudienceMatchingStrategy:            config.GetAudienceStrategy(),
+		SendDebugMessagesToClients:          config.SendDebugMessagesToClients,
+		TokenURL:                            config.TokenURL,
+		JWKSFetcherStrategy:                 config.GetJWKSFetcherStrategy(),
+		MinParameterEntropy:                 config.GetMinParameterEntropy(),
+		UseLegacyErrorFormat:                config.UseLegacyErrorFormat,
+		ClientAuthenticationStrategy:        config.GetClientAuthenticationStrategy(),
+		ResponseModeHandlerExtension:        config.ResponseModeHandlerExtension,
+		PushedAuthorizationRequestURIPrefix: config.PushedAuthorizationRequestURIPrefix,
+		PushedAuthorizationContextLifespan:  config.PushedAuthorizationContextLifespan,
 	}
 
 	for _, factory := range factories {
@@ -88,6 +90,9 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 		}
 		if rh, ok := res.(fosite.RevocationHandler); ok {
 			f.RevocationHandlers.Append(rh)
+		}
+		if ph, ok := res.(fosite.PushedAuthorizeEndpointHandler); ok {
+			f.PushedAuthorizeEndpointHandlers.Append(ph)
 		}
 	}
 

--- a/compose/compose_par.go
+++ b/compose/compose_par.go
@@ -1,0 +1,24 @@
+package compose
+
+import (
+	"github.com/ory/fosite/handler/par"
+)
+
+func PARStorageFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
+	return &par.PushedAuthorizeHandler{
+		Storage:                  storage.(par.PARStorage),
+		RequestURIPrefix:         config.PushedAuthorizationRequestURIPrefix,
+		PARContextLifetime:       config.PushedAuthorizationContextLifespan,
+		ScopeStrategy:            config.GetScopeStrategy(),
+		AudienceMatchingStrategy: config.GetAudienceStrategy(),
+		IsRedirectURISecure:      config.GetRedirectSecureChecker(),
+	}
+}
+
+// AuthorizePARFactory creates an OAuth2 token revocation handler.
+func AuthorizePARFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
+	return &par.AuthorizePARHandler{
+		Storage:          storage.(par.PARStorage),
+		RequestURIPrefix: config.PushedAuthorizationRequestURIPrefix,
+	}
+}

--- a/compose/config.go
+++ b/compose/config.go
@@ -117,6 +117,13 @@ type Config struct {
 
 	// ResponseModeHandlerExtension provides a handler for custom response modes
 	ResponseModeHandlerExtension fosite.ResponseModeHandler
+
+	// PushedAuthorizationRequestURIPrefix is the URI prefix for the PAR request_uri.
+	// This is defaulted to 'urn:ietf:params:oauth:request_uri:'.
+	PushedAuthorizationRequestURIPrefix string
+
+	// PushedAuthorizationContextLifespan is the lifespan of the PAR context
+	PushedAuthorizationContextLifespan time.Duration
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.

--- a/context.go
+++ b/context.go
@@ -30,9 +30,11 @@ func NewContext() context.Context {
 type ContextKey string
 
 const (
-	RequestContextKey           = ContextKey("request")
-	AccessRequestContextKey     = ContextKey("accessRequest")
-	AccessResponseContextKey    = ContextKey("accessResponse")
-	AuthorizeRequestContextKey  = ContextKey("authorizeRequest")
-	AuthorizeResponseContextKey = ContextKey("authorizeResponse")
+	RequestContextKey                 = ContextKey("request")
+	AccessRequestContextKey           = ContextKey("accessRequest")
+	AccessResponseContextKey          = ContextKey("accessResponse")
+	AuthorizeRequestContextKey        = ContextKey("authorizeRequest")
+	AuthorizeResponseContextKey       = ContextKey("authorizeResponse")
+	PushedAuthorizeResponseContextKey = ContextKey("pushedAuthorizeResponse")
+	ClientContextKey                  = ContextKey("client")
 )

--- a/handler.go
+++ b/handler.go
@@ -76,3 +76,12 @@ type RevocationHandler interface {
 	// RevokeToken handles access and refresh token revocation.
 	RevokeToken(ctx context.Context, token string, tokenType TokenType, client Client) error
 }
+
+// PushedAuthorizeEndpointHandler is the interface that handles PAR (https://datatracker.ietf.org/doc/html/rfc9126)
+type PushedAuthorizeEndpointHandler interface {
+	// HandlePushedAuthorizeRequest handles a pushed authorize endpoint request. To extend the handler's capabilities, the http request
+	// is passed along, if further information retrieval is required. If the handler feels that he is not responsible for
+	// the pushed authorize request, he must return nil and NOT modify session nor responder neither requester.
+	//
+	HandlePushedAuthorizeEndpointRequest(ctx context.Context, requester AuthorizeRequester, responder PushedAuthorizeResponder) error
+}

--- a/handler/par/flow_authorize_par.go
+++ b/handler/par/flow_authorize_par.go
@@ -26,7 +26,10 @@ func (c *AuthorizePARHandler) HandleAuthorizeEndpointRequest(ctx context.Context
 		return errorsx.WithStack(fosite.ErrInvalidRequestURI.WithHint("Invalid PAR session").WithWrap(err).WithDebug(err.Error()))
 	}
 
-	c.Storage.DeletePARSession(ctx, requestURI)
+	err = c.Storage.DeletePARSession(ctx, requestURI)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
+	}
 
 	// validate the clients match
 	if ar.GetRequestForm().Get("client_id") != ar.GetClient().GetID() {

--- a/handler/par/flow_authorize_par.go
+++ b/handler/par/flow_authorize_par.go
@@ -1,0 +1,37 @@
+package par
+
+import (
+	"context"
+	"strings"
+
+	"github.com/ory/fosite"
+	"github.com/ory/x/errorsx"
+)
+
+type AuthorizePARHandler struct {
+	Storage          PARStorage
+	RequestURIPrefix string
+}
+
+func (c *AuthorizePARHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, _ fosite.AuthorizeResponder) error {
+	requestURI := ar.GetRequestForm().Get("request_uri")
+	if requestURI == "" || !strings.HasPrefix(requestURI, c.RequestURIPrefix) {
+		// nothing to do here
+		return nil
+	}
+
+	// hydrate the requester
+	err := c.Storage.GetPARSession(ctx, requestURI, ar)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrInvalidRequestURI.WithHint("Invalid PAR session").WithWrap(err).WithDebug(err.Error()))
+	}
+
+	c.Storage.DeletePARSession(ctx, requestURI)
+
+	// validate the clients match
+	if ar.GetRequestForm().Get("client_id") != ar.GetClient().GetID() {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("'client_id' must match the pushed authorization request"))
+	}
+
+	return nil
+}

--- a/handler/par/flow_authorize_par.go
+++ b/handler/par/flow_authorize_par.go
@@ -8,11 +8,13 @@ import (
 	"github.com/ory/x/errorsx"
 )
 
+// AuthorizePARHandler implements the handler that consumes the PAR request_uri
 type AuthorizePARHandler struct {
 	Storage          PARStorage
 	RequestURIPrefix string
 }
 
+// HandleAuthorizeEndpointRequest handles the authorize endpoint request for PAR
 func (c *AuthorizePARHandler) HandleAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, _ fosite.AuthorizeResponder) error {
 	requestURI := ar.GetRequestForm().Get("request_uri")
 	if requestURI == "" || !strings.HasPrefix(requestURI, c.RequestURIPrefix) {
@@ -21,13 +23,11 @@ func (c *AuthorizePARHandler) HandleAuthorizeEndpointRequest(ctx context.Context
 	}
 
 	// hydrate the requester
-	err := c.Storage.GetPARSession(ctx, requestURI, ar)
-	if err != nil {
+	if err := c.Storage.GetPARSession(ctx, requestURI, ar); err != nil {
 		return errorsx.WithStack(fosite.ErrInvalidRequestURI.WithHint("Invalid PAR session").WithWrap(err).WithDebug(err.Error()))
 	}
 
-	err = c.Storage.DeletePARSession(ctx, requestURI)
-	if err != nil {
+	if err := c.Storage.DeletePARSession(ctx, requestURI); err != nil {
 		return errorsx.WithStack(fosite.ErrServerError.WithWrap(err).WithDebug(err.Error()))
 	}
 

--- a/handler/par/flow_authorize_par_test.go
+++ b/handler/par/flow_authorize_par_test.go
@@ -76,7 +76,7 @@ func TestAuthorizeCode_PushAuthorizeRequest(t *testing.T) {
 								RequestedAt: time.Now().UTC(),
 							},
 							State:       "superstate",
-							RedirectURI: parseUrl("https://asdf.de/cb"),
+							RedirectURI: parseURL("https://asdf.de/cb"),
 						}
 
 						err := handler.Storage.CreatePARSession(context.Background(), requestURI, r)

--- a/handler/par/flow_authorize_par_test.go
+++ b/handler/par/flow_authorize_par_test.go
@@ -1,0 +1,112 @@
+package par
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+	"testing" //"time"
+
+	"github.com/ory/fosite/handler/oauth2"
+	"github.com/ory/fosite/token/hmac"
+
+	//"github.com/golang/mock/gomock"
+	"time"
+
+	"github.com/ory/fosite" //"github.com/ory/fosite/internal"
+	"github.com/ory/fosite/storage"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var hmacshaStrategy = oauth2.HMACSHAStrategy{
+	Enigma:                &hmac.HMACStrategy{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")},
+	AccessTokenLifespan:   time.Hour * 24,
+	AuthorizeCodeLifespan: time.Hour * 24,
+}
+
+func TestAuthorizeCode_PushAuthorizeRequest(t *testing.T) {
+	requestURIPrefix := "urn:ietf:params:oauth:request_uri_diff:"
+	requestURI := fmt.Sprintf("%s%s", requestURIPrefix, "abcdefgh")
+	for k, _ := range map[string]oauth2.CoreStrategy{
+		"hmac": &hmacshaStrategy,
+	} {
+		t.Run("strategy="+k, func(t *testing.T) {
+			store := storage.NewMemoryStore()
+
+			handler := AuthorizePARHandler{
+				Storage:          store,
+				RequestURIPrefix: requestURIPrefix,
+			}
+
+			for _, c := range []struct {
+				handler     AuthorizePARHandler
+				areq        *fosite.AuthorizeRequest
+				description string
+				setup       func(t *testing.T)
+				expectErr   error
+				expect      func(t *testing.T, areq *fosite.AuthorizeRequest, aresp *fosite.AuthorizeResponse)
+			}{
+				{
+					handler: handler,
+					areq: &fosite.AuthorizeRequest{
+						Request: fosite.Request{
+							Form: url.Values{
+								"request_uri": []string{requestURI},
+							},
+							Session:     &fosite.DefaultSession{},
+							RequestedAt: time.Now().UTC(),
+						},
+					},
+					description: "should succeed",
+					setup: func(t *testing.T) {
+						r := &fosite.AuthorizeRequest{
+							ResponseTypes: fosite.Arguments{"code"},
+							Request: fosite.Request{
+								Client: &fosite.DefaultClient{
+									ResponseTypes: fosite.Arguments{"code"},
+									RedirectURIs:  []string{"https://asdf.de/cb"},
+									Audience:      []string{"https://www.ory.sh/api"},
+								},
+								RequestedAudience: []string{"https://www.ory.sh/api"},
+								RequestedScope:    fosite.Arguments{"a", "b"},
+								Session: &fosite.DefaultSession{
+									ExpiresAt: map[fosite.TokenType]time.Time{fosite.AccessToken: time.Now().UTC().Add(time.Hour)},
+								},
+								RequestedAt: time.Now().UTC(),
+							},
+							State:       "superstate",
+							RedirectURI: parseUrl("https://asdf.de/cb"),
+						}
+
+						err := handler.Storage.CreatePARSession(context.Background(), requestURI, r)
+						require.NoError(t, err)
+					},
+					expect: func(t *testing.T, areq *fosite.AuthorizeRequest, aresp *fosite.AuthorizeResponse) {
+						assert.Equal(t, "a b", strings.Join(areq.GetRequestedScopes(), " "))
+						assert.Equal(t, "superstate", areq.GetState())
+						// TODO: Add more
+					},
+				},
+			} {
+				t.Run("case="+c.description, func(t *testing.T) {
+					if c.setup != nil {
+						c.setup(t)
+					}
+
+					aresp := fosite.NewAuthorizeResponse()
+					err := handler.HandleAuthorizeEndpointRequest(context.Background(), c.areq, aresp)
+					if c.expectErr != nil {
+						require.EqualError(t, err, c.expectErr.Error(), "%+v", err)
+					} else {
+						require.NoError(t, err, "%+v", err)
+					}
+
+					if c.expect != nil {
+						c.expect(t, c.areq, aresp)
+					}
+				})
+			}
+		})
+	}
+}

--- a/handler/par/flow_pushed_authorize.go
+++ b/handler/par/flow_pushed_authorize.go
@@ -1,0 +1,80 @@
+package par
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/token/hmac"
+	"github.com/ory/x/errorsx"
+)
+
+const (
+	defaultPARKeyLength = 32
+)
+
+var b64 = base64.URLEncoding.WithPadding(base64.NoPadding)
+
+type PushedAuthorizeHandler struct {
+	Storage                  PARStorage
+	PARContextLifetime       time.Duration
+	RequestURIPrefix         string
+	ScopeStrategy            fosite.ScopeStrategy
+	AudienceMatchingStrategy fosite.AudienceMatchingStrategy
+
+	IsRedirectURISecure func(*url.URL) bool
+}
+
+// HandlePushedAuthorizeRequest handles a pushed authorize endpoint request. To extend the handler's capabilities, the http request
+// is passed along, if further information retrieval is required. If the handler feels that he is not responsible for
+// the pushed authorize request, he must return nil and NOT modify session nor responder neither requester.
+//
+func (c *PushedAuthorizeHandler) HandlePushedAuthorizeEndpointRequest(ctx context.Context, ar fosite.AuthorizeRequester, resp fosite.PushedAuthorizeResponder) error {
+	if !ar.GetResponseTypes().HasOneOf("token", "code", "id_token") {
+		return nil
+	}
+
+	if !c.secureChecker()(ar.GetRedirectURI()) {
+		return errorsx.WithStack(fosite.ErrInvalidRequest.WithHint("Redirect URL is using an insecure protocol, http is only allowed for hosts with suffix `localhost`, for example: http://myapp.localhost/."))
+	}
+
+	client := ar.GetClient()
+	for _, scope := range ar.GetRequestedScopes() {
+		if !c.ScopeStrategy(client.GetScopes(), scope) {
+			return errorsx.WithStack(fosite.ErrInvalidScope.WithHintf("The OAuth 2.0 Client is not allowed to request scope '%s'.", scope))
+		}
+	}
+
+	if err := c.AudienceMatchingStrategy(client.GetAudience(), ar.GetRequestedAudience()); err != nil {
+		return err
+	}
+
+	if ar.GetSession() != nil {
+		ar.GetSession().SetExpiresAt(fosite.PushedAuthorizeRequestContext, time.Now().UTC().Add(c.PARContextLifetime))
+	}
+
+	// generate an ID
+	stateKey, err := hmac.RandomBytes(defaultPARKeyLength)
+	if err != nil {
+		return errorsx.WithStack(fosite.ErrInsufficientEntropy.WithHint("Unable to generate the random part of the request_uri.").WithWrap(err).WithDebug(err.Error()))
+	}
+
+	requestURI := fmt.Sprintf("%s%s", c.RequestURIPrefix, b64.EncodeToString(stateKey))
+	// store
+	if err = c.Storage.CreatePARSession(ctx, requestURI, ar); err != nil {
+		return errorsx.WithStack(fosite.ErrServerError.WithHint("Unable to store the PAR session").WithWrap(err).WithDebug(err.Error()))
+	}
+
+	resp.SetRequestURI(requestURI)
+	return nil
+}
+
+func (c *PushedAuthorizeHandler) secureChecker() func(*url.URL) bool {
+	if c.IsRedirectURISecure == nil {
+		c.IsRedirectURISecure = fosite.IsRedirectURISecure
+	}
+	return c.IsRedirectURISecure
+}

--- a/handler/par/flow_pushed_authorize_test.go
+++ b/handler/par/flow_pushed_authorize_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ory/fosite/storage"
 )
 
-func parseUrl(uu string) *url.URL {
+func parseURL(uu string) *url.URL {
 	u, _ := url.Parse(uu)
 	return u
 }
@@ -62,7 +62,7 @@ func TestAuthorizeCode_HandleAuthorizeEndpointRequest(t *testing.T) {
 						RedirectURIs:  []string{"http://asdf.com/cb"},
 					},
 				},
-				RedirectURI: parseUrl("http://asdf.com/cb"),
+				RedirectURI: parseURL("http://asdf.com/cb"),
 			},
 			description: "should fail because redirect uri is not https",
 			expectErr:   fosite.ErrInvalidRequest,
@@ -79,7 +79,7 @@ func TestAuthorizeCode_HandleAuthorizeEndpointRequest(t *testing.T) {
 					},
 					RequestedAudience: []string{"https://www.ory.sh/not-api"},
 				},
-				RedirectURI: parseUrl("https://asdf.com/cb"),
+				RedirectURI: parseURL("https://asdf.com/cb"),
 			},
 			description: "should fail because audience doesn't match",
 			expectErr:   fosite.ErrInvalidRequest,
@@ -102,7 +102,7 @@ func TestAuthorizeCode_HandleAuthorizeEndpointRequest(t *testing.T) {
 					RequestedAt: time.Now().UTC(),
 				},
 				State:       "superstate",
-				RedirectURI: parseUrl("https://asdf.de/cb"),
+				RedirectURI: parseURL("https://asdf.de/cb"),
 			},
 			description: "should pass",
 			expect: func(t *testing.T, areq *fosite.AuthorizeRequest, aresp *fosite.PushedAuthorizeResponse) {

--- a/handler/par/flow_pushed_authorize_test.go
+++ b/handler/par/flow_pushed_authorize_test.go
@@ -1,0 +1,129 @@
+package par
+
+import (
+	"context"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/ory/fosite"
+	"github.com/ory/fosite/storage"
+)
+
+func parseUrl(uu string) *url.URL {
+	u, _ := url.Parse(uu)
+	return u
+}
+
+func TestAuthorizeCode_HandleAuthorizeEndpointRequest(t *testing.T) {
+	requestURIPrefix := "urn:ietf:params:oauth:request_uri_diff:"
+	store := storage.NewMemoryStore()
+	handler := PushedAuthorizeHandler{
+		Storage:                  store,
+		PARContextLifetime:       30 * time.Minute,
+		RequestURIPrefix:         requestURIPrefix,
+		ScopeStrategy:            fosite.HierarchicScopeStrategy,
+		AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
+	}
+	for _, c := range []struct {
+		handler     PushedAuthorizeHandler
+		areq        *fosite.AuthorizeRequest
+		description string
+		expectErr   error
+		expect      func(t *testing.T, areq *fosite.AuthorizeRequest, aresp *fosite.PushedAuthorizeResponse)
+	}{
+		{
+			handler: handler,
+			areq: &fosite.AuthorizeRequest{
+				ResponseTypes: fosite.Arguments{""},
+				Request:       *fosite.NewRequest(),
+			},
+			description: "should pass because not responsible for handling an empty response type",
+		},
+		{
+			handler: handler,
+			areq: &fosite.AuthorizeRequest{
+				ResponseTypes: fosite.Arguments{"foo"},
+				Request:       *fosite.NewRequest(),
+			},
+			description: "should pass because not responsible for handling an invalid response type",
+		},
+		{
+			handler: handler,
+			areq: &fosite.AuthorizeRequest{
+				ResponseTypes: fosite.Arguments{"code"},
+				Request: fosite.Request{
+					Client: &fosite.DefaultClient{
+						ResponseTypes: fosite.Arguments{"code"},
+						RedirectURIs:  []string{"http://asdf.com/cb"},
+					},
+				},
+				RedirectURI: parseUrl("http://asdf.com/cb"),
+			},
+			description: "should fail because redirect uri is not https",
+			expectErr:   fosite.ErrInvalidRequest,
+		},
+		{
+			handler: handler,
+			areq: &fosite.AuthorizeRequest{
+				ResponseTypes: fosite.Arguments{"code"},
+				Request: fosite.Request{
+					Client: &fosite.DefaultClient{
+						ResponseTypes: fosite.Arguments{"code"},
+						RedirectURIs:  []string{"https://asdf.com/cb"},
+						Audience:      []string{"https://www.ory.sh/api"},
+					},
+					RequestedAudience: []string{"https://www.ory.sh/not-api"},
+				},
+				RedirectURI: parseUrl("https://asdf.com/cb"),
+			},
+			description: "should fail because audience doesn't match",
+			expectErr:   fosite.ErrInvalidRequest,
+		},
+		{
+			handler: handler,
+			areq: &fosite.AuthorizeRequest{
+				ResponseTypes: fosite.Arguments{"code"},
+				Request: fosite.Request{
+					Client: &fosite.DefaultClient{
+						ResponseTypes: fosite.Arguments{"code"},
+						RedirectURIs:  []string{"https://asdf.de/cb"},
+						Audience:      []string{"https://www.ory.sh/api"},
+					},
+					RequestedAudience: []string{"https://www.ory.sh/api"},
+					GrantedScope:      fosite.Arguments{"a", "b"},
+					Session: &fosite.DefaultSession{
+						ExpiresAt: map[fosite.TokenType]time.Time{fosite.AccessToken: time.Now().UTC().Add(time.Hour)},
+					},
+					RequestedAt: time.Now().UTC(),
+				},
+				State:       "superstate",
+				RedirectURI: parseUrl("https://asdf.de/cb"),
+			},
+			description: "should pass",
+			expect: func(t *testing.T, areq *fosite.AuthorizeRequest, aresp *fosite.PushedAuthorizeResponse) {
+				requestURI := aresp.RequestURI
+				assert.NotEmpty(t, requestURI)
+				assert.True(t, strings.HasPrefix(requestURI, requestURIPrefix), "requestURI does not match: %s", requestURI)
+			},
+		},
+	} {
+		t.Run("case="+c.description, func(t *testing.T) {
+			aresp := &fosite.PushedAuthorizeResponse{}
+			err := c.handler.HandlePushedAuthorizeEndpointRequest(context.Background(), c.areq, aresp)
+			if c.expectErr != nil {
+				require.EqualError(t, err, c.expectErr.Error())
+			} else {
+				require.NoError(t, err)
+			}
+
+			if c.expect != nil {
+				c.expect(t, c.areq, aresp)
+			}
+		})
+	}
+}

--- a/handler/par/storage.go
+++ b/handler/par/storage.go
@@ -1,0 +1,19 @@
+// par packages the pushed authorization request handlers and storage
+package par
+
+import (
+	"context"
+
+	"github.com/ory/fosite"
+)
+
+// PARStorage holds information needed to store and retrieve PAR context.
+type PARStorage interface {
+	// CreatePARSession stores the pushed authorization request context. The requestURI is used to derive the key.
+	CreatePARSession(ctx context.Context, requestURI string, request fosite.AuthorizeRequester) error
+	// GetPARSession gets the push authorization request context. If the request is nil, a new request object
+	// is created. Otherwise, the same object is updated.
+	GetPARSession(ctx context.Context, requestURI string, request fosite.AuthorizeRequester) error
+	// DeletePARSession deletes the context.
+	DeletePARSession(ctx context.Context, requestURI string) (err error)
+}

--- a/internal/pushed_authorize_handler.go
+++ b/internal/pushed_authorize_handler.go
@@ -1,0 +1,47 @@
+package internal
+
+import (
+	context "context"
+	reflect "reflect"
+
+	gomock "github.com/golang/mock/gomock"
+
+	fosite "github.com/ory/fosite"
+)
+
+// MockPushedAuthorizeEndpointHandler is a mock of PushedAuthorizeEndpointHandler interface
+type MockPushedAuthorizeEndpointHandler struct {
+	ctrl     *gomock.Controller
+	recorder *MockPushedAuthorizeEndpointHandlerMockRecorder
+}
+
+// MockPushedAuthorizeEndpointHandlerMockRecorder is the mock recorder for PushedMockAuthorizeEndpointHandler
+type MockPushedAuthorizeEndpointHandlerMockRecorder struct {
+	mock *MockPushedAuthorizeEndpointHandler
+}
+
+// NewMockPushedAuthorizeEndpointHandler creates a new mock instance
+func NewMockPushedAuthorizeEndpointHandler(ctrl *gomock.Controller) *MockPushedAuthorizeEndpointHandler {
+	mock := &MockPushedAuthorizeEndpointHandler{ctrl: ctrl}
+	mock.recorder = &MockPushedAuthorizeEndpointHandlerMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use
+func (m *MockPushedAuthorizeEndpointHandler) EXPECT() *MockPushedAuthorizeEndpointHandlerMockRecorder {
+	return m.recorder
+}
+
+// HandlePushedAuthorizeEndpointRequest mocks base method
+func (m *MockPushedAuthorizeEndpointHandler) HandlePushedAuthorizeEndpointRequest(arg0 context.Context, arg1 fosite.AuthorizeRequester, arg2 fosite.PushedAuthorizeResponder) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HandlePushedAuthorizeEndpointRequest", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// HandlePushedAuthorizeEndpointRequest indicates an expected call of HandlePushedAuthorizeEndpointRequest
+func (mr *MockPushedAuthorizeEndpointHandlerMockRecorder) HandlePushedAuthorizeEndpointRequest(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandlePushedAuthorizeEndpointRequest", reflect.TypeOf((*MockPushedAuthorizeEndpointHandler)(nil).HandlePushedAuthorizeEndpointRequest), arg0, arg1, arg2)
+}

--- a/oauth2.go
+++ b/oauth2.go
@@ -348,8 +348,3 @@ type PushedAuthorizeResponder interface {
 	// ToMap converts the response to a map.
 	ToMap() map[string]interface{}
 }
-
-type MergeableAuthorizeRequester interface {
-	// Merge merges the argument into the method receiver.
-	MergeAuthorizeRequester(requester AuthorizeRequester)
-}

--- a/oauth2.go
+++ b/oauth2.go
@@ -332,6 +332,21 @@ type PushedAuthorizeResponder interface {
 	GetRequestURI() string
 	// SetRequestURI sets the request_uri
 	SetRequestURI(requestURI string)
+
+	// GetHeader returns the response's header
+	GetHeader() (header http.Header)
+
+	// AddHeader adds an header key value pair to the response
+	AddHeader(key, value string)
+
+	// SetExtra sets a key value pair for the response.
+	SetExtra(key string, value interface{})
+
+	// GetExtra returns a key's value.
+	GetExtra(key string) interface{}
+
+	// ToMap converts the response to a map.
+	ToMap() map[string]interface{}
 }
 
 type MergeableAuthorizeRequester interface {

--- a/oauth2.go
+++ b/oauth2.go
@@ -33,10 +33,11 @@ type TokenUse = TokenType
 type TokenType string
 
 const (
-	AccessToken   TokenType = "access_token"
-	RefreshToken  TokenType = "refresh_token"
-	AuthorizeCode TokenType = "authorize_code"
-	IDToken       TokenType = "id_token"
+	AccessToken                   TokenType = "access_token"
+	RefreshToken                  TokenType = "refresh_token"
+	AuthorizeCode                 TokenType = "authorize_code"
+	IDToken                       TokenType = "id_token"
+	PushedAuthorizeRequestContext TokenType = "par_context"
 
 	BearerAccessToken string = "bearer"
 )
@@ -324,4 +325,16 @@ type AuthorizeResponder interface {
 
 	// AddParameter adds key value pair to the response
 	AddParameter(key, value string)
+}
+
+type PushedAuthorizeResponder interface {
+	// GetRequestURI returns the request_uri
+	GetRequestURI() string
+	// SetRequestURI sets the request_uri
+	SetRequestURI(requestURI string)
+}
+
+type MergeableAuthorizeRequester interface {
+	// Merge merges the argument into the method receiver.
+	MergeAuthorizeRequester(requester AuthorizeRequester)
 }

--- a/pushed_authorize_request_handler.go
+++ b/pushed_authorize_request_handler.go
@@ -1,0 +1,38 @@
+package fosite
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ory/x/errorsx"
+)
+
+// NewPushedAuthorizeRequest validates the request and produces an AuthorizeRequester object that can be stored
+func (f *Fosite) NewPushedAuthorizeRequest(ctx context.Context, r *http.Request) (AuthorizeRequester, error) {
+	request := NewAuthorizeRequest()
+	if err := r.ParseMultipartForm(1 << 20); err != nil && err != http.ErrNotMultipart {
+		return request, errorsx.WithStack(ErrInvalidRequest.WithHint("Unable to parse HTTP body, make sure to send a properly formatted form request body.").WithWrap(err).WithDebug(err.Error()))
+	}
+	request.Form = r.Form
+	request.State = request.Form.Get("state")
+
+	// Authenticate the client in the same way as at the token endpoint
+	// (Section 2.3 of [RFC6749]).
+	client, err := f.AuthenticateClient(ctx, r, r.Form)
+	if err != nil {
+		return request, errorsx.WithStack(ErrInvalidClient.WithHint("The requested OAuth 2.0 Client could not be authenticated.").WithWrap(err).WithDebug(err.Error()))
+	}
+	request.Client = client
+
+	// Reject the request if the "request_uri" authorization request
+	// parameter is provided.
+	if r.Form.Get("request_uri") != "" {
+		return request, errorsx.WithStack(ErrInvalidRequest.WithHint("The request must not contain 'request_uri'."))
+	}
+
+	// Drop the client in context so it isn't re-fetched
+	ctx = context.WithValue(ctx, ClientContextKey, client)
+
+	// Validate as if this is a new authorize request
+	return f.NewAuthorizeRequest(ctx, r)
+}

--- a/pushed_authorize_request_handler_test.go
+++ b/pushed_authorize_request_handler_test.go
@@ -1,0 +1,652 @@
+package fosite_test
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/ory/fosite"
+	"github.com/ory/fosite/internal"
+	. "github.com/ory/fosite/internal"
+)
+
+// Should pass
+//
+// * https://openid.net/specs/oauth-v2-multiple-response-types-1_0.html#Terminology
+//   The OAuth 2.0 specification allows for registration of space-separated response_type parameter values.
+//   If a Response Type contains one of more space characters (%20), it is compared as a space-delimited list of
+//   values in which the order of values does not matter.
+func TestNewPushedAuthorizeRequest(t *testing.T) {
+	var store *MockStorage
+	var hasher *MockHasher
+	ctx := NewContext()
+
+	redir, _ := url.Parse("https://foo.bar/cb")
+	specialCharRedir, _ := url.Parse("web+application://callback")
+	for _, c := range []struct {
+		desc          string
+		conf          *Fosite
+		r             *http.Request
+		query         url.Values
+		expectedError error
+		mock          func()
+		expect        *AuthorizeRequest
+	}{
+		/* empty request */
+		{
+			desc:          "empty request fails",
+			conf:          &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			r:             &http.Request{},
+			expectedError: ErrInvalidClient,
+			mock:          func() {},
+		},
+		/* invalid redirect uri */
+		{
+			desc:          "invalid redirect uri fails",
+			conf:          &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query:         url.Values{"redirect_uri": []string{"invalid"}},
+			expectedError: ErrInvalidClient,
+			mock:          func() {},
+		},
+		/* invalid client */
+		{
+			desc:          "invalid client fails",
+			conf:          &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query:         url.Values{"redirect_uri": []string{"https://foo.bar/cb"}},
+			expectedError: ErrInvalidClient,
+			mock:          func() {},
+		},
+		/* redirect client mismatch */
+		{
+			desc: "client and request redirects mismatch",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"client_id":     []string{"1234"},
+				"client_secret": []string{"1234"},
+			},
+			expectedError: ErrInvalidRequest,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"invalid"}, Scopes: []string{}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+		},
+		/* redirect client mismatch */
+		{
+			desc: "client and request redirects mismatch",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  []string{""},
+				"client_id":     []string{"1234"},
+				"client_secret": []string{"1234"},
+			},
+			expectedError: ErrInvalidRequest,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"invalid"}, Scopes: []string{}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+		},
+		/* redirect client mismatch */
+		{
+			desc: "client and request redirects mismatch",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  []string{"https://foo.bar/cb"},
+				"client_id":     []string{"1234"},
+				"client_secret": []string{"1234"},
+			},
+			expectedError: ErrInvalidRequest,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"invalid"}, Scopes: []string{}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+		},
+		/* no state */
+		{
+			desc: "no state",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  []string{"https://foo.bar/cb"},
+				"client_id":     []string{"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": []string{"code"},
+			},
+			expectedError: ErrInvalidState,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+		},
+		/* short state */
+		{
+			desc: "short state",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code"},
+				"state":         {"short"},
+			},
+			expectedError: ErrInvalidState,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+		},
+		/* fails because scope not given */
+		{
+			desc: "should fail because client does not have scope baz",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar baz"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrInvalidScope,
+		},
+		/* fails because scope not given */
+		{
+			desc: "should fail because client does not have scope baz",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"},
+					Audience: []string{"https://cloud.ory.sh/api"},
+					Secret:   []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrInvalidRequest,
+		},
+		/* success case */
+		{
+			desc: "should pass",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					ResponseTypes: []string{"code token"},
+					RedirectURIs:  []string{"https://foo.bar/cb"},
+					Scopes:        []string{"foo", "bar"},
+					Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+					Secret:        []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultClient{
+						ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"},
+						Scopes:   []string{"foo", "bar"},
+						Audience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:   []byte("1234"),
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* repeated audience parameter */
+		{
+			desc: "repeated audience parameter",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					ResponseTypes: []string{"code token"},
+					RedirectURIs:  []string{"https://foo.bar/cb"},
+					Scopes:        []string{"foo", "bar"},
+					Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+					Secret:        []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultClient{
+						ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"},
+						Scopes:   []string{"foo", "bar"},
+						Audience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:   []byte("1234"),
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* repeated audience parameter with tricky values */
+		{
+			desc: "repeated audience parameter with tricky values",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: ExactAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"test value", ""},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					ResponseTypes: []string{"code token"},
+					RedirectURIs:  []string{"https://foo.bar/cb"},
+					Scopes:        []string{"foo", "bar"},
+					Audience:      []string{"test value"},
+					Secret:        []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultClient{
+						ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"},
+						Scopes:   []string{"foo", "bar"},
+						Audience: []string{"test value"},
+						Secret:   []byte("1234"),
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"test value"},
+				},
+			},
+		},
+		/* redirect_uri with special character in protocol*/
+		{
+			desc: "redirect_uri with special character",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"web+application://callback"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					ResponseTypes: []string{"code token"},
+					RedirectURIs:  []string{"web+application://callback"},
+					Scopes:        []string{"foo", "bar"},
+					Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+					Secret:        []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   specialCharRedir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultClient{
+						ResponseTypes: []string{"code token"}, RedirectURIs: []string{"web+application://callback"},
+						Scopes:   []string{"foo", "bar"},
+						Audience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:   []byte("1234"),
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* audience with double spaces between values */
+		{
+			desc: "audience with double spaces between values",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api  https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{
+					ResponseTypes: []string{"code token"},
+					RedirectURIs:  []string{"https://foo.bar/cb"},
+					Scopes:        []string{"foo", "bar"},
+					Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+					Secret:        []byte("1234"),
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultClient{
+						ResponseTypes: []string{"code token"}, RedirectURIs: []string{"https://foo.bar/cb"},
+						Scopes:   []string{"foo", "bar"},
+						Audience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:   []byte("1234"),
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* fails because unknown response_mode*/
+		{
+			desc: "should fail because unknown response_mode",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"unknown"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}, ResponseTypes: []string{"code token"}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrUnsupportedResponseMode,
+		},
+		/* fails because response_mode is requested but the OAuth 2.0 client doesn't support response mode */
+		{
+			desc: "should fail because response_mode is requested but the OAuth 2.0 client doesn't support response mode",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"form_post"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}, ResponseTypes: []string{"code token"}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrUnsupportedResponseMode,
+		},
+		/* fails because requested response mode is not allowed */
+		{
+			desc: "should fail because requested response mode is not allowed",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"form_post"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultResponseModeClient{
+					DefaultClient: &DefaultClient{
+						RedirectURIs:  []string{"https://foo.bar/cb"},
+						Scopes:        []string{"foo", "bar"},
+						ResponseTypes: []string{"code token"},
+						Secret:        []byte("1234"),
+					},
+					ResponseModes: []ResponseModeType{ResponseModeQuery},
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrUnsupportedResponseMode,
+		},
+		/* success with response mode */
+		{
+			desc: "success with response mode",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"form_post"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultResponseModeClient{
+					DefaultClient: &DefaultClient{
+						RedirectURIs:  []string{"https://foo.bar/cb"},
+						Scopes:        []string{"foo", "bar"},
+						ResponseTypes: []string{"code token"},
+						Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:        []byte("1234"),
+					},
+					ResponseModes: []ResponseModeType{ResponseModeFormPost},
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultResponseModeClient{
+						DefaultClient: &DefaultClient{
+							RedirectURIs:  []string{"https://foo.bar/cb"},
+							Scopes:        []string{"foo", "bar"},
+							ResponseTypes: []string{"code token"},
+							Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+							Secret:        []byte("1234"),
+						},
+						ResponseModes: []ResponseModeType{ResponseModeFormPost},
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* determine correct response mode if default */
+		{
+			desc: "success with response mode",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultResponseModeClient{
+					DefaultClient: &DefaultClient{
+						RedirectURIs:  []string{"https://foo.bar/cb"},
+						Scopes:        []string{"foo", "bar"},
+						ResponseTypes: []string{"code"},
+						Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:        []byte("1234"),
+					},
+					ResponseModes: []ResponseModeType{ResponseModeQuery},
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultResponseModeClient{
+						DefaultClient: &DefaultClient{
+							RedirectURIs:  []string{"https://foo.bar/cb"},
+							Scopes:        []string{"foo", "bar"},
+							ResponseTypes: []string{"code"},
+							Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+							Secret:        []byte("1234"),
+						},
+						ResponseModes: []ResponseModeType{ResponseModeQuery},
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* determine correct response mode if default */
+		{
+			desc: "success with response mode",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"audience":      {"https://cloud.ory.sh/api https://www.ory.sh/api"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultResponseModeClient{
+					DefaultClient: &DefaultClient{
+						RedirectURIs:  []string{"https://foo.bar/cb"},
+						Scopes:        []string{"foo", "bar"},
+						ResponseTypes: []string{"code token"},
+						Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+						Secret:        []byte("1234"),
+					},
+					ResponseModes: []ResponseModeType{ResponseModeFragment},
+				}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expect: &AuthorizeRequest{
+				RedirectURI:   redir,
+				ResponseTypes: []string{"code", "token"},
+				State:         "strong-state",
+				Request: Request{
+					Client: &DefaultResponseModeClient{
+						DefaultClient: &DefaultClient{
+							RedirectURIs:  []string{"https://foo.bar/cb"},
+							Scopes:        []string{"foo", "bar"},
+							ResponseTypes: []string{"code token"},
+							Audience:      []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+							Secret:        []byte("1234"),
+						},
+						ResponseModes: []ResponseModeType{ResponseModeFragment},
+					},
+					RequestedScope:    []string{"foo", "bar"},
+					RequestedAudience: []string{"https://cloud.ory.sh/api", "https://www.ory.sh/api"},
+				},
+			},
+		},
+		/* fails because request_uri is included */
+		{
+			desc: "should fail because request_uri is provided in the request",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"request_uri":   {"https://foo.bar/ru"},
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"1234"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"form_post"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}, ResponseTypes: []string{"code token"}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("1234"))).Return(nil)
+			},
+			expectedError: ErrInvalidRequest.WithHint("The request must not contain 'request_uri'."),
+		},
+		/* fails because of invalid client credentials */
+		{
+			desc: "should fail because of invalid client creds",
+			conf: &Fosite{Store: store, ScopeStrategy: ExactScopeStrategy, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy},
+			query: url.Values{
+				"request_uri":   {"https://foo.bar/ru"},
+				"redirect_uri":  {"https://foo.bar/cb"},
+				"client_id":     {"1234"},
+				"client_secret": []string{"4321"},
+				"response_type": {"code token"},
+				"state":         {"strong-state"},
+				"scope":         {"foo bar"},
+				"response_mode": {"form_post"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "1234").Return(&DefaultClient{RedirectURIs: []string{"https://foo.bar/cb"}, Scopes: []string{"foo", "bar"}, ResponseTypes: []string{"code token"}, Secret: []byte("1234")}, nil)
+				hasher.EXPECT().Compare(ctx, gomock.Eq([]byte("1234")), gomock.Eq([]byte("4321"))).Return(fmt.Errorf("invalid hash"))
+			},
+			expectedError: ErrInvalidClient,
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%s", c.desc), func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			store = NewMockStorage(ctrl)
+			hasher = internal.NewMockHasher(ctrl)
+			ctx := NewContext()
+			defer ctrl.Finish()
+
+			c.mock()
+			if c.r == nil {
+				c.r = &http.Request{Header: http.Header{}}
+				if c.query != nil {
+					c.r.URL = &url.URL{RawQuery: c.query.Encode()}
+				}
+			}
+
+			c.conf.Store = store
+			c.conf.Hasher = hasher
+			ar, err := c.conf.NewPushedAuthorizeRequest(ctx, c.r)
+			if c.expectedError != nil {
+				assert.EqualError(t, err, c.expectedError.Error())
+				// https://github.com/ory/hydra/issues/1642
+				AssertObjectKeysEqual(t, &AuthorizeRequest{State: c.query.Get("state")}, ar, "State")
+			} else {
+				require.NoError(t, err)
+				AssertObjectKeysEqual(t, c.expect, ar, "ResponseTypes", "RequestedAudience", "RequestedScope", "Client", "RedirectURI", "State")
+				assert.NotNil(t, ar.GetRequestedAt())
+			}
+		})
+	}
+}

--- a/pushed_authorize_response.go
+++ b/pushed_authorize_response.go
@@ -1,7 +1,17 @@
 package fosite
 
+import "net/http"
+
 type PushedAuthorizeResponse struct {
 	RequestURI string `json:"request_uri"`
+	Header     http.Header
+	Extra      map[string]interface{}
+}
+
+func NewPushedAuthorizeResponse() *PushedAuthorizeResponse {
+	return &PushedAuthorizeResponse{
+		Extra: map[string]interface{}{},
+	}
 }
 
 func (a *PushedAuthorizeResponse) GetRequestURI() string {
@@ -10,4 +20,25 @@ func (a *PushedAuthorizeResponse) GetRequestURI() string {
 
 func (a *PushedAuthorizeResponse) SetRequestURI(requestURI string) {
 	a.RequestURI = requestURI
+}
+
+func (a *PushedAuthorizeResponse) GetHeader() http.Header {
+	return a.Header
+}
+
+func (a *PushedAuthorizeResponse) AddHeader(key, value string) {
+	a.Header.Add(key, value)
+}
+
+func (a *PushedAuthorizeResponse) SetExtra(key string, value interface{}) {
+	a.Extra[key] = value
+}
+
+func (a *PushedAuthorizeResponse) GetExtra(key string) interface{} {
+	return a.Extra[key]
+}
+
+func (a *PushedAuthorizeResponse) ToMap() map[string]interface{} {
+	a.Extra["request_uri"] = a.RequestURI
+	return a.Extra
 }

--- a/pushed_authorize_response.go
+++ b/pushed_authorize_response.go
@@ -1,0 +1,13 @@
+package fosite
+
+type PushedAuthorizeResponse struct {
+	RequestURI string `json:"request_uri"`
+}
+
+func (a *PushedAuthorizeResponse) GetRequestURI() string {
+	return a.RequestURI
+}
+
+func (a *PushedAuthorizeResponse) SetRequestURI(requestURI string) {
+	a.RequestURI = requestURI
+}

--- a/pushed_authorize_response_writer.go
+++ b/pushed_authorize_response_writer.go
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author		Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @copyright 	2015-2018 Aeneas Rekkas <aeneas+oss@aeneas.io>
+ * @license 	Apache-2.0
+ *
+ */
+
+package fosite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+func (f *Fosite) NewPushedAuthorizeResponse(ctx context.Context, ar AuthorizeRequester, session Session) (PushedAuthorizeResponder, error) {
+	var resp = &PushedAuthorizeResponse{}
+
+	ctx = context.WithValue(ctx, AuthorizeRequestContextKey, ar)
+	ctx = context.WithValue(ctx, PushedAuthorizeResponseContextKey, resp)
+
+	ar.SetSession(session)
+	for _, h := range f.PushedAuthorizeEndpointHandlers {
+		if err := h.HandlePushedAuthorizeEndpointRequest(ctx, ar, resp); err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}
+
+func (f *Fosite) WritePushedAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequester, resp PushedAuthorizeResponder) {
+	// Set custom headers, e.g. "X-MySuperCoolCustomHeader" or "X-DONT-CACHE-ME"...
+	wh := rw.Header()
+	wh.Set("Cache-Control", "no-store")
+	wh.Set("Pragma", "no-cache")
+	wh.Set("Content-Type", "application/json;charset=UTF-8")
+	if err := json.NewEncoder(rw).Encode(resp); err != nil {
+		fmt.Printf("ERROR: err=%v\n", err)
+	}
+}
+
+func (f *Fosite) WritePushedAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequester, err error) {
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.Header().Set("Pragma", "no-cache")
+	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
+
+	rfcerr := ErrorToRFC6749Error(err).WithLegacyFormat(f.UseLegacyErrorFormat).WithExposeDebug(f.SendDebugMessagesToClients)
+
+	js, err := json.Marshal(rfcerr)
+	if err != nil {
+		if f.SendDebugMessagesToClients {
+			errorMessage := EscapeJSONString(err.Error())
+			http.Error(rw, fmt.Sprintf(`{"error":"server_error","error_description":"%s"}`, errorMessage), http.StatusInternalServerError)
+		} else {
+			http.Error(rw, `{"error":"server_error"}`, http.StatusInternalServerError)
+		}
+		return
+	}
+
+	rw.WriteHeader(rfcerr.CodeField)
+	_, _ = rw.Write(js)
+}

--- a/pushed_authorize_response_writer_test.go
+++ b/pushed_authorize_response_writer_test.go
@@ -1,0 +1,57 @@
+package fosite_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+
+	. "github.com/ory/fosite"
+	. "github.com/ory/fosite/internal"
+)
+
+func TestNewPushedAuthorizeResponse(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	handlers := []*MockPushedAuthorizeEndpointHandler{NewMockPushedAuthorizeEndpointHandler(ctrl)}
+	ar := NewMockAuthorizeRequester(ctrl)
+	defer ctrl.Finish()
+
+	ctx := context.Background()
+	oauth2 := &Fosite{
+		PushedAuthorizeEndpointHandlers: PushedAuthorizeEndpointHandlers{handlers[0]},
+	}
+	ar.EXPECT().SetSession(gomock.Eq(new(DefaultSession))).AnyTimes()
+	fooErr := errors.New("foo")
+	for k, c := range []struct {
+		isErr     bool
+		mock      func()
+		expectErr error
+	}{
+		{
+			mock: func() {
+				handlers[0].EXPECT().HandlePushedAuthorizeEndpointRequest(gomock.Any(), gomock.Eq(ar), gomock.Any()).Return(fooErr)
+			},
+			isErr:     true,
+			expectErr: fooErr,
+		},
+		{
+			mock: func() {
+				handlers[0].EXPECT().HandlePushedAuthorizeEndpointRequest(gomock.Any(), gomock.Eq(ar), gomock.Any()).Return(nil)
+			},
+			isErr: false,
+		},
+	} {
+		c.mock()
+		responder, err := oauth2.NewPushedAuthorizeResponse(ctx, ar, new(DefaultSession))
+		assert.Equal(t, c.isErr, err != nil, "%d: %s", k, err)
+		if err != nil {
+			assert.Equal(t, c.expectErr, err, "%d: %s", k, err)
+			assert.Nil(t, responder, "%d", k)
+		} else {
+			assert.NotNil(t, responder, "%d", k)
+		}
+		t.Logf("Passed test case %d", k)
+	}
+}

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -473,10 +473,7 @@ func (s *MemoryStore) GetPARSession(ctx context.Context, requestURI string, requ
 		return fosite.ErrNotFound
 	}
 
-	if req, ok := request.(fosite.MergeableAuthorizeRequester); ok {
-		req.MergeAuthorizeRequester(r)
-	}
-
+	request.Merge(r)
 	return nil
 }
 


### PR DESCRIPTION
This PR implements  [RFC9126 - Pushed Authorization Request](https://www.rfc-editor.org/rfc/rfc9126.html).

It introduces the following:

1. New PushedAuthorizeEndpointHandlers
2. Request and response writer handlers
3. `par` package contains 
    - New storage interface
    - Handler for authorize endpoint that reads the request context and hydrates the AuthorizeRequester
    - Handler for pushed authorization that processes the request and stores the request context
4. Merge func added to AuthorizeRequest. This is leveraged to hydrate the AuthorizeRequester in the authorize endpoint handler

## Related issue(s)

#628 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

This might conflict with my other pull request but I will fix the conflicts as needed.