### PR TITLE
feat: add the ability to set jwt header type

### DIFF
--- a/token/jwt/header.go
+++ b/token/jwt/header.go
@@ -14,7 +14,7 @@ func NewHeaders() *Headers {
 
 // ToMap will transform the headers to a map structure
 func (h *Headers) ToMap() map[string]interface{} {
-	var filter = map[string]bool{"alg": true, "typ": true}
+	var filter = map[string]bool{"alg": true}
 	var extra = map[string]interface{}{}
 
 	// filter known values from extra.

--- a/token/jwt/token.go
+++ b/token/jwt/token.go
@@ -109,7 +109,9 @@ func (t *Token) SignedString(k interface{}) (rawToken string, err error) {
 
 func unsignedToken(t *Token) (string, error) {
 	t.Header["alg"] = "none"
-	t.Header[string(JWTHeaderType)] = JWTHeaderTypeValue
+	if _, ok := t.Header[string(JWTHeaderType)]; !ok {
+		t.Header[string(JWTHeaderType)] = JWTHeaderTypeValue
+	}
 	hbytes, err := json.Marshal(&t.Header)
 	if err != nil {
 		return "", errorsx.WithStack(err)

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -22,32 +22,73 @@ import (
 )
 
 func TestUnsignedToken(t *testing.T) {
-	key := UnsafeAllowNoneSignatureType
-	token := NewWithClaims(SigningMethodNone, MapClaims{
-		"aud": "foo",
-		"exp": time.Now().UTC().Add(time.Hour).Unix(),
-		"iat": time.Now().UTC().Unix(),
-		"sub": "nestor",
-	})
-	rawToken, err := token.SignedString(key)
-	require.NoError(t, err)
-	require.NotEmpty(t, rawToken)
-	parts := strings.Split(rawToken, ".")
-	require.Len(t, parts, 3)
-	require.Empty(t, parts[2])
-	tk, err := jwt.ParseSigned(rawToken)
-	require.NoError(t, err)
-	require.Len(t, tk.Headers, 1)
-	require.Equal(t, "JWT", tk.Headers[0].ExtraHeaders[jose.HeaderKey("typ")])
+	var testCases = []struct {
+		name         string
+		jwtHeaders   map[string]interface{}
+		expectedType string
+	}{
+		{
+			name:         "set JWT as 'typ' when the the type is not specified in the headers",
+			jwtHeaders:   map[string]interface{}{},
+			expectedType: "JWT",
+		},
+		{
+			name:         "'typ' set explicitly",
+			jwtHeaders:   map[string]interface{}{"typ": "at+jwt"},
+			expectedType: "at+jwt",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			key := UnsafeAllowNoneSignatureType
+			token := NewWithClaims(SigningMethodNone, MapClaims{
+				"aud": "foo",
+				"exp": time.Now().UTC().Add(time.Hour).Unix(),
+				"iat": time.Now().UTC().Unix(),
+				"sub": "nestor",
+			})
+			token.Header = tc.jwtHeaders
+			rawToken, err := token.SignedString(key)
+			require.NoError(t, err)
+			require.NotEmpty(t, rawToken)
+			parts := strings.Split(rawToken, ".")
+			require.Len(t, parts, 3)
+			require.Empty(t, parts[2])
+			tk, err := jwt.ParseSigned(rawToken)
+			require.NoError(t, err)
+			require.Len(t, tk.Headers, 1)
+			require.Equal(t, tc.expectedType, tk.Headers[0].ExtraHeaders[jose.HeaderKey("typ")])
+		})
+	}
 }
 
 func TestJWTHeaders(t *testing.T) {
-	rawToken := makeSampleToken(nil, jose.RS256, gen.MustRSAKey())
-	tk, err := jwt.ParseSigned(rawToken)
-	require.NoError(t, err)
-	require.Len(t, tk.Headers, 1)
-	require.Equal(t, tk.Headers[0].Algorithm, "RS256")
-	require.Equal(t, "JWT", tk.Headers[0].ExtraHeaders[jose.HeaderKey("typ")])
+	var testCases = []struct {
+		name         string
+		jwtHeaders   map[string]interface{}
+		expectedType string
+	}{
+		{
+			name:         "set JWT as 'typ' when the the type is not specified in the headers",
+			jwtHeaders:   map[string]interface{}{},
+			expectedType: "JWT",
+		},
+		{
+			name:         "'typ' set explicitly",
+			jwtHeaders:   map[string]interface{}{"typ": "at+jwt"},
+			expectedType: "at+jwt",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawToken := makeSampleTokenWithCustomHeaders(nil, jose.RS256, tc.jwtHeaders, gen.MustRSAKey())
+			tk, err := jwt.ParseSigned(rawToken)
+			require.NoError(t, err)
+			require.Len(t, tk.Headers, 1)
+			require.Equal(t, tk.Headers[0].Algorithm, "RS256")
+			require.Equal(t, tc.expectedType, tk.Headers[0].ExtraHeaders[jose.HeaderKey("typ")])
+		})
+	}
 }
 
 var keyFuncError error = fmt.Errorf("error loading key")
@@ -409,6 +450,18 @@ func TestParser_Parse(t *testing.T) {
 
 func makeSampleToken(c MapClaims, m jose.SignatureAlgorithm, key interface{}) string {
 	token := NewWithClaims(m, c)
+	s, e := token.SignedString(key)
+
+	if e != nil {
+		panic(e.Error())
+	}
+
+	return s
+}
+
+func makeSampleTokenWithCustomHeaders(c MapClaims, m jose.SignatureAlgorithm, headers map[string]interface{}, key interface{}) string {
+	token := NewWithClaims(m, c)
+	token.Header = headers
 	s, e := token.SignedString(key)
 
 	if e != nil {


### PR DESCRIPTION
First, thank you for all your work on this library! 🙇 

We are implementing [RFC9068](https://datatracker.ietf.org/doc/rfc9068/) and during that we found the following issue: the JWT header's `typ` parameter is implicitly set to "JWT" inside token.go by the the `unsignedToken` function. Also the `ToMap` function filters out the `typ` as well and unfortunately it cannot be changed from the Session for example. And based on https://datatracker.ietf.org/doc/html/rfc9068#section-2.1-3 the `typ` must be set to `at+jwt`. 

This PR adds the ability to set the `typ` parameter from the `jwt.Headers` and when the `typ` is not set explicitly then the `typ` will be set to "JWT".

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
