### PR TITLE
fix: WriteIntrospectionResponse should always issue headers

### DIFF
--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -179,6 +179,10 @@ func (f *Fosite) WriteIntrospectionError(ctx context.Context, rw http.ResponseWr
 //	  "active": false
 //	}
 func (f *Fosite) WriteIntrospectionResponse(ctx context.Context, rw http.ResponseWriter, r IntrospectionResponder) {
+	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
+	rw.Header().Set("Cache-Control", "no-store")
+	rw.Header().Set("Pragma", "no-cache")
+
 	if !r.IsActive() {
 		_ = json.NewEncoder(rw).Encode(&struct {
 			Active bool `json:"active"`
@@ -226,8 +230,5 @@ func (f *Fosite) WriteIntrospectionResponse(ctx context.Context, rw http.Respons
 		response["username"] = r.GetAccessRequester().GetSession().GetUsername()
 	}
 
-	rw.Header().Set("Content-Type", "application/json;charset=UTF-8")
-	rw.Header().Set("Cache-Control", "no-store")
-	rw.Header().Set("Pragma", "no-cache")
 	_ = json.NewEncoder(rw).Encode(response)
 }

--- a/introspection_response_writer_test.go
+++ b/introspection_response_writer_test.go
@@ -53,6 +53,7 @@ func TestWriteIntrospectionResponse(t *testing.T) {
 
 	rw := internal.NewMockResponseWriter(c)
 	rw.EXPECT().Write(gomock.Any()).AnyTimes()
+	rw.EXPECT().Header().AnyTimes().Return(http.Header{})
 	f.WriteIntrospectionResponse(context.Background(), rw, &IntrospectionResponse{
 		AccessRequester: NewAccessRequest(nil),
 	})


### PR DESCRIPTION
A simple fix. For inactive tokens there were no headers.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).