### PR TITLE
Fix: Use proper scopes in refresh token handler

### DIFF
--- a/integration/refresh_token_grant_test.go
+++ b/integration/refresh_token_grant_test.go
@@ -150,15 +150,17 @@ func TestRefreshTokenFlow(t *testing.T) {
 			},
 		},
 		{
-			description: "should fail because scope is no longer allowed",
+			description: "should pass even if client scope is no longer allowed",
 			setup: func(t *testing.T) {
 				oauthClient.ClientID = refreshCheckClient.ID
 				oauthClient.Scopes = []string{"fosite", "offline", "openid"}
 			},
 			beforeRefresh: func(t *testing.T) {
-				refreshCheckClient.Scopes = []string{"offline", "openid"}
+				// The client scopes are irrelevant after the refresh token has been granted.
+				refreshCheckClient.Scopes = nil
 			},
-			pass: false,
+			pass:  true,
+			check: func(t *testing.T, original, refreshed *oauth2.Token, or, rr *introspectionResponse) {},
 		},
 		{
 			description: "should fail because audience is no longer allowed",


### PR DESCRIPTION
Fixes #696 

The token refresh handler currently has two issues related to scopes:
1. It does not read or honor the optional `scope` form parameter
2. It defaults to the current `client` scopes, rather than the originally `granted` scopes. One issue related to this is that if the client scopes are narrowed, then the existing refresh tokens may fail to refresh, even if the user originally consented to those scopes. 

This PR fixes the OAuth2 token refresh handler to:
- Read and use the optional 'scope' form parameter, if present.
- Otherwise default to requesting the originally granted scopes.
    
The token refresh handler endpoint should be completely agnostic of:
- The originally **requested** scopes
- The **client scopes** (both current and past client scopes)

## Related Issue or Design Document

#696


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
