### PR TITLE
feat: allow for permanent refresh_token(s)

### DIFF
--- a/context.go
+++ b/context.go
@@ -35,5 +35,5 @@ const (
 	AccessResponseContextKey    = ContextKey("accessResponse")
 	AuthorizeRequestContextKey  = ContextKey("authorizeRequest")
 	AuthorizeResponseContextKey = ContextKey("authorizeResponse")
-	EnableOneTimeUseRefreshTokenContextKey  = ContextKey("enableOneTimeUseRefreshToken")
+	RefreshTokenRotationEnabledContextKey  = ContextKey("refreshTokenRotationEnabled")
 )

--- a/context.go
+++ b/context.go
@@ -35,4 +35,5 @@ const (
 	AccessResponseContextKey    = ContextKey("accessResponse")
 	AuthorizeRequestContextKey  = ContextKey("authorizeRequest")
 	AuthorizeResponseContextKey = ContextKey("authorizeResponse")
+	EnableOneTimeUseRefreshTokenContextKey  = ContextKey("enableOneTimeUseRefreshToken")
 )

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -133,7 +133,7 @@ func (c *RefreshTokenGrantHandler) PopulateTokenEndpointResponse(ctx context.Con
 	}
 
 	oneTimeUseRefreshToken := true
-	oneTimeUseRefreshTokenContext := ctx.Value(fosite.EnableOneTimeUseRefreshTokenContextKey)
+	oneTimeUseRefreshTokenContext := ctx.Value(fosite.RefreshTokenRotationEnabledContextKey)
 	if oneTimeUseRefreshTokenContext != nil {
 		oneTimeUseRefreshToken = oneTimeUseRefreshTokenContext.(bool)
 	}

--- a/handler/oauth2/flow_refresh_test.go
+++ b/handler/oauth2/flow_refresh_test.go
@@ -444,7 +444,8 @@ func TestRefreshFlow_PopulateTokenEndpointResponse(t *testing.T) {
 
 					c.setup()
 
-					err := h.PopulateTokenEndpointResponse(nil, areq, aresp)
+					ctx := context.TODO()
+					err := h.PopulateTokenEndpointResponse(ctx, areq, aresp)
 					if c.expectErr != nil {
 						assert.EqualError(t, err, c.expectErr.Error())
 					} else {


### PR DESCRIPTION
This is a branch of `v0.40.2` that introduces the ability to disable one-time-use refresh tokens (RT). From my reading of issues here in the fosite repository and the Hydra repository, a number of users desire a feature like this. My hope is that this change can be released with a new version `v0.40.3` and a new version of Hydra `v1.10.7`. With these new releases I can update my deployment of Hydra to pick up the new feature. 

One time use refresh-tokens can introduce issues where a user's "session" stored in a 3rd party database can be completely disabled, forcing the end-user to go through an OAuth2 flow with Hydra again. The related issues I have included below outline some of the ways this can happen and include some discussion. 

For brevity here is a use case involving threads that can permanently disable a session:

1. Execute an OAuth2 flow with Hydra and receive an `access_token` (AT-0) and `refresh_token` (RT-0). 
2. Thread-A: (AT-0 has expired) use RT-0 to obtain new tokens, AT-1, RT-1
3. Thread-B: (AT-0 has expired) _also_ uses RT-0 to obtain a new RT, but this fails because Thread-1 has already used the token
4. Thread-A: uses AT-1 to call an API endpoint (ie; `/userinfo`)
5. Thread-A: (AT-1 has expired) use RT-1 to obtain new tokens. This **fails** because in step 3, Thread-B attempted to use RT-0 after it was used. There is now no way to get back into a functional state and the end-user must go through the flow again.

This can be worked-around by implementing a distributed-lock pattern in the client to Hydra, but I believe this places an undue burden on the client developers. This burden is exacerbated by the nature of implementing OAuth2 flows for an application: each client will likely be an independent 3rd party entity to the entity hosting Hydra. Further, a distributed-locking pattern can not account for the other failure cases, such as network errors.

Note: There is a companion [PR in Hydra](https://github.com/ory/hydra/pull/2815) that adds a configuration option to enable/disable this behavior.

## Related issue(s)

#255 
[Hydra #1831](https://github.com/ory/hydra/issues/1831)

## Checklist

- [ ] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [ ] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

I implemented this change with the goal of changing as little as possible, hence the use of `Context` to pass information from Hydra to this library. I have seen no other mechanism for accessing configuration provided in Hydra to fosite, nor is the Strategy Pattern possible here, as `HandleTokenEndpointRequest` does not use a strategy for revoking a token. Instead `HandleTokenEndpointRequest` accesses `TokenRevocationStorage` directly, meaning that this behavior is applied to every Strategy involved. A deeper change could be made to introduce a higher-level strategy for handling token refresh, or introducing a TokenRevocation strategy but this is in conflict with my goal of making a small, precise, change. 
