### PR TITLE
fix: url-encode the fragment of the redirect URL of the authorize response

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -212,6 +212,7 @@ func WriteAuthorizeFormPostResponse(redirectURL string, parameters url.Values, t
 	})
 }
 
+// Deprecated: Do not use.
 func URLSetFragment(source *url.URL, fragment url.Values) {
 	var f string
 	for k, v := range fragment {

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -57,8 +57,13 @@ func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 		// Implicit grants
 		// The endpoint URI MUST NOT include a fragment component.
 		redir.Fragment = ""
-		URLSetFragment(redir, resp.GetParameters())
-		sendRedirect(redir.String(), rw)
+
+		u := redir.String()
+		fr := resp.GetParameters()
+		if len(fr) > 0 {
+			u = u + "#" + fr.Encode()
+		}
+		sendRedirect(u, rw)
 		return
 	default:
 		if f.ResponseModeHandler().ResponseModes().Has(rm) {


### PR DESCRIPTION
This patch reverts the encoding logic for the fragment of the redirect URL returned as part of the authorize response to what was the one before version `0.36.0`. In that version, the code was refactored and the keys and values of the fragment ceased to be url-encoded. This in turn reflected on all Ory Hydra versions starting from `1.9.0` and provoked a breaking change that made the parsing of the fragment impossible if any of the params contain a character like `&` or `=` because they get treated as separators instead of as text

## Related Issue or Design Document

Fixes #648

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

These changes reflect on Ory Hydra, partially restoring the behaviour related to the fragment encoding to the one that was before version `1.9`. The OAuth specs mandate the fragment to be encoded using the `application/x-www-form-urlencoded` format, which is slightly different from the usual query string format: in fact, the spaces are not encoded as `%20` but rather as a `+`. For this reason, decoding the value in Javascript must first replace all `+` signs with spaces and only then call `decodeURIComponent()`. Since before the spaces were encoded wrongly, this path strictly speaking is still breaking the frontends. Let me know if we want to completely restore the logic or if the current implementation is fine as-is: in that case, a note should probably be added to the CHANGELOG