### PR TITLE
fix: missing init of the par sessions in the example store

### DIFF
--- a/storage/memory.go
+++ b/storage/memory.go
@@ -160,6 +160,7 @@ func NewExampleStore() *MemoryStore {
 		AccessTokenRequestIDs:  map[string]string{},
 		RefreshTokenRequestIDs: map[string]string{},
 		IssuerPublicKeys:       map[string]IssuerPublicKeys{},
+		PARSessions:            map[string]fosite.AuthorizeRequester{},
 	}
 }
 


### PR DESCRIPTION
fix: The example storage is missing the initialization of the PARsessions. So when using that example storage with the PAR endpoints the application will panic with an error that it tried to assign something to a nil pointer/map

This fix initializes the par map.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
