### PR TITLE
feat: grant requested audience(s) in client_credentials flow

### DIFF
--- a/handler/oauth2/flow_client_credentials.go
+++ b/handler/oauth2/flow_client_credentials.go
@@ -40,6 +40,10 @@ func (c *ClientCredentialsGrantHandler) HandleTokenEndpointRequest(ctx context.C
 		return err
 	}
 
+	for _, audience := range request.GetRequestedAudience() {
+		request.GrantAudience(audience)
+	}
+
 	// The client MUST authenticate with the authorization server as described in Section 3.2.1.
 	// This requirement is already fulfilled because fosite requires all token requests to be authenticated as described
 	// in https://tools.ietf.org/html/rfc6749#section-3.2.1

--- a/integration/client_credentials_grant_test.go
+++ b/integration/client_credentials_grant_test.go
@@ -87,6 +87,7 @@ func runClientCredentialsGrantTest(t *testing.T, strategy oauth2.AccessTokenStra
 				introspect(t, ts, token.AccessToken, &j, oauthClient.ClientID, oauthClient.ClientSecret)
 				assert.Equal(t, oauthClient.ClientID, gjson.GetBytes(j, "client_id").String())
 				assert.Equal(t, "fosite", gjson.GetBytes(j, "scope").String())
+				assert.Equal(t, "[\"https://www.ory.sh/api\"]", gjson.GetBytes(j, "aud").String())
 			},
 		},
 		{


### PR DESCRIPTION
This change ensures that the audience claim is populated from the requested audience(s) when the token request explicitly contains the set of audiences (`audience` parameter) in case of client_credentials request.

## Why?
The `audience` claim is mandatory in access tokens that conform to RFC9068 JWT profile. I found that the audience claim is not populated by the library during a `client_credentials` flow, but fosite checks if the requested audience(s) are allowed by the specified client, so decided to implement the audience granting based on the rfc7523 implementation: https://github.com/ory/fosite/blob/45a6785cc54fcbd9195b0de4b821bb5fed6a41be/handler/rfc7523/handler.go#L104. 

I researched the topic a bit and I haven't found any standard which describes how this should behave (the closest is the proposed RFC8707), however I found that both Hydra (https://github.com/ory/hydra/blob/3703e5a7b1a910a15e2118c9ad5cba93e54e4d3d/oauth2/handler.go#L913) and Auth0 (https://auth0.com/docs/get-started/authentication-and-authorization-flow/call-your-api-using-the-client-credentials-flow#example-post-to-token-url) supports this behavior.

## Related Issue or Design Document


## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments