### PR TITLE
fix: [#630] Use the correct algorithm for at_hash and c_hash

### DIFF
--- a/handler/openid/flow_implicit.go
+++ b/handler/openid/flow_implicit.go
@@ -23,7 +23,6 @@ package openid
 
 import (
 	"context"
-	"encoding/base64"
 
 	"github.com/ory/x/errorsx"
 
@@ -93,12 +92,12 @@ func (c *OpenIDConnectImplicitHandler) HandleAuthorizeEndpointRequest(ctx contex
 		}
 
 		ar.SetResponseTypeHandled("token")
-		hash, err := c.RS256JWTStrategy.Hash(ctx, []byte(resp.GetParameters().Get("access_token")))
+		hash, err := c.ComputeHash(ctx, sess, resp.GetParameters().Get("access_token"))
 		if err != nil {
 			return err
 		}
 
-		claims.AccessTokenHash = base64.RawURLEncoding.EncodeToString([]byte(hash[:c.RS256JWTStrategy.GetSigningMethodLength()/2]))
+		claims.AccessTokenHash = hash
 	} else {
 		resp.AddParameter("state", ar.GetState())
 	}

--- a/handler/openid/helper.go
+++ b/handler/openid/helper.go
@@ -95,8 +95,7 @@ func (i *IDTokenHandleHelper) ComputeHash(ctx context.Context, sess Session, tok
 	var err error
 	hashSize := 256
 	if alg, ok := sess.IDTokenHeaders().Get("alg").(string); ok {
-		hashSize, err = strconv.Atoi(alg[2:])
-		if err != nil {
+		if hashSize, err = strconv.Atoi(alg[2:]); err != nil {
 			hashSize = 256
 		}
 	}

--- a/handler/openid/helper.go
+++ b/handler/openid/helper.go
@@ -93,7 +93,7 @@ func (i *IDTokenHandleHelper) IssueExplicitIDToken(ctx context.Context, ar fosit
 func (i *IDTokenHandleHelper) ComputeHash(ctx context.Context, sess Session, token string) (string, error) {
 	var err error
 	hash := sha256.New()
-	if alg, ok := sess.IDTokenHeaders().Get("alg").(string); ok {
+	if alg, ok := sess.IDTokenHeaders().Get("alg").(string); ok && len(alg) > 2 {
 		if hashSize, err := strconv.Atoi(alg[2:]); err == nil {
 			if hashSize == 384 {
 				hash = sha512.New384()

--- a/handler/openid/helper_test.go
+++ b/handler/openid/helper_test.go
@@ -159,3 +159,45 @@ func TestGetAccessTokenHashWithDifferentKeyLength(t *testing.T) {
 	hash := h.GetAccessTokenHash(nil, req, resp)
 	assert.Equal(t, "VNX38yiOyeqBPheW5jDsWQKa6IjJzK66", hash)
 }
+
+func TestGetAccessTokenHashWithBadAlg(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	req := internal.NewMockAccessRequester(ctrl)
+	resp := internal.NewMockAccessResponder(ctrl)
+
+	defer ctrl.Finish()
+
+	headers := &jwt.Headers{
+		Extra: map[string]interface{}{
+			"alg": "R",
+		},
+	}
+	req.EXPECT().GetSession().Return(&DefaultSession{Headers: headers})
+	resp.EXPECT().GetAccessToken().Return("7a35f818-9164-48cb-8c8f-e1217f44228431c41102-d410-4ed5-9276-07ba53dfdcd8")
+
+	h := &IDTokenHandleHelper{IDTokenStrategy: strat}
+
+	hash := h.GetAccessTokenHash(nil, req, resp)
+	assert.Equal(t, "Zfn_XBitThuDJiETU3OALQ", hash)
+}
+
+func TestGetAccessTokenHashWithMissingKeyLength(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	req := internal.NewMockAccessRequester(ctrl)
+	resp := internal.NewMockAccessResponder(ctrl)
+
+	defer ctrl.Finish()
+
+	headers := &jwt.Headers{
+		Extra: map[string]interface{}{
+			"alg": "RS",
+		},
+	}
+	req.EXPECT().GetSession().Return(&DefaultSession{Headers: headers})
+	resp.EXPECT().GetAccessToken().Return("7a35f818-9164-48cb-8c8f-e1217f44228431c41102-d410-4ed5-9276-07ba53dfdcd8")
+
+	h := &IDTokenHandleHelper{IDTokenStrategy: strat}
+
+	hash := h.GetAccessTokenHash(nil, req, resp)
+	assert.Equal(t, "Zfn_XBitThuDJiETU3OALQ", hash)
+}

--- a/handler/openid/helper_test.go
+++ b/handler/openid/helper_test.go
@@ -130,10 +130,32 @@ func TestGetAccessTokenHash(t *testing.T) {
 
 	defer ctrl.Finish()
 
+	req.EXPECT().GetSession().Return(nil)
 	resp.EXPECT().GetAccessToken().Return("7a35f818-9164-48cb-8c8f-e1217f44228431c41102-d410-4ed5-9276-07ba53dfdcd8")
 
 	h := &IDTokenHandleHelper{IDTokenStrategy: strat}
 
 	hash := h.GetAccessTokenHash(nil, req, resp)
 	assert.Equal(t, "Zfn_XBitThuDJiETU3OALQ", hash)
+}
+
+func TestGetAccessTokenHashWithDifferentKeyLength(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	req := internal.NewMockAccessRequester(ctrl)
+	resp := internal.NewMockAccessResponder(ctrl)
+
+	defer ctrl.Finish()
+
+	headers := &jwt.Headers{
+		Extra: map[string]interface{}{
+			"alg": "RS384",
+		},
+	}
+	req.EXPECT().GetSession().Return(&DefaultSession{Headers: headers})
+	resp.EXPECT().GetAccessToken().Return("7a35f818-9164-48cb-8c8f-e1217f44228431c41102-d410-4ed5-9276-07ba53dfdcd8")
+
+	h := &IDTokenHandleHelper{IDTokenStrategy: strat}
+
+	hash := h.GetAccessTokenHash(nil, req, resp)
+	assert.Equal(t, "VNX38yiOyeqBPheW5jDsWQKa6IjJzK66", hash)
 }


### PR DESCRIPTION
## Related Issue or Design Document

The defect is described in #630 along with the discussion.

1. `at_hash`: https://openid.net/specs/openid-connect-core-1_0.html#CodeIDToken
2. `c_hash`: https://openid.net/specs/openid-connect-core-1_0.html#HybridIDToken

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

There are two key changes:

1. Standardize computation of the hash across the different flows
2. Introduce `ComputeHash` that extracts the algorithm, if available, from the openid.Session header and computes the hash. It falls back to 256 key length to retain backward compatibility.