### PR TITLE
fix: pass JWK for singing so that KeyID is set in JWTs

### DIFF
--- a/token/jwt/jwt.go
+++ b/token/jwt/jwt.go
@@ -48,9 +48,9 @@ func (j *DefaultSigner) Generate(ctx context.Context, claims MapClaims, header M
 
 	switch t := key.(type) {
 	case *jose.JSONWebKey:
-		return generateToken(claims, header, jose.SignatureAlgorithm(t.Algorithm), t.Key)
+		return generateToken(claims, header, jose.SignatureAlgorithm(t.Algorithm), t)
 	case jose.JSONWebKey:
-		return generateToken(claims, header, jose.SignatureAlgorithm(t.Algorithm), t.Key)
+		return generateToken(claims, header, jose.SignatureAlgorithm(t.Algorithm), t)
 	case *rsa.PrivateKey:
 		return generateToken(claims, header, jose.RS256, t)
 	case *ecdsa.PrivateKey:


### PR DESCRIPTION
It is harder to validate generated JWTs because currently they do not include a key ID in the header. Even when key ID exists in the JWK used for signing. The reason is that Fosite currently removes this metadata information, but it is not necessary to remove it, our signing library uses it and knows how to use JWKs, even more, it adds key ID automatically if it is available and provided with a JWK.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).
