### PR TITLE
fix: do not store stacktrace in sentinel errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -22,10 +22,10 @@ import (
 var (
 	// ErrInvalidatedAuthorizeCode is an error indicating that an authorization code has been
 	// used previously.
-	ErrInvalidatedAuthorizeCode = errors.New("Authorization code has ben invalidated")
+	ErrInvalidatedAuthorizeCode = stderr.New("Authorization code has ben invalidated")
 	// ErrSerializationFailure is an error indicating that the transactional capable storage could not guarantee
 	// consistency of Update & Delete operations on the same rows between multiple sessions.
-	ErrSerializationFailure = errors.New("The request could not be completed due to concurrent access")
+	ErrSerializationFailure = stderr.New("The request could not be completed due to concurrent access")
 	ErrUnknownRequest       = &RFC6749Error{
 		ErrorField:       errUnknownErrorName,
 		DescriptionField: "The handler is not responsible for this request.",


### PR DESCRIPTION
`github.com/pkg/errors`'s `New` records a stack trace but for sentinel errors you do not want to record a stack trace of Go initialization. One should return `errorsx.WithStack(ErrInvalidatedAuthorizeCode)` to attach a stack trace with the error.

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).