### PR TITLE
fix: add missing ctx argument to IsRedirectURISecureStrict

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -180,7 +180,7 @@ func IsRedirectURISecure(ctx context.Context, redirectURI *url.URL) bool {
 // IsRedirectURISecureStrict is stricter than IsRedirectURISecure and it does not allow custom-scheme
 // URLs because they can be hijacked for native apps. Use claimed HTTPS redirects instead.
 // See discussion in https://github.com/ory/fosite/pull/489.
-func IsRedirectURISecureStrict(redirectURI *url.URL) bool {
+func IsRedirectURISecureStrict(ctx context.Context, redirectURI *url.URL) bool {
 	return redirectURI.Scheme == "https" || (redirectURI.Scheme == "http" && IsLocalhost(redirectURI))
 }
 

--- a/authorize_helper_test.go
+++ b/authorize_helper_test.go
@@ -309,7 +309,7 @@ func TestIsRedirectURISecureStrict(t *testing.T) {
 	} {
 		uu, err := url.Parse(c.u)
 		require.NoError(t, err)
-		assert.Equal(t, !c.err, fosite.IsRedirectURISecureStrict(uu), "case %d", d)
+		assert.Equal(t, !c.err, fosite.IsRedirectURISecureStrict(context.Background(), uu), "case %d", d)
 	}
 }
 


### PR DESCRIPTION
## Related Issue or Design Document

I think this was missed when `ctx` was added around. Now it cannot be used for `RedirectSecureChecker` config.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
