### PR TITLE
docs: inconsistent RFC links in documentation

### DIFF
--- a/introspection_request_handler.go
+++ b/introspection_request_handler.go
@@ -17,7 +17,7 @@ import (
 )
 
 // NewIntrospectionRequest initiates token introspection as defined in
-// https://tools.ietf.org/search/rfc7662#section-2.1
+// https://tools.ietf.org/html/rfc7662#section-2.1
 //
 // The protected resource calls the introspection endpoint using an HTTP
 // POST [RFC7231] request with parameters sent as

--- a/introspection_response_writer.go
+++ b/introspection_response_writer.go
@@ -13,7 +13,7 @@ import (
 )
 
 // WriteIntrospectionError responds with token metadata discovered by token introspection as defined in
-// https://tools.ietf.org/search/rfc7662#section-2.2
+// https://tools.ietf.org/html/rfc7662#section-2.2
 //
 // If the protected resource uses OAuth 2.0 client credentials to
 // authenticate to the introspection endpoint and its credentials are
@@ -53,7 +53,7 @@ func (f *Fosite) WriteIntrospectionError(ctx context.Context, rw http.ResponseWr
 }
 
 // WriteIntrospectionResponse responds with an error if token introspection failed as defined in
-// https://tools.ietf.org/search/rfc7662#section-2.3
+// https://tools.ietf.org/html/rfc7662#section-2.3
 //
 // The server responds with a JSON object [RFC7159] in "application/
 // json" format with the following top-level members.

--- a/oauth2.go
+++ b/oauth2.go
@@ -145,15 +145,15 @@ type OAuth2Provider interface {
 	IntrospectToken(ctx context.Context, token string, tokenUse TokenUse, session Session, scope ...string) (TokenUse, AccessRequester, error)
 
 	// NewIntrospectionRequest initiates token introspection as defined in
-	// https://tools.ietf.org/search/rfc7662#section-2.1
+	// https://tools.ietf.org/html/rfc7662#section-2.1
 	NewIntrospectionRequest(ctx context.Context, r *http.Request, session Session) (IntrospectionResponder, error)
 
 	// WriteIntrospectionError responds with an error if token introspection failed as defined in
-	// https://tools.ietf.org/search/rfc7662#section-2.3
+	// https://tools.ietf.org/html/rfc7662#section-2.3
 	WriteIntrospectionError(ctx context.Context, rw http.ResponseWriter, err error)
 
 	// WriteIntrospectionResponse responds with token metadata discovered by token introspection as defined in
-	// https://tools.ietf.org/search/rfc7662#section-2.2
+	// https://tools.ietf.org/html/rfc7662#section-2.2
 	WriteIntrospectionResponse(ctx context.Context, rw http.ResponseWriter, r IntrospectionResponder)
 
 	// NewPushedAuthorizeRequest validates the request and produces an AuthorizeRequester object that can be stored
@@ -171,7 +171,7 @@ type OAuth2Provider interface {
 
 // IntrospectionResponder is the response object that will be returned when token introspection was successful,
 // for example when the client is allowed to perform token introspection. Refer to
-// https://tools.ietf.org/search/rfc7662#section-2.2 for more details.
+// https://tools.ietf.org/html/rfc7662#section-2.2 for more details.
 type IntrospectionResponder interface {
 	// IsActive returns true if the introspected token is active and false otherwise.
 	IsActive() bool


### PR DESCRIPTION
There are some invalid links in the documentation, which can result in the user writing this PR and forgetting what they were working on in the first place.

## Related Issue or Design Document
see above

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [no] I have referenced an issue containing the design document if my change introduces a new feature.
- [no] I have read the [security policy](../security/policy).
- [+] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

`/search/...` should be `/html/...`
