### PR TITLE
feat: adds `web_message` response

### DIFF
--- a/authorize_error.go
+++ b/authorize_error.go
@@ -69,6 +69,10 @@ func (f *Fosite) WriteAuthorizeError(rw http.ResponseWriter, ar AuthorizeRequest
 		rw.Header().Set("Content-Type", "text/html;charset=UTF-8")
 		WriteAuthorizeFormPostResponse(redirectURI.String(), errors, GetPostFormHTMLTemplate(*f), rw)
 		return
+	} else if ar.GetResponseMode() == ResponseModeWebMessage {
+		rw.Header().Set("Content-Type", "text/html;charset=UTF-8")
+		WriteAuthorizeFormPostResponse(redirectURI.String(), errors, GetPostFormHTMLTemplate(*f), rw)
+		return
 	} else if ar.GetResponseMode() == ResponseModeFragment {
 		redirectURIString = redirectURI.String() + "#" + errors.Encode()
 	} else {

--- a/authorize_request.go
+++ b/authorize_request.go
@@ -28,10 +28,11 @@ import (
 type ResponseModeType string
 
 const (
-	ResponseModeDefault  = ResponseModeType("")
-	ResponseModeFormPost = ResponseModeType("form_post")
-	ResponseModeQuery    = ResponseModeType("query")
-	ResponseModeFragment = ResponseModeType("fragment")
+	ResponseModeDefault    = ResponseModeType("")
+	ResponseModeFormPost   = ResponseModeType("form_post")
+	ResponseModeQuery      = ResponseModeType("query")
+	ResponseModeFragment   = ResponseModeType("fragment")
+	ResponseModeWebMessage = ResponseModeType("web_message")
 )
 
 // AuthorizeRequest is an implementation of AuthorizeRequester

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -238,6 +238,8 @@ func (f *Fosite) ParseResponseMode(r *http.Request, request *AuthorizeRequest) e
 		request.ResponseMode = ResponseModeQuery
 	case string(ResponseModeFormPost):
 		request.ResponseMode = ResponseModeFormPost
+	case string(ResponseModeWebMessage):
+		request.ResponseMode = ResponseModeWebMessage
 	default:
 		rm := ResponseModeType(responseMode)
 		if f.ResponseModeHandler().ResponseModes().Has(rm) {

--- a/authorize_write.go
+++ b/authorize_write.go
@@ -38,6 +38,10 @@ func (f *Fosite) WriteAuthorizeResponse(rw http.ResponseWriter, ar AuthorizeRequ
 
 	redir := ar.GetRedirectURI()
 	switch rm := ar.GetResponseMode(); rm {
+	case ResponseModeWebMessage:
+		rw.Header().Set("Content-Type", "text/html;charset=UTF-8")
+		WriteWebMessageResponse(redir.String(), resp.GetParameters(), GetWebMessageResponse(*f), rw)
+		return
 	case ResponseModeFormPost:
 		//form_post
 		rw.Header().Add("Content-Type", "text/html;charset=UTF-8")

--- a/authorize_write_test.go
+++ b/authorize_write_test.go
@@ -212,8 +212,25 @@ func TestWriteAuthorizeResponse(t *testing.T) {
 				resp.EXPECT().GetHeader().Return(http.Header{"X-Bar": {"baz"}})
 				resp.EXPECT().GetParameters().Return(url.Values{"code": {"poz65kqoneu"}, "state": {"qm6dnsrn"}})
 
-				rw.EXPECT().Header().Return(header).AnyTimes()
+				rw.EXPECT().Header().Return(header).Times(2)
 				rw.EXPECT().Write(gomock.Any()).AnyTimes()
+			},
+			expect: func() {
+				assert.Equal(t, "text/html;charset=UTF-8", header.Get("Content-Type"))
+			},
+		},
+
+		{
+			setup: func() {
+				redir, _ := url.Parse("https://foobar.com/?foo=bar")
+				ar.EXPECT().GetRedirectURI().Return(redir).AnyTimes()
+				ar.EXPECT().GetResponseMode().Return(ResponseModeWebMessage).AnyTimes()
+				resp.EXPECT().GetParameters().Return(url.Values{"code": {"code123"}, "state": {"state123"}}).AnyTimes()
+				resp.EXPECT().GetHeader().Return(http.Header{})
+
+				rw.EXPECT().Header().Return(header).Times(2)
+				rw.EXPECT().Write(gomock.Any()).AnyTimes()
+
 			},
 			expect: func() {
 				assert.Equal(t, "text/html;charset=UTF-8", header.Get("Content-Type"))

--- a/compose/compose.go
+++ b/compose/compose.go
@@ -75,6 +75,7 @@ func Compose(config *Config, storage interface{}, strategy interface{}, hasher f
 		ResponseModeHandlerExtension: config.ResponseModeHandlerExtension,
 		MessageCatalog:               config.MessageCatalog,
 		FormPostHTMLTemplate:         config.FormPostHTMLTemplate,
+		WebMessageHTMLTemplate:       config.WebMessageHTMLTemplate,
 	}
 
 	for _, factory := range factories {

--- a/compose/config.go
+++ b/compose/config.go
@@ -125,6 +125,9 @@ type Config struct {
 
 	// FormPostHTMLTemplate sets html template for rendering the authorization response when the request has response_mode=form_post.
 	FormPostHTMLTemplate *template.Template
+
+	// WebMessageHTMLTemplate sets html template for rendering the authorization response when the request has response_mode=web_message.
+	WebMessageHTMLTemplate *template.Template
 }
 
 // GetScopeStrategy returns the scope strategy to be used. Defaults to glob scope strategy.

--- a/fosite.go
+++ b/fosite.go
@@ -113,6 +113,9 @@ type Fosite struct {
 	// FormPostHTMLTemplate sets html template for rendering the authorization response when the request has response_mode=form_post. Defaults to fosite.FormPostDefaultTemplate
 	FormPostHTMLTemplate *template.Template
 
+	// WebMessageHTMLTemplate sets the html template used for response_mode=web_message. Defaults to fosite.WebMessageHTMLTemplate
+	WebMessageHTMLTemplate *template.Template
+
 	// ClientAuthenticationStrategy provides an extension point to plug a strategy to authenticate clients
 	ClientAuthenticationStrategy ClientAuthenticationStrategy
 


### PR DESCRIPTION
This change introduces the `web_message` response type, defined in draft draft-sakimura-oauth-wmrm-00: https://datatracker.ietf.org/doc/html/draft-sakimura-oauth-wmrm-00

I realize that this is a non-standardized feature but quite a few providers currently offer this, specifically for supporting SPAs. The benefit of this approach is that the root window does not need to change the location for token retrieval and 'refreshes' .

## Related Issue or Design Document

Issue: #657 


## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA. _(CLA assistant doesn't seem to be working atm but I'll update ASAP)._
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

If this is a feature that will go upstream I'll write some integration tests.

