### PR TITLE
feat: move OTEL to a new 'InstrumentedFosite'

### DIFF
--- a/access_request_handler.go
+++ b/access_request_handler.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/ory/fosite/i18n"
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pkg/errors"
 )
@@ -42,9 +40,6 @@ import (
 //     client MUST authenticate with the authorization server as described
 //     in Section 3.2.1.
 func (f *Fosite) NewAccessRequest(ctx context.Context, r *http.Request, session Session) (_ AccessRequester, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAccessRequest")
-	defer otelx.End(span, &err)
-
 	accessRequest := NewAccessRequest(session)
 	accessRequest.Request.Lang = i18n.GetLangFromRequest(f.Config.GetMessageCatalog(ctx), r)
 

--- a/access_response_writer.go
+++ b/access_response_writer.go
@@ -7,16 +7,11 @@ import (
 	"context"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pkg/errors"
 )
 
 func (f *Fosite) NewAccessResponse(ctx context.Context, requester AccessRequester) (_ AccessResponder, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAccessResponse")
-	defer otelx.End(span, &err)
-
 	var tk TokenEndpointHandler
 
 	response := NewAccessResponse()

--- a/authorize_request_handler.go
+++ b/authorize_request_handler.go
@@ -11,12 +11,10 @@ import (
 	"strings"
 
 	"github.com/go-jose/go-jose/v3"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ory/fosite/i18n"
 	"github.com/ory/fosite/token/jwt"
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
 
 	"github.com/pkg/errors"
 
@@ -309,9 +307,6 @@ func (f *Fosite) authorizeRequestFromPAR(ctx context.Context, r *http.Request, r
 }
 
 func (f *Fosite) NewAuthorizeRequest(ctx context.Context, r *http.Request) (_ AuthorizeRequester, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAuthorizeRequest")
-	defer otelx.End(span, &err)
-
 	return f.newAuthorizeRequest(ctx, r, false)
 }
 

--- a/authorize_response_writer.go
+++ b/authorize_response_writer.go
@@ -9,14 +9,9 @@ import (
 	"net/url"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 )
 
 func (f *Fosite) NewAuthorizeResponse(ctx context.Context, ar AuthorizeRequester, session Session) (_ AuthorizeResponder, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAuthorizeResponse")
-	defer otelx.End(span, &err)
-
 	var resp = &AuthorizeResponse{
 		Header:     http.Header{},
 		Parameters: url.Values{},

--- a/introspect.go
+++ b/introspect.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pkg/errors"
 )
@@ -39,9 +37,6 @@ func AccessTokenFromRequest(req *http.Request) string {
 }
 
 func (f *Fosite) IntrospectToken(ctx context.Context, token string, tokenUse TokenUse, session Session, scopes ...string) (_ TokenUse, _ AccessRequester, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.IntrospectToken")
-	defer otelx.End(span, &err)
-
 	var found = false
 	var foundTokenUse TokenUse = ""
 

--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -9,11 +9,9 @@ import (
 	"net/url"
 	"strings"
 
-	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/text/language"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
 )
 
 // NewIntrospectionRequest initiates token introspection as defined in
@@ -96,9 +94,6 @@ import (
 //
 //	token=mF_9.B5f-4.1JqM&token_type_hint=access_token
 func (f *Fosite) NewIntrospectionRequest(ctx context.Context, r *http.Request, session Session) (_ IntrospectionResponder, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewIntrospectionRequest")
-	defer otelx.End(span, &err)
-
 	ctx = context.WithValue(ctx, RequestContextKey, r)
 
 	if r.Method != "POST" {

--- a/otel/access_request_handler_test.go
+++ b/otel/access_request_handler_test.go
@@ -1,0 +1,461 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package otel_test
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/oleiade/reflections"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/ory/fosite"
+	"github.com/ory/fosite/internal"
+	. "github.com/ory/fosite/otel"
+)
+
+func TestNewAccessRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := internal.NewMockStorage(ctrl)
+	handler := internal.NewMockTokenEndpointHandler(ctrl)
+	handler.EXPECT().CanHandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	handler.EXPECT().CanSkipClientAuth(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+	hasher := internal.NewMockHasher(ctrl)
+	defer ctrl.Finish()
+
+	client := &DefaultClient{}
+	config := &Config{ClientSecretsHasher: hasher, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy}
+	fosite := &InstrumentedFosite{Fosite: &Fosite{Store: store, Config: config}}
+	for k, c := range []struct {
+		header    http.Header
+		form      url.Values
+		mock      func()
+		method    string
+		expectErr error
+		expect    *AccessRequest
+		handlers  TokenEndpointHandlers
+	}{
+		{
+			header:    http.Header{},
+			expectErr: ErrInvalidRequest,
+			form:      url.Values{},
+			method:    "POST",
+			mock:      func() {},
+		},
+		{
+			header: http.Header{},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock:      func() {},
+			expectErr: ErrInvalidRequest,
+		},
+		{
+			header: http.Header{},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+				"client_id":  {""},
+			},
+			expectErr: ErrInvalidRequest,
+			mock:      func() {},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			expectErr: ErrInvalidClient,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(nil, errors.New(""))
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "GET",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			expectErr: ErrInvalidRequest,
+			mock:      func() {},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			expectErr: ErrInvalidClient,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(nil, errors.New(""))
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			expectErr: ErrInvalidClient,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = false
+				client.Secret = []byte("foo")
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(errors.New(""))
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			expectErr: ErrServerError,
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = false
+				client.Secret = []byte("foo")
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(ErrServerError)
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = false
+				client.Secret = []byte("foo")
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			handlers: TokenEndpointHandlers{handler},
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: client,
+				},
+			},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			method: "POST",
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = true
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			handlers: TokenEndpointHandlers{handler},
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: client,
+				},
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			r := &http.Request{
+				Header:   c.header,
+				PostForm: c.form,
+				Form:     c.form,
+				Method:   c.method,
+			}
+			c.mock()
+			ctx := NewContext()
+			config.TokenEndpointHandlers = c.handlers
+			ar, err := fosite.NewAccessRequest(ctx, r, new(DefaultSession))
+
+			if c.expectErr != nil {
+				assert.EqualError(t, err, c.expectErr.Error())
+			} else {
+				require.NoError(t, err)
+				AssertObjectKeysEqual(t, c.expect, ar, "GrantTypes", "Client")
+				assert.NotNil(t, ar.GetRequestedAt())
+			}
+		})
+	}
+}
+
+func TestNewAccessRequestWithoutClientAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := internal.NewMockStorage(ctrl)
+	handler := internal.NewMockTokenEndpointHandler(ctrl)
+	handler.EXPECT().CanHandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	handler.EXPECT().CanSkipClientAuth(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	hasher := internal.NewMockHasher(ctrl)
+	defer ctrl.Finish()
+
+	client := &DefaultClient{}
+	anotherClient := &DefaultClient{ID: "another"}
+	config := &Config{ClientSecretsHasher: hasher, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy}
+	fosite := &Fosite{Store: store, Config: config}
+	for k, c := range []struct {
+		header    http.Header
+		form      url.Values
+		mock      func()
+		method    string
+		expectErr error
+		expect    *AccessRequest
+		handlers  TokenEndpointHandlers
+	}{
+		// No grant type -> error
+		{
+			form: url.Values{},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Any()).Times(0)
+			},
+			method:    "POST",
+			expectErr: ErrInvalidRequest,
+		},
+		// No registered handlers -> error
+		{
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Any()).Times(0)
+			},
+			method:    "POST",
+			expectErr: ErrInvalidRequest,
+			handlers:  TokenEndpointHandlers{},
+		},
+		// Handler can skip client auth and ignores missing client.
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				// despite error from storage, we should success, because client auth is not required
+				store.EXPECT().GetClient(gomock.Any(), "foo").Return(nil, errors.New("no client")).Times(1)
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method: "POST",
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: client,
+				},
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		// Should pass if no auth is set in the header and can skip!
+		{
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method: "POST",
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: client,
+				},
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+		// Should also pass if client auth is set!
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), "foo").Return(anotherClient, nil).Times(1)
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(1)
+				handler.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method: "POST",
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: anotherClient,
+				},
+			},
+			handlers: TokenEndpointHandlers{handler},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			r := &http.Request{
+				Header:   c.header,
+				PostForm: c.form,
+				Form:     c.form,
+				Method:   c.method,
+			}
+			c.mock()
+			ctx := NewContext()
+			config.TokenEndpointHandlers = c.handlers
+			ar, err := fosite.NewAccessRequest(ctx, r, new(DefaultSession))
+
+			if c.expectErr != nil {
+				assert.EqualError(t, err, c.expectErr.Error())
+			} else {
+				require.NoError(t, err)
+				AssertObjectKeysEqual(t, c.expect, ar, "GrantTypes", "Client")
+				assert.NotNil(t, ar.GetRequestedAt())
+			}
+		})
+	}
+}
+
+// In this test case one handler requires client auth and another handler not.
+func TestNewAccessRequestWithMixedClientAuth(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	store := internal.NewMockStorage(ctrl)
+
+	handlerWithClientAuth := internal.NewMockTokenEndpointHandler(ctrl)
+	handlerWithClientAuth.EXPECT().CanHandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	handlerWithClientAuth.EXPECT().CanSkipClientAuth(gomock.Any(), gomock.Any()).Return(false).AnyTimes()
+
+	handlerWithoutClientAuth := internal.NewMockTokenEndpointHandler(ctrl)
+	handlerWithoutClientAuth.EXPECT().CanHandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+	handlerWithoutClientAuth.EXPECT().CanSkipClientAuth(gomock.Any(), gomock.Any()).Return(true).AnyTimes()
+
+	hasher := internal.NewMockHasher(ctrl)
+	defer ctrl.Finish()
+
+	client := &DefaultClient{}
+	config := &Config{ClientSecretsHasher: hasher, AudienceMatchingStrategy: DefaultAudienceMatchingStrategy}
+	fosite := &Fosite{Store: store, Config: config}
+	for k, c := range []struct {
+		header    http.Header
+		form      url.Values
+		mock      func()
+		method    string
+		expectErr error
+		expect    *AccessRequest
+		handlers  TokenEndpointHandlers
+	}{
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = false
+				client.Secret = []byte("foo")
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(errors.New("hash err"))
+				handlerWithoutClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method:    "POST",
+			expectErr: ErrInvalidClient,
+			handlers:  TokenEndpointHandlers{handlerWithoutClientAuth, handlerWithClientAuth},
+		},
+		{
+			header: http.Header{
+				"Authorization": {basicAuth("foo", "bar")},
+			},
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Eq("foo")).Return(client, nil)
+				client.Public = false
+				client.Secret = []byte("foo")
+				hasher.EXPECT().Compare(gomock.Any(), gomock.Eq([]byte("foo")), gomock.Eq([]byte("bar"))).Return(nil)
+				handlerWithoutClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+				handlerWithClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method: "POST",
+			expect: &AccessRequest{
+				GrantTypes: Arguments{"foo"},
+				Request: Request{
+					Client: client,
+				},
+			},
+			handlers: TokenEndpointHandlers{handlerWithoutClientAuth, handlerWithClientAuth},
+		},
+		{
+			header: http.Header{},
+			form: url.Values{
+				"grant_type": {"foo"},
+			},
+			mock: func() {
+				store.EXPECT().GetClient(gomock.Any(), gomock.Any()).Times(0)
+				handlerWithoutClientAuth.EXPECT().HandleTokenEndpointRequest(gomock.Any(), gomock.Any()).Return(nil)
+			},
+			method:    "POST",
+			expectErr: ErrInvalidRequest,
+			handlers:  TokenEndpointHandlers{handlerWithoutClientAuth, handlerWithClientAuth},
+		},
+	} {
+		t.Run(fmt.Sprintf("case=%d", k), func(t *testing.T) {
+			r := &http.Request{
+				Header:   c.header,
+				PostForm: c.form,
+				Form:     c.form,
+				Method:   c.method,
+			}
+			c.mock()
+			ctx := NewContext()
+			config.TokenEndpointHandlers = c.handlers
+			ar, err := fosite.NewAccessRequest(ctx, r, new(DefaultSession))
+
+			if c.expectErr != nil {
+				assert.EqualError(t, err, c.expectErr.Error())
+			} else {
+				require.NoError(t, err)
+				AssertObjectKeysEqual(t, c.expect, ar, "GrantTypes", "Client")
+				assert.NotNil(t, ar.GetRequestedAt())
+			}
+		})
+	}
+}
+
+func basicAuth(username, password string) string {
+	return "Basic " + base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", username, password)))
+}
+
+func AssertObjectKeysEqual(t *testing.T, a, b interface{}, keys ...string) {
+	assert.True(t, len(keys) > 0, "No key provided.")
+	for _, k := range keys {
+		c, err := reflections.GetField(a, k)
+		assert.NoError(t, err)
+		d, err := reflections.GetField(b, k)
+		assert.NoError(t, err)
+		assert.Equal(t, c, d, "field: %s", k)
+	}
+}

