### PR TITLE
fix: force HTTP GET for redirect responses

### DIFF
--- a/authorize_error.go
+++ b/authorize_error.go
@@ -82,5 +82,5 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 	}
 
 	rw.Header().Set("Location", redirectURIString)
-	rw.WriteHeader(http.StatusFound)
+	rw.WriteHeader(http.StatusSeeOther)
 }

--- a/authorize_error_test.go
+++ b/authorize_error_test.go
@@ -94,7 +94,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeQuery).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?error=invalid_request&error_debug=with-debug&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -116,7 +116,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeQuery).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.+Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.+with-debug&state=foostate")
@@ -137,7 +137,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeQuery).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.+Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -157,7 +157,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeDefault).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -177,7 +177,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeQuery).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&foo=bar&state=foostate")
@@ -197,7 +197,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"foobar"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=unsupported_grant_type&error_description=The+authorization+grant+type+is+not+supported+by+the+authorization+server.&state=foostate")
@@ -217,7 +217,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -237,7 +237,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -257,7 +257,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -278,7 +278,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/#error=invalid_request&error_debug=with-debug&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -300,7 +300,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.+Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.+with-debug&state=foostate")
@@ -323,7 +323,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.+Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -346,7 +346,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=invalid_request&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -367,7 +367,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"code", "token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=invalid_request&error_debug=with-debug&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -388,7 +388,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"id_token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=invalid_request&error_debug=with-debug&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")
@@ -409,7 +409,7 @@ func TestWriteAuthorizeError(t *testing.T) {
 				req.EXPECT().GetResponseTypes().AnyTimes().Return(Arguments([]string{"token"}))
 				req.EXPECT().GetResponseMode().Return(ResponseModeFragment).AnyTimes()
 				rw.EXPECT().Header().Times(3).Return(header)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			checkHeader: func(t *testing.T, k int) {
 				a, _ := url.Parse("https://foobar.com/?foo=bar#error=invalid_request&error_debug=with-debug&error_description=The+request+is+missing+a+required+parameter%2C+includes+an+invalid+parameter+value%2C+includes+a+parameter+more+than+once%2C+or+is+otherwise+malformed.&error_hint=Make+sure+that+the+various+parameters+are+correct%2C+be+aware+of+case+sensitivity+and+trim+your+parameters.+Make+sure+that+the+client+you+are+using+has+exactly+whitelisted+the+redirect_uri+you+specified.&state=foostate")

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -75,5 +75,5 @@ func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 // user-agent.
 func sendRedirect(url string, rw http.ResponseWriter) {
 	rw.Header().Set("Location", url)
-	rw.WriteHeader(http.StatusFound)
+	rw.WriteHeader(http.StatusSeeOther)
 }

--- a/authorize_write_test.go
+++ b/authorize_write_test.go
@@ -55,7 +55,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				assert.Equal(t, http.Header{
@@ -74,7 +74,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				assert.Equal(t, http.Header{
@@ -93,7 +93,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				expectedUrl, _ := url.Parse("https://foobar.com/?foo=bar&bar=baz")
@@ -113,7 +113,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{"X-Bar": {"baz"}})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				assert.Equal(t, http.Header{
@@ -133,7 +133,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{"X-Bar": {"baz"}})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				expectedUrl, err := url.Parse("https://foobar.com/?foo=bar&bar=b%2Baz&scope=a+b")
@@ -155,7 +155,7 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{"X-Bar": {"baz"}})
 
 				rw.EXPECT().Header().Return(header).Times(2)
-				rw.EXPECT().WriteHeader(http.StatusFound)
+				rw.EXPECT().WriteHeader(http.StatusSeeOther)
 			},
 			expect: func() {
 				assert.Equal(t, http.Header{


### PR DESCRIPTION
`302 Found` behavior is not consistent across browsers and my team got into an issue with Safari maintaining `HTTP POST` across redirects after login through form. This results in a callback executed with `HTTP POST` instead of `HTTP GET`.

Changing redirects to `303 See Other` to force `HTTP GET`.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

