### PR TITLE
chore: update go-jose to v3.0.0

### DIFF
--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -10,7 +10,7 @@ import (
 	"net/http"
 	"strings"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 
 	"github.com/ory/fosite/i18n"
 	"github.com/ory/fosite/token/jwt"

--- a/authorize_request_handler_oidc_request_test.go
+++ b/authorize_request_handler_oidc_request_test.go
@@ -16,9 +16,9 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/ory/fosite/token/jwt"
 )

--- a/client.go
+++ b/client.go
@@ -4,7 +4,7 @@
 package fosite
 
 import (
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 )
 
 // Client represents a client or an app.

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/ory/x/errorsx"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/pkg/errors"
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/ory/fosite/token/jwt"
 )

--- a/client_authentication_jwks_strategy.go
+++ b/client_authentication_jwks_strategy.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/ory/x/errorsx"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 )
 
 const defaultJWKSFetcherStrategyCachePrefix = "github.com/ory/fosite.DefaultJWKSFetcherStrategy:"

--- a/client_authentication_jwks_strategy_test.go
+++ b/client_authentication_jwks_strategy_test.go
@@ -17,9 +17,9 @@ import (
 
 	"github.com/ory/fosite/internal/gen"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
 )
 
 func initServerWithKey(t *testing.T) *httptest.Server {

--- a/client_authentication_test.go
+++ b/client_authentication_test.go
@@ -20,10 +20,10 @@ import (
 
 	"github.com/ory/fosite/internal/gen"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/ory/fosite/token/jwt"
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/cristalhq/jwt/v4 v4.0.2
 	github.com/dgraph-io/ristretto v0.0.3
 	github.com/ecordell/optgen v0.0.6
+	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.4.2
@@ -39,7 +40,6 @@ require (
 	golang.org/x/net v0.7.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/text v0.7.0
-	gopkg.in/square/go-jose.v2 v2.5.2-0.20210529014059-a5c7eec3c614
 )
 
 replace github.com/dgraph-io/ristretto => github.com/ory/ristretto v0.1.1-0.20211108053508-297c39e6640f

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/globalsign/mgo v0.0.0-20180905125535-1ca0a4f7cbcb/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0OGD1HRkm4kmhM+pmpv3AKq5SU7GMg4oO/Q=
 github.com/go-bindata/go-bindata v3.1.1+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
+github.com/go-jose/go-jose/v3 v3.0.0 h1:s6rrhirfEP/CGIoc6p+PZAeogN2SxKav6Wp7+dyMWVo=
+github.com/go-jose/go-jose/v3 v3.0.0/go.mod h1:RNkWWRld676jZEYoV3+XK8L2ZnNSvIsxFMht0mSX+u8=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
@@ -1030,8 +1032,6 @@ gopkg.in/ini.v1 v1.57.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/square/go-jose.v2 v2.1.9/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/square/go-jose.v2 v2.2.2/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
-gopkg.in/square/go-jose.v2 v2.5.2-0.20210529014059-a5c7eec3c614 h1:lwJmuuJQGclcankpPJwh8rorzB0bNbVALv8phDGh8TQ=
-gopkg.in/square/go-jose.v2 v2.5.2-0.20210529014059-a5c7eec3c614/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/handler/rfc7523/handler.go
+++ b/handler/rfc7523/handler.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/ory/fosite/handler/oauth2"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/x/errorsx"

--- a/handler/rfc7523/handler_test.go
+++ b/handler/rfc7523/handler_test.go
@@ -17,10 +17,10 @@ import (
 
 	"github.com/ory/fosite/handler/oauth2"
 
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/internal"

--- a/handler/rfc7523/storage.go
+++ b/handler/rfc7523/storage.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 )
 
 // RFC7523KeyStorage holds information needed to validate jwt assertion in authorization grants.

--- a/integration/authorize_jwt_bearer_required_iat_test.go
+++ b/integration/authorize_jwt_bearer_required_iat_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"

--- a/integration/authorize_jwt_bearer_required_jti_test.go
+++ b/integration/authorize_jwt_bearer_required_jti_test.go
@@ -9,10 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"

--- a/integration/authorize_jwt_bearer_test.go
+++ b/integration/authorize_jwt_bearer_test.go
@@ -11,10 +11,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"

--- a/integration/clients/jwt_bearer.go
+++ b/integration/clients/jwt_bearer.go
@@ -13,8 +13,8 @@ import (
 	"net/url"
 	"strings"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 )
 
 // #nosec:gosec G101 - False Positive

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -15,10 +15,10 @@ import (
 	"github.com/ory/fosite/internal"
 	"github.com/ory/fosite/internal/gen"
 
+	"github.com/go-jose/go-jose/v3"
 	"github.com/gorilla/mux"
 	goauth "golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/handler/oauth2"

--- a/integration/introspect_jwt_bearer_token_test.go
+++ b/integration/introspect_jwt_bearer_token_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/compose"

--- a/internal/oauth2_auth_jwt_storage.go
+++ b/internal/oauth2_auth_jwt_storage.go
@@ -12,8 +12,8 @@ import (
 	reflect "reflect"
 	time "time"
 
+	jose "github.com/go-jose/go-jose/v3"
 	gomock "github.com/golang/mock/gomock"
-	jose "gopkg.in/square/go-jose.v2"
 )
 
 // MockRFC7523KeyStorage is a mock of RFC7523KeyStorage interface.

--- a/storage/memory.go
+++ b/storage/memory.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 
 	"github.com/ory/fosite"
 	"github.com/ory/fosite/internal"

--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -14,7 +14,7 @@ import (
 	"crypto/sha256"
 	"strings"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 
 	"github.com/ory/x/errorsx"
 

--- a/token/jwt/jwt_test.go
+++ b/token/jwt/jwt_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	"gopkg.in/square/go-jose.v2"
+	"github.com/go-jose/go-jose/v3"
 
 	"github.com/ory/fosite/internal/gen"
 

--- a/token/jwt/map_claims.go
+++ b/token/jwt/map_claims.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"time"
 
-	jjson "gopkg.in/square/go-jose.v2/json"
+	jjson "github.com/go-jose/go-jose/v3/json"
 
 	"github.com/ory/x/errorsx"
 )

--- a/token/jwt/token.go
+++ b/token/jwt/token.go
@@ -9,8 +9,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 
 	"github.com/ory/x/errorsx"
 )

--- a/token/jwt/token_test.go
+++ b/token/jwt/token_test.go
@@ -15,10 +15,10 @@ import (
 
 	"github.com/ory/fosite/internal/gen"
 
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/square/go-jose.v2"
-	"gopkg.in/square/go-jose.v2/jwt"
 )
 
 func TestUnsignedToken(t *testing.T) {


### PR DESCRIPTION
This commit updates `go-jose` from `v2.5.2` to `v3.0.0`.

It contains a fix [^1] for an issue that is stopping us from updating the version of `fosite` that we use.

[^1]: https://github.com/go-jose/go-jose/commit/4ac8eda113724c926632d14de694dbf1ff70d2cc

