### PR TITLE
Fix bug which prevents the `at_hash` claim from appearing in the ID token from an authcode grant for some storage implementations

### DIFF
--- a/handler/openid/flow_explicit_token.go
+++ b/handler/openid/flow_explicit_token.go
@@ -55,7 +55,7 @@ func (c *OpenIDConnectExplicitHandler) PopulateTokenEndpointResponse(ctx context
 		return errorsx.WithStack(fosite.ErrUnauthorizedClient.WithHint("The OAuth 2.0 Client is not allowed to use the authorization grant \"authorization_code\"."))
 	}
 
-	sess, ok := requester.GetSession().(Session)
+	sess, ok := authorize.GetSession().(Session)
 	if !ok {
 		return errorsx.WithStack(fosite.ErrServerError.WithDebug("Failed to generate id token because session must be of type fosite/handler/openid.Session."))
 	}


### PR DESCRIPTION
fosite has a bug which may prevent the `at_hash` claim from appearing in the ID token from an authcode grant. The bug is in the `PopulateTokenEndpointResponse` method of `OpenIDConnectExplicitHandler`. The bug will only impact systems which implement the storage interfaces by returning different struct instances.

There are two sessions at play the `PopulateTokenEndpointResponse` method of `OpenIDConnectExplicitHandler`:
1. The `requester` parameter contains a session. In typical usage of fosite, `requester` is created by a custom implementation of the token endpoint to represent the current request to the token endpoint. The token endpoint calls `NewAccessRequest`, which calls `HandleTokenEndpointRequest` on each token endpoint handler. The `AuthorizeExplicitGrantHandler`’s implementation of that function performs a storage lookup using `c.CoreStorage.GetAuthorizeCodeSession(ctx, signature, request.GetSession())` to find the authorize request for the given authcode. It then sets that session from storage onto the new request using `request.SetSession(authorizeRequest.GetSession())` (see flow_authorize_code_token.go).
2. The second session is looked up directly by the `PopulateTokenEndpointResponse` method by calling `c.OpenIDConnectRequestStorage.GetOpenIDConnectSession(ctx, requester.GetRequestForm().Get("code"), requester)`.

These two sessions may not necessarily be the same instance (same pointer), depending on the implementation of the storage interfaces. Fosite should not assume that they will be the same instance, since they came from different calls to storage interfaces.

The last line of the `PopulateTokenEndpointResponse` method of `OpenIDConnectExplicitHandler` uses the `authorize` variable to create the ID token. The access token hash which is computed a few lines above must be set onto the `authorize` variable’s session in order to have it available during the creation of the ID token. The fix is to simply use the `authorize` variable’s session.

Note that the bug did not impact the refresh grant, where the ID token does correctly include the `at_hash` claim.

The unit tests in `flow_explicit_token_test.go` have been updated to use two different instances of sessions to demonstrate the issue. They have also been updated to be able to run independently without polluting each other, by moving the test setup into the loop and by having each test perform its own test setup. Before the fix, many of these tests fail when run individually because they were accidentally relying on the pollution caused by each previous test in the same file. A new test case was also added to backfill for a case (unrelated to the bug) which was not previously covered.

The integration tests were not changed. They do not catch the bug because they use the storage implementation in `memory.go` which always returns the same session instance for the two relevant sessions. It might be nice if this storage implementation always returned a copy of the session (always different instances) but it is not obvious how to enhance the code in this way.

Note that the unit and integration tests of the Pinniped project demonstrate the bug. Pinniped uses fosite to implement a partial OIDC provider which supports the OIDC authcode and refresh flows. The ID tokens returned by the authcode grant never includes the `at_hash` claim, but the ID tokens returned by the refresh grant do include the claim. The changes that would be made to the project’s tests if this bug fix is accepted into fosite are shown in [Pinniped PR 1165](https://github.com/vmware-tanzu/pinniped/pull/1165). The Pinniped project has a [unit test](https://github.com/vmware-tanzu/pinniped/blob/018bdacc6d574e4387e19d1f6b73c354462d7e3a/internal/oidc/token/token_handler_test.go#L1082) which performs an authcode grant and then performs a refresh grant, and the behavior of the fosite library can easily be observed by adding breakpoints in the relevant fosite code and then running the test in the debugger.

## Related Issue or Design Document

None.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation within the code base (if appropriate).

## Further comments

None.