### PR TITLE
feat: Enable urn:ietf:params:oauth:grant-type:jwt-bearer for unauthenticated Clients

### DIFF
--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -535,6 +535,19 @@ func TestAuthenticateClient(t *testing.T) {
 			r:         new(http.Request),
 			expectErr: ErrInvalidClient,
 		},
+		{
+			d:      "should fail despite valid assertion because client unknown",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "bar", Secret: barSecret, Public: false}, JSONWebKeys: rsaJwks, TokenEndpointAuthMethod: "none"},
+			form: url.Values{"assertion": {mustGenerateRSAAssertion(t, jwt.MapClaims{
+				"sub": "bar",
+				"exp": time.Now().Add(time.Hour).Unix(),
+				"iss": "foo",
+				"jti": "12345",
+				"aud": "token-url",
+			}, rsaKey, "kid-foo")}, "grant_type": []string{gtJWT}},
+			r:         new(http.Request),
+			expectErr: ErrInvalidClient,
+		},
 	} {
 		t.Run(fmt.Sprintf("case=%d/description=%s", k, tc.d), func(t *testing.T) {
 			store := storage.NewMemoryStore()


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a codeblock documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

This PR allows the `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type to work with public clients (`token_endpoint_auth_method` none). The issuer is used to derive the client ID that is used to verify whether client is indeed public or not.

This change is required to reach compatibility with Salesforce Named Credentials with Authentication Method `WT Token Exchange`. For further Details see:

* [Named Credential](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_callouts_named_credentials.htm)
* [Sample](https://ambassadorpatryk.com/2020/08/jwt-validation-policy-and-salesforce-named-credentials/)
* [APEX Class](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_Auth_JWTBearerTokenExchange.htm) 


It is also backed by [rfc7523](https://datatracker.ietf.org/doc/html/rfc7523#section-2.1), that says that Authentication of the client is optional.

This is not a breaking change. Also security is not impacted as clients will need to be made public explicitly.

## Related Issue or Design Document

This is not a major design change. All it does is check whether an assertion passed by an unauthenticated client (no client credentials in token request) in the context of an `urn:ietf:params:oauth:grant-type:jwt-bearer` grant resembles a registered and public OAuth2 client by extracting the issuer field.

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
2. implements a new feature, link the issue containing the design document in the format of `#1234`;
3. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discusssions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->

In order to be useful for me and my project this change needs to be built into hydra. However hydra is not affected by any of the changes and continues to work as expected.

Below is a curl representation of a Salesforce Request:

```
curl -X 'POST' 'https://webhook.site/' -H 'connection: close' -H 'content-length: 839' -H 'content-type: application/x-www-form-urlencoded' -H 'accept: text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2' -H 'host: webhook.site' -H 'pragma: no-cache' -H 'cache-control: no-cache' -H 'user-agent: SFDC-Callout/54.0' -d $'grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJraWQiOiJKV1RfQ0VSVCIsInR5cCI6IkpXVCIsImFsZyI6IlJTMjU2In0.eyJpc3MiOiI1ZWQ4MTJkYy05MzllLTExZWMtYjkwOS0wMjQyYWMxMjAwMDQiLCJzdWIiOiI1ZWQ4MTJkYy05MzllLTExZWMtYjkwOS0wMjQyYWMxMjAwMDQiLCJhdWQiOlsiaHR0cHM6Ly9oeWRyYS5jZWxvbmlzbGFicy5pby9vYXV0aDIvdG9rZW4iLCJ0ZWFtLWxhYnMiLCJodHRwOi8vbG9jYWxob3N0OjQ0NDQvb2F1dGgyL3Rva2VuIl0sIm5iZiI6MTY0NTY4NTA4NSwiaWF0IjoxNjQ1Njg1MDg1LCJleHAiOjE2NDU3NzE0ODV9.W_WaaBqn4XHgpB0JoVoN9lwSiZtic-hpRP24JF4OgRiIXUA4wqM7iDyq__OaFPRoYRZu1hWZzTk-i5bOB05Se5opmB_JOnaz2c7G3953sod9GOmiQdLdwHr2ZQ9G-ry6bWeieRMvWLtQ3TjrUjyycyZ-EKdz0aosJRhIqtR7VA7c0Q8wiLLifOOX5Wg0t4fRGLyN16dG2ME1KTyx3BPB65tJirXVqE0a4XGx6wDxL_00Z3YEgxWpylCULE62eRFt35l3VizwG3yp_cQZpBM2MJL5VpJMXT_-zKT_Lvpj81VM1l2s6Jm0vyrC2TbmBfS1Rbkuv-fgSxrimtjPUUEDaw&scope=pycelonis-pack.pycelonis-model'
```