### PR TITLE
fix: remove redundant map access

### DIFF
--- a/session.go
+++ b/session.go
@@ -52,9 +52,6 @@ func (s *DefaultSession) GetExpiresAt(key TokenType) time.Time {
 		s.ExpiresAt = make(map[TokenType]time.Time)
 	}
 
-	if _, ok := s.ExpiresAt[key]; !ok {
-		return time.Time{}
-	}
 	return s.ExpiresAt[key]
 }
 

--- a/session_test.go
+++ b/session_test.go
@@ -15,3 +15,11 @@ func TestSession(t *testing.T) {
 	assert.Empty(t, s.GetUsername())
 	assert.Nil(t, s.Clone())
 }
+
+func TestZeroSession(t *testing.T) {
+	var s *DefaultSession = new(DefaultSession)
+	assert.Empty(t, s.GetSubject())
+	assert.Empty(t, s.GetUsername())
+	assert.Empty(t, s.Clone())
+	assert.Empty(t, s.GetExpiresAt(AccessToken))
+}


### PR DESCRIPTION
Remove a redundant check for whether an element is present in a map. Since we return the zero value of a `time.Time` anyway, it's simpler to use the single return value version to access the map.
## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

I have not added any documentation or tests for this since it is such a small fix.