### PR TITLE
feat: add ResourceAccessScopeStrategy

### DIFF
--- a/scope_strategy.go
+++ b/scope_strategy.go
@@ -83,3 +83,69 @@ func WildcardScopeStrategy(matchers []string, needle string) bool {
 
 	return false
 }
+
+func ResourceAccessScopeStrategy(matchers []string, needle string) bool {
+	needleResources := strings.Split(needle, ":")
+
+matcherloop:
+	for _, matcher := range matchers {
+		matcherResources := strings.Split(matcher, ":")
+
+		if len(matcherResources) != len(needleResources) {
+			continue matcherloop
+		}
+
+		var match bool
+
+		for index, matcherResource := range matcherResources {
+			isLastLoop := index+1 == len(matcherResources)
+			needleResource := needleResources[index]
+
+			// on the last resource we split off the verb
+			matcherVerb := ""
+			if strings.Contains(matcherResource, ".") && isLastLoop {
+				matcherVerb = matcherResource[strings.LastIndex(matcherResource, "."):]
+				matcherResource, _ = strings.CutSuffix(matcherResource, matcherVerb)
+			}
+
+			needleVerb := ""
+			if strings.Contains(needleResource, ".") && isLastLoop && matcherVerb != "" {
+				needleVerb = needleResource[strings.LastIndex(needleResource, "."):]
+				needleResource, _ = strings.CutSuffix(needleResource, needleVerb)
+			}
+
+			var exactmatch bool
+			var prefixmatch bool
+
+			if matcherResource == needleResource {
+				exactmatch = true
+			}
+			// if prefix we check only on the left side of `-`
+			if strings.HasSuffix(matcherResource, "-*") {
+				matcherPrefix, _, _ := strings.Cut(matcherResource, "-")
+				needlePrefix, _, hasPrefix := strings.Cut(needleResource, "-")
+				if hasPrefix && needlePrefix == matcherPrefix {
+					prefixmatch = true
+				}
+			}
+			match = prefixmatch || exactmatch
+
+			if !match {
+				continue matcherloop
+			}
+
+			// if matcher defines .* as verb then everything is permitted
+			// resource provider has responsibility to assume least privilege
+			if isLastLoop && matcherVerb != "" {
+				if matcherVerb == ".*" {
+					continue
+				}
+				match = matcherVerb == needleVerb
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Related to [this hydra issue](https://github.com/ory/hydra/issues/3751).

This scope strategy splits a scope into resources delimited with `:`.
Each resource can have dynamic values if it has the suffix `-*`.
The last resource can specify a verb delimited with `.`.

The hierarchy of the matcher and scope resources needs to be identical.

Examples:
* `users.*` matches `users.read`
* `users.write` does not match `users.read`
* `users:settings` matches `users:settings`
* `users:settings` does not match `users:settings.read`
* `users:client-*.read` does match `users:client-bar.read`
* `users:client-*` does not match `users:client-bar.read`
* `users:client-*.*` does match `users:client-foo.write`

Open questions:
Should I make the resource/verb delimiter configurable? What about allowing dynamic resources?