### PR TITLE
fix: fix server error of handling refresh token reuse

### DIFF
--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -66,7 +66,7 @@ func (c *RefreshTokenGrantHandler) HandleTokenEndpointRequest(ctx context.Contex
 	if errors.Is(err, fosite.ErrInactiveToken) {
 		// Detected refresh token reuse
 		if rErr := c.handleRefreshTokenReuse(ctx, signature, originalRequest); rErr != nil {
-			return errorsx.WithStack(fosite.ErrServerError.WithWrap(rErr).WithDebug(rErr.Error()))
+			return errorsx.WithStack(rErr)
 		}
 
 		return errorsx.WithStack(fosite.ErrInactiveToken.WithWrap(err).WithDebug(err.Error()))


### PR DESCRIPTION
Fix server error of handling refresh token reuse.
When refresh token requests come same time, some times server error is occurred. (related to https://github.com/ory/hydra/pull/3207 )

This error is client matter. So I want to fix it as client error.

### Log

```json
{
  "error": {
    "debug": "invalid_request",
    "reason": "",
    "status": "Internal Server Error",
    "status_code": 500
  }
}
```

<details>
  <summary>StackTrace(debug mode)</summary>

```
github.com/ory/x/errorsx.WithStack
	/go/pkg/mod/github.com/ory/x@v0.0.368/errorsx/errors.go:38
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).handleRefreshTokenEndpointStorageError
	/go/pkg/mod/github.com/ory/fosite@v0.42.3-0.20220729111320-05d71b23559c/handler/oauth2/flow_refresh.go:241
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).handleRefreshTokenReuse.func1
	/go/pkg/mod/github.com/ory/fosite@v0.42.3-0.20220729111320-05d71b23559c/handler/oauth2/flow_refresh.go:207
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).handleRefreshTokenReuse
	/go/pkg/mod/github.com/ory/fosite@v0.42.3-0.20220729111320-05d71b23559c/handler/oauth2/flow_refresh.go:211
github.com/ory/fosite/handler/oauth2.(*RefreshTokenGrantHandler).HandleTokenEndpointRequest
	/go/pkg/mod/github.com/ory/fosite@v0.42.3-0.20220729111320-05d71b23559c/handler/oauth2/flow_refresh.go:69
github.com/ory/fosite.(*Fosite).NewAccessRequest
	/go/pkg/mod/github.com/ory/fosite@v0.42.3-0.20220729111320-05d71b23559c/access_request_handler.go:108
github.com/ory/hydra/oauth2.(*Handler).TokenHandler
	/project/oauth2/handler.go:584
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/julienschmidt/httprouter.(*Router).Handler.func1
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:275
github.com/julienschmidt/httprouter.(*Router).ServeHTTP
	/go/pkg/mod/github.com/julienschmidt/httprouter@v1.3.0/router.go:387
github.com/urfave/negroni.Wrap.func1
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:46
github.com/urfave/negroni.HandlerFunc.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/ory/hydra/x.RejectInsecureRequests.func1
	/project/x/tls_termination.go:90
github.com/urfave/negroni.HandlerFunc.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:29
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
github.com/ory/x/metricsx.(*Service).ServeHTTP
	/go/pkg/mod/github.com/ory/x@v0.0.368/metricsx/middleware.go:275
github.com/urfave/negroni.middleware.ServeHTTP
	/go/pkg/mod/github.com/urfave/negroni@v1.0.0/negroni.go:38
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerResponseSize.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:198
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerCounter.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:101
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:68
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerDuration.func2
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:76
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/prometheus/client_golang/prometheus/promhttp.InstrumentHandlerRequestSize.func1
	/go/pkg/mod/github.com/prometheus/client_golang@v1.11.0/prometheus/promhttp/instrument_server.go:165
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
github.com/ory/x/prometheusx.Metrics.instrumentHandlerStatusBucket.func1
	/go/pkg/mod/github.com/ory/x@v0.0.368/prometheusx/metrics.go:108
net/http.HandlerFunc.ServeHTTP
	/usr/local/go/src/net/http/server.go:2084
```

</details>

## Related Issue or Design Document

related to https://github.com/ory/hydra/pull/3207

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
      If this pull request addresses a security vulnerability,
      I confirm that I got green light (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
