### PR TITLE
feat: customizable token prefix

### DIFF
--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -22,6 +22,7 @@ type CommonStrategy struct {
 type HMACSHAStrategyConfigurator interface {
 	fosite.AccessTokenLifespanProvider
 	fosite.RefreshTokenLifespanProvider
+	fosite.TokenPrefixProvider
 	fosite.AuthorizeCodeLifespanProvider
 	fosite.TokenEntropyProvider
 	fosite.GlobalSecretProvider

--- a/config.go
+++ b/config.go
@@ -34,6 +34,12 @@ type AccessTokenLifespanProvider interface {
 	GetAccessTokenLifespan(ctx context.Context) time.Duration
 }
 
+// TokenPrefixProvider returns the provider for configuring the token prefix.
+type TokenPrefixProvider interface {
+	// GetAccessTokenLifespan returns the access token lifespan.
+	GetTokenPrefixProvider(ctx context.Context) string
+}
+
 // IDTokenLifespanProvider returns the provider for configuring the ID token lifespan.
 type IDTokenLifespanProvider interface {
 	// GetIDTokenLifespan returns the ID token lifespan.

--- a/config_default.go
+++ b/config_default.go
@@ -26,6 +26,7 @@ var (
 	_ AuthorizeCodeLifespanProvider                = (*Config)(nil)
 	_ RefreshTokenLifespanProvider                 = (*Config)(nil)
 	_ AccessTokenLifespanProvider                  = (*Config)(nil)
+	_ TokenPrefixProvider                          = (*Config)(nil)
 	_ ScopeStrategyProvider                        = (*Config)(nil)
 	_ AudienceStrategyProvider                     = (*Config)(nil)
 	_ RedirectSecureCheckerProvider                = (*Config)(nil)
@@ -71,6 +72,9 @@ type Config struct {
 	// RefreshTokenLifespan sets how long a refresh token is going to be valid. Defaults to 30 days. Set to -1 for
 	// refresh tokens that never expire.
 	RefreshTokenLifespan time.Duration
+
+	// TokenPrefix sets the prefix for hmac tokens to help identify tokens. Defaults to "ory"
+	TokenPrefix string
 
 	// AuthorizeCodeLifespan sets how long an authorize code is going to be valid. Defaults to fifteen minutes.
 	AuthorizeCodeLifespan time.Duration
@@ -326,6 +330,13 @@ func (c *Config) GetOmitRedirectScopeParam(ctx context.Context) bool {
 
 func (c *Config) GetAccessTokenIssuer(ctx context.Context) string {
 	return c.AccessTokenIssuer
+}
+
+func (c *Config) GetTokenPrefixProvider(_ context.Context) string {
+	if c.TokenPrefix == "" {
+		c.TokenPrefix = "ory"
+	}
+	return c.TokenPrefix
 }
 
 func (c *Config) GetJWTScopeField(ctx context.Context) jwt.JWTScopeFieldEnum {

--- a/fosite.go
+++ b/fosite.go
@@ -106,6 +106,7 @@ type Configurator interface {
 	RefreshTokenScopesProvider
 	AccessTokenLifespanProvider
 	RefreshTokenLifespanProvider
+	TokenPrefixProvider
 	AuthorizeCodeLifespanProvider
 	TokenEntropyProvider
 	RotatedGlobalSecretsProvider

--- a/handler/oauth2/flow_authorize_code_auth.go
+++ b/handler/oauth2/flow_authorize_code_auth.go
@@ -29,6 +29,7 @@ type AuthorizeExplicitGrantHandler struct {
 		fosite.AuthorizeCodeLifespanProvider
 		fosite.AccessTokenLifespanProvider
 		fosite.RefreshTokenLifespanProvider
+		fosite.TokenPrefixProvider
 		fosite.ScopeStrategyProvider
 		fosite.AudienceStrategyProvider
 		fosite.RedirectSecureCheckerProvider

--- a/handler/oauth2/flow_authorize_implicit.go
+++ b/handler/oauth2/flow_authorize_implicit.go
@@ -25,6 +25,7 @@ type AuthorizeImplicitGrantTypeHandler struct {
 
 	Config interface {
 		fosite.AccessTokenLifespanProvider
+		fosite.TokenPrefixProvider
 		fosite.ScopeStrategyProvider
 		fosite.AudienceStrategyProvider
 	}

--- a/handler/oauth2/flow_client_credentials.go
+++ b/handler/oauth2/flow_client_credentials.go
@@ -20,6 +20,7 @@ type ClientCredentialsGrantHandler struct {
 		fosite.ScopeStrategyProvider
 		fosite.AudienceStrategyProvider
 		fosite.AccessTokenLifespanProvider
+		fosite.TokenPrefixProvider
 	}
 }
 

--- a/handler/oauth2/flow_refresh.go
+++ b/handler/oauth2/flow_refresh.go
@@ -26,6 +26,7 @@ type RefreshTokenGrantHandler struct {
 	Config                 interface {
 		fosite.AccessTokenLifespanProvider
 		fosite.RefreshTokenLifespanProvider
+		fosite.TokenPrefixProvider
 		fosite.ScopeStrategyProvider
 		fosite.AudienceStrategyProvider
 		fosite.RefreshTokenScopesProvider

--- a/handler/oauth2/flow_resource_owner.go
+++ b/handler/oauth2/flow_resource_owner.go
@@ -30,6 +30,7 @@ type ResourceOwnerPasswordCredentialsGrantHandler struct {
 		fosite.RefreshTokenScopesProvider
 		fosite.RefreshTokenLifespanProvider
 		fosite.AccessTokenLifespanProvider
+		fosite.TokenPrefixProvider
 	}
 }
 

--- a/handler/oauth2/helper.go
+++ b/handler/oauth2/helper.go
@@ -13,6 +13,7 @@ import (
 type HandleHelperConfigProvider interface {
 	fosite.AccessTokenLifespanProvider
 	fosite.RefreshTokenLifespanProvider
+	fosite.TokenPrefixProvider
 }
 
 type HandleHelper struct {

--- a/handler/oauth2/strategy_hmacsha_test.go
+++ b/handler/oauth2/strategy_hmacsha_test.go
@@ -178,3 +178,20 @@ func TestHMACAuthorizeCode(t *testing.T) {
 		})
 	}
 }
+
+func TestHMACTokenPrefix(t *testing.T) {
+	t.Run("PrefixToken", func(t *testing.T) {
+		hmacshaStrategy = HMACSHAStrategy{
+			Enigma: &hmac.HMACStrategy{Config: &fosite.Config{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")}},
+			Config: &fosite.Config{
+				AccessTokenLifespan:   time.Hour * 24,
+				AuthorizeCodeLifespan: time.Hour * 24,
+				TokenPrefix:           "abc",
+			},
+		}
+		token, signature, err := hmacshaStrategy.GenerateAccessToken(nil, &hmacValidCase)
+		assert.NoError(t, err)
+		assert.Equal(t, strings.Split(token, ".")[1], signature)
+		assert.Contains(t, token, "abc_at_")
+	})
+}

--- a/handler/openid/flow_hybrid.go
+++ b/handler/openid/flow_hybrid.go
@@ -27,6 +27,7 @@ type OpenIDConnectHybridHandler struct {
 		fosite.IDTokenLifespanProvider
 		fosite.MinParameterEntropyProvider
 		fosite.ScopeStrategyProvider
+		fosite.TokenPrefixProvider
 	}
 }
 

--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -32,6 +32,7 @@ var hmacStrategy = &oauth2.HMACSHAStrategy{
 			GlobalSecret: []byte("some-super-cool-secret-that-nobody-knows-nobody-knows"),
 		},
 	},
+	Config: &fosite.Config{},
 }
 
 type defaultSession struct {

--- a/handler/rfc7523/handler.go
+++ b/handler/rfc7523/handler.go
@@ -24,6 +24,7 @@ type Handler struct {
 
 	Config interface {
 		fosite.AccessTokenLifespanProvider
+		fosite.TokenPrefixProvider
 		fosite.TokenURLProvider
 		fosite.GrantTypeJWTBearerCanSkipClientAuthProvider
 		fosite.GrantTypeJWTBearerIDOptionalProvider


### PR DESCRIPTION
matching Hydra PR: https://github.com/ory/hydra/pull/3407

https://github.com/ory/fosite/pull/675 added `ory_at|pt|ac` prefixes to HMAC tokens. This is a good feature for detecting tokens in places they shouldn't exist. However, for security minded self-hosted implementations, it is often preferred to avoid underlying tooling providers. In this case, it is preferrable to be able to customize the `ory` name and replace it with another key. 

This PR adds ability to customize the token prefix before `at|pt|ac`. 

## Related Issue or Design Document
Related to https://github.com/ory/fosite/pull/675 and https://github.com/ory/hydra/issues/2845.

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments
For backwards compatibility for integrations that already upgraded, it continues to remove the ory specific prefix when trimming.
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
