### PR TITLE
fix: when TokenRevocationStorage.GetRefreshTokenSession return fosite.ErrInactiveToken, handle fosite.ErrInactiveToken

### DIFF
--- a/handler/oauth2/revocation.go
+++ b/handler/oauth2/revocation.go
@@ -80,8 +80,9 @@ func (r *TokenRevocationHandler) RevokeToken(ctx context.Context, token string, 
 }
 
 func storeErrorsToRevocationError(err1, err2 error) error {
-	// both errors are 404 or nil <=> the token is revoked
-	if (errors.Is(err1, fosite.ErrNotFound) || err1 == nil) && (errors.Is(err2, fosite.ErrNotFound) || err2 == nil) {
+	// both errors are fosite.ErrNotFound and fosite.ErrInactiveToken or nil <=> the token is revoked
+	if (errors.Is(err1, fosite.ErrNotFound) || errors.Is(err1, fosite.ErrInactiveToken) || err1 == nil) &&
+		(errors.Is(err2, fosite.ErrNotFound) || errors.Is(err2, fosite.ErrInactiveToken) || err2 == nil) {
 		return nil
 	}
 

--- a/handler/oauth2/revocation_test.go
+++ b/handler/oauth2/revocation_test.go
@@ -162,6 +162,35 @@ func TestRevokeToken(t *testing.T) {
 			},
 		},
 		{
+
+			description: "should pass - refresh token discovery first; refresh token is inactive",
+			expectErr:   nil,
+			client:      &fosite.DefaultClient{ID: "bar"},
+			mock: func() {
+				token = "foo"
+				tokenType = fosite.RefreshToken
+				rtStrat.EXPECT().RefreshTokenSignature(gomock.Any(), token)
+				store.EXPECT().GetRefreshTokenSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fosite.ErrInactiveToken)
+
+				atStrat.EXPECT().AccessTokenSignature(gomock.Any(), token)
+				store.EXPECT().GetAccessTokenSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fosite.ErrNotFound)
+			},
+		},
+		{
+			description: "should pass - access token discovery first; refresh token is inactive",
+			expectErr:   nil,
+			client:      &fosite.DefaultClient{ID: "bar"},
+			mock: func() {
+				token = "foo"
+				tokenType = fosite.AccessToken
+				atStrat.EXPECT().AccessTokenSignature(gomock.Any(), token)
+				store.EXPECT().GetAccessTokenSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fosite.ErrNotFound)
+
+				rtStrat.EXPECT().RefreshTokenSignature(gomock.Any(), token)
+				store.EXPECT().GetRefreshTokenSession(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, fosite.ErrInactiveToken)
+			},
+		},
+		{
 			description: "should fail - store error for access token get",
 			expectErr:   fosite.ErrTemporarilyUnavailable,
 			client:      &fosite.DefaultClient{ID: "bar"},


### PR DESCRIPTION
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

When TokenRevocationStorage.GetRefreshTokenSession return fosite.ErrInactiveToken, handle fosite.ErrInactiveToken.


## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

related to: https://github.com/ory/fosite/issues/709
(Sorry, it may not be a related issue.)

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
