### PR TITLE
feat: Add support for ClientSecretValidationStrategyProvider

### DIFF
--- a/config.go
+++ b/config.go
@@ -297,3 +297,9 @@ type PushedAuthorizeRequestConfigProvider interface {
 	// must contain the PAR request_uri.
 	EnforcePushedAuthorize(ctx context.Context) bool
 }
+
+// ClientSecretValidationStrategyProvider returns the provider for configuring the client secret validation strategy.
+type ClientSecretValidationStrategyProvider interface {
+	// GetClientSecretValidationStrategy returns the client secret validation strategy.
+	GetClientSecretValidationStrategy(ctx context.Context) ClientSecretValidationStrategy
+}

--- a/config_default.go
+++ b/config_default.go
@@ -80,6 +80,7 @@ var (
 	_ RevocationHandlersProvider                   = (*Config)(nil)
 	_ PushedAuthorizeRequestHandlersProvider       = (*Config)(nil)
 	_ PushedAuthorizeRequestConfigProvider         = (*Config)(nil)
+	_ ClientSecretValidationStrategyProvider       = (*Config)(nil)
 )
 
 type Config struct {
@@ -230,6 +231,9 @@ type Config struct {
 
 	// IsPushedAuthorizeEnforced enforces pushed authorization request for /authorize
 	IsPushedAuthorizeEnforced bool
+
+	// ClientSecretValidationStrategy indicates the Strategy to validate client secrets
+	ClientSecretValidationStrategy ClientSecretValidationStrategy
 }
 
 func (c *Config) GetGlobalSecret(ctx context.Context) []byte {
@@ -505,4 +509,10 @@ func (c *Config) GetPushedAuthorizeContextLifespan(ctx context.Context) time.Dur
 // must contain the PAR request_uri.
 func (c *Config) EnforcePushedAuthorize(ctx context.Context) bool {
 	return c.IsPushedAuthorizeEnforced
+}
+
+
+// GetClientSecretValidationStrategy returns the client secret validation strategy.
+func (c *Config) GetClientSecretValidationStrategy(ctx context.Context) ClientSecretValidationStrategy {
+	return c.ClientSecretValidationStrategy
 }

--- a/fosite.go
+++ b/fosite.go
@@ -149,6 +149,7 @@ type Configurator interface {
 	TokenIntrospectionHandlersProvider
 	RevocationHandlersProvider
 	UseLegacyErrorFormatProvider
+	ClientSecretValidationStrategyProvider
 }
 
 func NewOAuth2Provider(s Storage, c Configurator) *Fosite {


### PR DESCRIPTION
This pull request intends to fix #693 by creating a `ClientSecretValidationStrategyProvider`. It's a simple solution for the problem described on the issue. 

The solution adopted was adding a `ClientSecretValidationStrategyProvider` to the `Configurator` interface. The default `Config` object implements the method that returns the `Strategy`. That `Strategy` method might be overridden instantiating a `Config` before the Fosite Compose.

It doesn't introduce any breaking changes since the default strategy is the same one as before. All previous unit tests still pass and new ones were added to ensure that the strategy override is working as intended.

## Checklist

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [X] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added necessary documentation within the code base (if appropriate).
