### PR TITLE
docs: add deprecation to communicate ropc discouragement

### DIFF
--- a/compose/compose_oauth2.go
+++ b/compose/compose_oauth2.go
@@ -88,6 +88,10 @@ func OAuth2AuthorizeImplicitFactory(config *Config, storage interface{}, strateg
 
 // OAuth2ResourceOwnerPasswordCredentialsFactory creates an OAuth2 resource owner password credentials grant handler and registers
 // an access token, refresh token and authorize code validator.
+//
+// Deprecated: This factory is deprecated as a means to communicate that the ROPC grant type is widely discouraged and
+// is at the time of this writing going to be omitted in the OAuth 2.1 spec. For more information on why this grant type
+// is discouraged see: https://www.scottbrady91.com/oauth/why-the-resource-owner-password-credentials-grant-type-is-not-authentication-nor-suitable-for-modern-applications
 func OAuth2ResourceOwnerPasswordCredentialsFactory(config *Config, storage interface{}, strategy interface{}) interface{} {
 	return &oauth2.ResourceOwnerPasswordCredentialsGrantHandler{
 		ResourceOwnerPasswordCredentialsGrantStorage: storage.(oauth2.ResourceOwnerPasswordCredentialsGrantStorage),

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -32,6 +32,9 @@ import (
 	"github.com/ory/fosite"
 )
 
+// Deprecated: This handler is deprecated as a means to communicate that the ROPC grant type is widely discouraged and
+// is at the time of this writing going to be omitted in the OAuth 2.1 spec. For more information on why this grant type
+// is discouraged see: https://www.scottbrady91.com/oauth/why-the-resource-owner-password-credentials-grant-type-is-not-authentication-nor-suitable-for-modern-applications
 type ResourceOwnerPasswordCredentialsGrantHandler struct {
 	// ResourceOwnerPasswordCredentialsGrantStorage is used to persist session data across requests.
 	ResourceOwnerPasswordCredentialsGrantStorage ResourceOwnerPasswordCredentialsGrantStorage


### PR DESCRIPTION
This adds godoc deprecations to the compose.OAuth2ResourceOwnerPasswordCredentialsFactory and oauth2.ResourceOwnerPasswordCredentialsGrantHandler in order to clearly communicate the discouragement of the ROPC grant type to users implementing this library.

## Related Issue or Design Document

https://github.com/ory/fosite/issues/650#issuecomment-1100768170

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md)
      and signed the CLA.
- [x] I have referenced an issue containing the design document if my change
      introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security
      vulnerability. If this pull request addresses a security vulnerability, I
      confirm that I got green light (please contact
      [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push
      the changes.
- [x] I have added tests that prove my fix is effective or that my feature
      works.
- [x] I have added necessary documentation within the code base (if
      appropriate).

## Further comments

No testing is applicable to this change as far as I am aware.