--- a/otel/fosite.go
+++ b/otel/fosite.go
@@ -1,0 +1,62 @@
+package otel
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/ory/fosite"
+	"github.com/ory/x/otelx"
+	"go.opentelemetry.io/otel/trace"
+)
+
+type InstrumentedFosite struct {
+	*fosite.Fosite
+}
+
+func (f *InstrumentedFosite) NewAccessRequest(ctx context.Context, r *http.Request, session fosite.Session) (_ fosite.AccessRequester, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAccessRequest")
+	defer otelx.End(span, &err)
+	return f.Fosite.NewAccessRequest(ctx, r, session)
+}
+
+func (f *InstrumentedFosite) NewAccessResponse(ctx context.Context, requester fosite.AccessRequester) (_ fosite.AccessResponder, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAccessResponse")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewAccessResponse(ctx, requester)
+}
+
+func (f *InstrumentedFosite) NewAuthorizeRequest(ctx context.Context, r *http.Request) (_ fosite.AuthorizeRequester, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAuthorizeRequest")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewAuthorizeRequest(ctx, r)
+}
+
+func (f *InstrumentedFosite) NewAuthorizeResponse(ctx context.Context, ar fosite.AuthorizeRequester, session fosite.Session) (_ fosite.AuthorizeResponder, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewAuthorizeResponse")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewAuthorizeResponse(ctx, ar, session)
+}
+
+func (f *InstrumentedFosite) NewPushedAuthorizeRequest(ctx context.Context, r *http.Request) (_ fosite.AuthorizeRequester, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewPushedAuthorizeRequest")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewPushedAuthorizeRequest(ctx, r)
+}
+
+func (f *InstrumentedFosite) NewPushedAuthorizeResponse(ctx context.Context, ar fosite.AuthorizeRequester, session fosite.Session) (_ fosite.PushedAuthorizeResponder, err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewPushedAuthorizeResponse")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewPushedAuthorizeResponse(ctx, ar, session)
+}
+
+func (f *InstrumentedFosite) NewRevocationRequest(ctx context.Context, r *http.Request) (err error) {
+	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewRevocationRequest")
+	defer otelx.End(span, &err)
+
+	return f.Fosite.NewRevocationRequest(ctx, r)
+}

