### PR TITLE
fix: empty client secret via basic auth header means "none" authn

### DIFF
--- a/client_authentication.go
+++ b/client_authentication.go
@@ -233,7 +233,7 @@ func (f *Fosite) DefaultClientAuthenticationStrategy(ctx context.Context, r *htt
 		// If this isn't an OpenID Connect client then we actually don't care about any of this, just continue!
 	} else if ok && form.Get("client_id") != "" && form.Get("client_secret") != "" && oidcClient.GetTokenEndpointAuthMethod() != "client_secret_post" {
 		return nil, errorsx.WithStack(ErrInvalidClient.WithHintf("The OAuth 2.0 Client supports client authentication method '%s', but method 'client_secret_post' was requested. You must configure the OAuth 2.0 client's 'token_endpoint_auth_method' value to accept 'client_secret_post'.", oidcClient.GetTokenEndpointAuthMethod()))
-	} else if _, _, basicOk := r.BasicAuth(); basicOk && ok && oidcClient.GetTokenEndpointAuthMethod() != "client_secret_basic" {
+	} else if _, secret, basicOk := r.BasicAuth(); basicOk && ok && secret != "" && oidcClient.GetTokenEndpointAuthMethod() != "client_secret_basic" {
 		return nil, errorsx.WithStack(ErrInvalidClient.WithHintf("The OAuth 2.0 Client supports client authentication method '%s', but method 'client_secret_basic' was requested. You must configure the OAuth 2.0 client's 'token_endpoint_auth_method' value to accept 'client_secret_basic'.", oidcClient.GetTokenEndpointAuthMethod()))
 	} else if ok && oidcClient.GetTokenEndpointAuthMethod() != "none" && client.IsPublic() {
 		return nil, errorsx.WithStack(ErrInvalidClient.WithHintf("The OAuth 2.0 Client supports client authentication method '%s', but method 'none' was requested. You must configure the OAuth 2.0 client's 'token_endpoint_auth_method' value to accept 'none'.", oidcClient.GetTokenEndpointAuthMethod()))

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -163,6 +163,25 @@ func TestAuthenticateClient(t *testing.T) {
 			r:      new(http.Request),
 		},
 		{
+			d:      "should pass because client is public and client secret is empty in query param",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "none"},
+			form:   url.Values{"client_id": []string{"foo"}, "client_secret": []string{""}},
+			r:      new(http.Request),
+		},
+		{
+			d:      "should pass because client is public and client secret is empty in basic auth header",
+			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "none"},
+			form:   url.Values{},
+			r:      &http.Request{Header: clientBasicAuthHeader("foo", "")},
+		},
+		{
+			d:         "should fail because client requires basic auth and client secret is empty in basic auth header",
+			client:    &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "foo", Public: true}, TokenEndpointAuthMethod: "client_secret_basic"},
+			form:      url.Values{},
+			r:         &http.Request{Header: clientBasicAuthHeader("foo", "")},
+			expectErr: ErrInvalidClient,
+		},
+		{
 			d:      "should pass with client credentials containing special characters",
 			client: &DefaultOpenIDConnectClient{DefaultClient: &DefaultClient{ID: "!foo%20bar", Secret: complexSecret}, TokenEndpointAuthMethod: "client_secret_post"},
 			form:   url.Values{"client_id": []string{"!foo%20bar"}, "client_secret": []string{complexSecretRaw}},


### PR DESCRIPTION
The existing client authentication code treats an empty client_secret
query parameter to be equivalent to "none" authentication instead of
"client_secret_post."

This change updates the basic auth check to be consistent with this.
That is, an empty secret via the basic auth header is considered to
mean "none" instead of "client_secret_basic."

The "golang.org/x/oauth2" library probes for both methods of
authentication, starting with the basic auth header approach first.

As required, both client ID and secret are encoded in one header:

https://github.com/golang/oauth2/blob/ee480838109b20d468babcb00b7027c82f962065/internal/token.go#L174-L176

Since this code path is taken regardless of if the client is public
or confidential, without this change, it results in an error in the
fosite code.  Since the request fails, the library code simply tries
with the other approach, which works because the client secret is
empty.  Needless to say, it is inefficient to force public clients
to make multiple requests.

Signed-off-by: Monis Khan <mok@vmware.com>

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [ ] I have added necessary documentation within the code base (if
      appropriate).