### PR TITLE
refactor: split HMAC SHA strategy

### DIFF
--- a/compose/compose_strategy.go
+++ b/compose/compose_strategy.go
@@ -31,8 +31,10 @@ type HMACSHAStrategyConfigurator interface {
 
 func NewOAuth2HMACStrategy(config HMACSHAStrategyConfigurator) *oauth2.HMACSHAStrategy {
 	return &oauth2.HMACSHAStrategy{
-		Enigma: &hmac.HMACStrategy{Config: config},
-		Config: config,
+		BaseHMACSHAStrategy: &oauth2.BaseHMACSHAStrategy{
+			Enigma: &hmac.HMACStrategy{Config: config},
+			Config: config,
+		},
 	}
 }
 

--- a/handler/oauth2/strategy_hmacsha.go
+++ b/handler/oauth2/strategy_hmacsha.go
@@ -5,8 +5,6 @@ package oauth2
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/ory/x/errorsx"
@@ -15,55 +13,39 @@ import (
 	enigma "github.com/ory/fosite/token/hmac"
 )
 
-type HMACSHAStrategy struct {
+var _ CoreStrategy = (*BaseHMACSHAStrategy)(nil)
+
+type BaseHMACSHAStrategy struct {
 	Enigma *enigma.HMACStrategy
 	Config interface {
 		fosite.AccessTokenLifespanProvider
 		fosite.RefreshTokenLifespanProvider
 		fosite.AuthorizeCodeLifespanProvider
 	}
-	prefix *string
 }
 
-func (h *HMACSHAStrategy) AccessTokenSignature(ctx context.Context, token string) string {
-	return h.Enigma.Signature(token)
-}
-func (h *HMACSHAStrategy) RefreshTokenSignature(ctx context.Context, token string) string {
-	return h.Enigma.Signature(token)
-}
-func (h *HMACSHAStrategy) AuthorizeCodeSignature(ctx context.Context, token string) string {
+func (h *BaseHMACSHAStrategy) AccessTokenSignature(_ context.Context, token string) string {
 	return h.Enigma.Signature(token)
 }
 
-func (h *HMACSHAStrategy) getPrefix(part string) string {
-	if h.prefix == nil {
-		prefix := "ory_%s_"
-		h.prefix = &prefix
-	} else if len(*h.prefix) == 0 {
-		return ""
-	}
-
-	return fmt.Sprintf(*h.prefix, part)
+func (h *BaseHMACSHAStrategy) RefreshTokenSignature(_ context.Context, token string) string {
+	return h.Enigma.Signature(token)
 }
 
-func (h *HMACSHAStrategy) trimPrefix(token, part string) string {
-	return strings.TrimPrefix(token, h.getPrefix(part))
+func (h *BaseHMACSHAStrategy) AuthorizeCodeSignature(_ context.Context, token string) string {
+	return h.Enigma.Signature(token)
 }
 
-func (h *HMACSHAStrategy) setPrefix(token, part string) string {
-	return h.getPrefix(part) + token
-}
-
-func (h *HMACSHAStrategy) GenerateAccessToken(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
+func (h *BaseHMACSHAStrategy) GenerateAccessToken(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
 	token, sig, err := h.Enigma.Generate(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	return h.setPrefix(token, "at"), sig, nil
+	return token, sig, nil
 }
 
-func (h *HMACSHAStrategy) ValidateAccessToken(ctx context.Context, r fosite.Requester, token string) (err error) {
+func (h *BaseHMACSHAStrategy) ValidateAccessToken(ctx context.Context, r fosite.Requester, token string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(fosite.AccessToken)
 	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetAccessTokenLifespan(ctx)).Before(time.Now().UTC()) {
 		return errorsx.WithStack(fosite.ErrTokenExpired.WithHintf("Access token expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetAccessTokenLifespan(ctx))))
@@ -73,42 +55,42 @@ func (h *HMACSHAStrategy) ValidateAccessToken(ctx context.Context, r fosite.Requ
 		return errorsx.WithStack(fosite.ErrTokenExpired.WithHintf("Access token expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(token, "at"))
+	return h.Enigma.Validate(ctx, token)
 }
 
-func (h *HMACSHAStrategy) GenerateRefreshToken(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
+func (h *BaseHMACSHAStrategy) GenerateRefreshToken(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
 	token, sig, err := h.Enigma.Generate(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	return h.setPrefix(token, "rt"), sig, nil
+	return token, sig, nil
 }
 
-func (h *HMACSHAStrategy) ValidateRefreshToken(ctx context.Context, r fosite.Requester, token string) (err error) {
+func (h *BaseHMACSHAStrategy) ValidateRefreshToken(ctx context.Context, r fosite.Requester, token string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(fosite.RefreshToken)
 	if exp.IsZero() {
 		// Unlimited lifetime
-		return h.Enigma.Validate(ctx, h.trimPrefix(token, "rt"))
+		return h.Enigma.Validate(ctx, token)
 	}
 
 	if !exp.IsZero() && exp.Before(time.Now().UTC()) {
 		return errorsx.WithStack(fosite.ErrTokenExpired.WithHintf("Refresh token expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(token, "rt"))
+	return h.Enigma.Validate(ctx, token)
 }
 
-func (h *HMACSHAStrategy) GenerateAuthorizeCode(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
+func (h *BaseHMACSHAStrategy) GenerateAuthorizeCode(ctx context.Context, _ fosite.Requester) (token string, signature string, err error) {
 	token, sig, err := h.Enigma.Generate(ctx)
 	if err != nil {
 		return "", "", err
 	}
 
-	return h.setPrefix(token, "ac"), sig, nil
+	return token, sig, nil
 }
 
-func (h *HMACSHAStrategy) ValidateAuthorizeCode(ctx context.Context, r fosite.Requester, token string) (err error) {
+func (h *BaseHMACSHAStrategy) ValidateAuthorizeCode(ctx context.Context, r fosite.Requester, token string) (err error) {
 	var exp = r.GetSession().GetExpiresAt(fosite.AuthorizeCode)
 	if exp.IsZero() && r.GetRequestedAt().Add(h.Config.GetAuthorizeCodeLifespan(ctx)).Before(time.Now().UTC()) {
 		return errorsx.WithStack(fosite.ErrTokenExpired.WithHintf("Authorize code expired at '%s'.", r.GetRequestedAt().Add(h.Config.GetAuthorizeCodeLifespan(ctx))))
@@ -118,5 +100,5 @@ func (h *HMACSHAStrategy) ValidateAuthorizeCode(ctx context.Context, r fosite.Re
 		return errorsx.WithStack(fosite.ErrTokenExpired.WithHintf("Authorize code expired at '%s'.", exp))
 	}
 
-	return h.Enigma.Validate(ctx, h.trimPrefix(token, "ac"))
+	return h.Enigma.Validate(ctx, token)
 }

--- a/handler/oauth2/strategy_hmacsha_prefixed.go
+++ b/handler/oauth2/strategy_hmacsha_prefixed.go
@@ -1,0 +1,60 @@
+// Copyright © 2024 Ory Corp
+// SPDX-License-Identifier: Apache-2.0
+
+package oauth2
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/ory/fosite"
+)
+
+var _ CoreStrategy = (*HMACSHAStrategy)(nil)
+
+type HMACSHAStrategy struct {
+	*BaseHMACSHAStrategy
+}
+
+func (h *HMACSHAStrategy) getPrefix(part string) string {
+	return fmt.Sprintf("ory_%s_", part)
+}
+
+func (h *HMACSHAStrategy) trimPrefix(token, part string) string {
+	return strings.TrimPrefix(token, h.getPrefix(part))
+}
+
+func (h *HMACSHAStrategy) setPrefix(token, part string) string {
+	if token == "" {
+		return ""
+	}
+	return h.getPrefix(part) + token
+}
+
+func (h *HMACSHAStrategy) GenerateAccessToken(ctx context.Context, r fosite.Requester) (token string, signature string, err error) {
+	token, sig, err := h.BaseHMACSHAStrategy.GenerateAccessToken(ctx, r)
+	return h.setPrefix(token, "at"), sig, err
+}
+
+func (h *HMACSHAStrategy) ValidateAccessToken(ctx context.Context, r fosite.Requester, token string) (err error) {
+	return h.BaseHMACSHAStrategy.ValidateAccessToken(ctx, r, h.trimPrefix(token, "at"))
+}
+
+func (h *HMACSHAStrategy) GenerateRefreshToken(ctx context.Context, r fosite.Requester) (token string, signature string, err error) {
+	token, sig, err := h.BaseHMACSHAStrategy.GenerateRefreshToken(ctx, r)
+	return h.setPrefix(token, "rt"), sig, err
+}
+
+func (h *HMACSHAStrategy) ValidateRefreshToken(ctx context.Context, r fosite.Requester, token string) (err error) {
+	return h.BaseHMACSHAStrategy.ValidateRefreshToken(ctx, r, h.trimPrefix(token, "rt"))
+}
+
+func (h *HMACSHAStrategy) GenerateAuthorizeCode(ctx context.Context, r fosite.Requester) (token string, signature string, err error) {
+	token, sig, err := h.BaseHMACSHAStrategy.GenerateAuthorizeCode(ctx, r)
+	return h.setPrefix(token, "ac"), sig, err
+}
+
+func (h *HMACSHAStrategy) ValidateAuthorizeCode(ctx context.Context, r fosite.Requester, token string) (err error) {
+	return h.BaseHMACSHAStrategy.ValidateAuthorizeCode(ctx, r, h.trimPrefix(token, "ac"))
+}

--- a/handler/oauth2/strategy_hmacsha_test.go
+++ b/handler/oauth2/strategy_hmacsha_test.go
@@ -17,10 +17,12 @@ import (
 )
 
 var hmacshaStrategy = HMACSHAStrategy{
-	Enigma: &hmac.HMACStrategy{Config: &fosite.Config{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")}},
-	Config: &fosite.Config{
-		AccessTokenLifespan:   time.Hour * 24,
-		AuthorizeCodeLifespan: time.Hour * 24,
+	BaseHMACSHAStrategy: &BaseHMACSHAStrategy{
+		Enigma: &hmac.HMACStrategy{Config: &fosite.Config{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")}},
+		Config: &fosite.Config{
+			AccessTokenLifespan:   time.Hour * 24,
+			AuthorizeCodeLifespan: time.Hour * 24,
+		},
 	},
 }
 

--- a/handler/openid/flow_hybrid_test.go
+++ b/handler/openid/flow_hybrid_test.go
@@ -27,9 +27,11 @@ import (
 )
 
 var hmacStrategy = &oauth2.HMACSHAStrategy{
-	Enigma: &hmac.HMACStrategy{
-		Config: &fosite.Config{
-			GlobalSecret: []byte("some-super-cool-secret-that-nobody-knows-nobody-knows"),
+	BaseHMACSHAStrategy: &oauth2.BaseHMACSHAStrategy{
+		Enigma: &hmac.HMACStrategy{
+			Config: &fosite.Config{
+				GlobalSecret: []byte("some-super-cool-secret-that-nobody-knows-nobody-knows"),
+			},
 		},
 	},
 }

--- a/handler/pkce/handler_test.go
+++ b/handler/pkce/handler_test.go
@@ -38,9 +38,11 @@ func (m *mockCodeStrategy) ValidateAuthorizeCode(ctx context.Context, requester 
 func TestPKCEHandleAuthorizeEndpointRequest(t *testing.T) {
 	var config fosite.Config
 	h := &Handler{
-		Storage:               storage.NewMemoryStore(),
-		AuthorizeCodeStrategy: new(oauth2.HMACSHAStrategy),
-		Config:                &config,
+		Storage: storage.NewMemoryStore(),
+		AuthorizeCodeStrategy: &oauth2.HMACSHAStrategy{
+			BaseHMACSHAStrategy: new(oauth2.BaseHMACSHAStrategy),
+		},
+		Config: &config,
 	}
 	w := fosite.NewAuthorizeResponse()
 	r := fosite.NewAuthorizeRequest()

--- a/integration/helper_setup_test.go
+++ b/integration/helper_setup_test.go
@@ -173,14 +173,16 @@ func newJWTBearerAppClient(ts *httptest.Server) *clients.JWTBearer {
 }
 
 var hmacStrategy = &oauth2.HMACSHAStrategy{
-	Enigma: &hmac.HMACStrategy{
-		Config: &fosite.Config{
-			GlobalSecret: []byte("some-super-cool-secret-that-nobody-knows"),
+	BaseHMACSHAStrategy: &oauth2.BaseHMACSHAStrategy{
+		Enigma: &hmac.HMACStrategy{
+			Config: &fosite.Config{
+				GlobalSecret: []byte("some-super-cool-secret-that-nobody-knows"),
+			},
 		},
-	},
-	Config: &fosite.Config{
-		AccessTokenLifespan:   accessTokenLifespan,
-		AuthorizeCodeLifespan: authCodeLifespan,
+		Config: &fosite.Config{
+			AccessTokenLifespan:   accessTokenLifespan,
+			AuthorizeCodeLifespan: authCodeLifespan,
+		},
 	},
 }
 


### PR DESCRIPTION
BREAKING CHANGES: Going forward, the `HMACSHAStrategy` requires a `BaseHMACSHAStrategy`. Here is how to upgrade it:

```patch
var hmacshaStrategy = HMACSHAStrategy{
-	Enigma: &hmac.HMACStrategy{Config: &fosite.Config{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")}},
-	Config: &fosite.Config{
-		AccessTokenLifespan:   time.Hour * 24,
-		AuthorizeCodeLifespan: time.Hour * 24,
+	BaseHMACSHAStrategy: &BaseHMACSHAStrategy{
+		Enigma: &hmac.HMACStrategy{Config: &fosite.Config{GlobalSecret: []byte("foobarfoobarfoobarfoobarfoobarfoobarfoobarfoobar")}},
+		Config: &fosite.Config{
+			AccessTokenLifespan:   time.Hour * 24,
+			AuthorizeCodeLifespan: time.Hour * 24,
+		},
	},
}
```

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- ~[ ] I have referenced an issue containing the design document if my change introduces a new feature.~
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- ~[ ] I have added tests that prove my fix is effective or that my feature works.~
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