--- a/otel/fosite.go
+++ b/otel/fosite.go
@@ -1,3 +1,6 @@
+// Copyright © 2023 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
 package otel
 
 import (

--- a/pushed_authorize_request_handler.go
+++ b/pushed_authorize_request_handler.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/ory/fosite/i18n"
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 )
 
 const (
@@ -23,9 +21,6 @@ const (
 
 // NewPushedAuthorizeRequest validates the request and produces an AuthorizeRequester object that can be stored
 func (f *Fosite) NewPushedAuthorizeRequest(ctx context.Context, r *http.Request) (_ AuthorizeRequester, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewPushedAuthorizeRequest")
-	defer otelx.End(span, &err)
-
 	request := NewAuthorizeRequest()
 	request.Request.Lang = i18n.GetLangFromRequest(f.Config.GetMessageCatalog(ctx), r)
 

--- a/pushed_authorize_response_writer.go
+++ b/pushed_authorize_response_writer.go
@@ -10,15 +10,10 @@ import (
 	"net/http"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 )
 
 // NewPushedAuthorizeResponse executes the handlers and builds the response
 func (f *Fosite) NewPushedAuthorizeResponse(ctx context.Context, ar AuthorizeRequester, session Session) (_ PushedAuthorizeResponder, err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewPushedAuthorizeResponse")
-	defer otelx.End(span, &err)
-
 	// Get handlers. If no handlers are defined, this is considered a misconfigured Fosite instance.
 	handlersProvider, ok := f.Config.(PushedAuthorizeRequestHandlersProvider)
 	if !ok {

--- a/revoke_handler.go
+++ b/revoke_handler.go
@@ -10,8 +10,6 @@ import (
 	"net/http"
 
 	"github.com/ory/x/errorsx"
-	"github.com/ory/x/otelx"
-	"go.opentelemetry.io/otel/trace"
 
 	"github.com/pkg/errors"
 )
@@ -34,9 +32,6 @@ import (
 // An invalid token type hint value is ignored by the authorization
 // server and does not influence the revocation response.
 func (f *Fosite) NewRevocationRequest(ctx context.Context, r *http.Request) (err error) {
-	ctx, span := trace.SpanFromContext(ctx).TracerProvider().Tracer("github.com/ory/fosite").Start(ctx, "Fosite.NewRevocationRequest")
-	defer otelx.End(span, &err)
-
 	ctx = context.WithValue(ctx, RequestContextKey, r)
 
 	if r.Method != "POST" {


### PR DESCRIPTION
The recent change in [#761 ] introduces OTEL as part of Fosite. While this is valuable, this should
be provided as a wrapper and not as a hard wired part of Fosite, which is meant to be a SDK. Also,
popular instrumentation options and APM vendors have some level of support for OTEL but shine
when their wrapper SDKs are used that do not always comply with OTEL interfaces. See New Relic
and Instana SDKs for reference.

This change proposes that OTEL should be an opt-in as part of a wrapper implementation of Fosite
that is called `InstrumentedFosite` under the `otel` package. It also offers a pattern that can be applied
to any code blocks and handlers that should be instrumented to derive maximum benefits from a telemetry
perspective. For example - there may be no value in instrumenting a code block that interfaces with no
external components beyond the overall telemetry offered at a HTTP middleware level, whereas there
may be a great deal of value instrumenting call outs to external APIs and databases.

## Related Issue or Design Document

#761 

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments
