### PR TITLE
feat: configure client assertion issuer

### DIFF
--- a/client.go
+++ b/client.go
@@ -58,6 +58,9 @@ type OpenIDConnectClient interface {
 	// public key used by the client to authenticate.
 	GetJSONWebKeysURI() string
 
+	// GetJSONWebTokenClientAssertionIssuer returns the issuer of client assertions used to authenticate.
+	GetJSONWebTokenClientAssertionIssuer() string
+
 	// JWS [JWS] alg algorithm [JWA] that MUST be used for signing Request Objects sent to the OP.
 	// All Request Objects from this Client MUST be rejected, if not signed with this algorithm.
 	GetRequestObjectSigningAlgorithm() string
@@ -94,6 +97,7 @@ type DefaultOpenIDConnectClient struct {
 	*DefaultClient
 	JSONWebKeysURI                    string              `json:"jwks_uri"`
 	JSONWebKeys                       *jose.JSONWebKeySet `json:"jwks"`
+	JSONWebTokenClientAssertionIssuer string              `json:"jwt_client_assertion_issuer"`
 	TokenEndpointAuthMethod           string              `json:"token_endpoint_auth_method"`
 	RequestURIs                       []string            `json:"request_uris"`
 	RequestObjectSigningAlgorithm     string              `json:"request_object_signing_alg"`
@@ -163,6 +167,13 @@ func (c *DefaultOpenIDConnectClient) GetJSONWebKeysURI() string {
 
 func (c *DefaultOpenIDConnectClient) GetJSONWebKeys() *jose.JSONWebKeySet {
 	return c.JSONWebKeys
+}
+
+func (c *DefaultOpenIDConnectClient) GetJSONWebTokenClientAssertionIssuer() string {
+	if c.JSONWebTokenClientAssertionIssuer == "" {
+		return c.ID
+	}
+	return c.JSONWebTokenClientAssertionIssuer
 }
 
 func (c *DefaultOpenIDConnectClient) GetTokenEndpointAuthSigningAlgorithm() string {

--- a/client_authentication.go
+++ b/client_authentication.go
@@ -148,8 +148,8 @@ func (f *Fosite) DefaultClientAuthenticationStrategy(ctx context.Context, r *htt
 
 		claims := token.Claims
 		var jti string
-		if !claims.VerifyIssuer(clientID, true) {
-			return nil, errorsx.WithStack(ErrInvalidClient.WithHint("Claim 'iss' from 'client_assertion' must match the 'client_id' of the OAuth 2.0 Client."))
+		if !claims.VerifyIssuer(client.(OpenIDConnectClient).GetJSONWebTokenClientAssertionIssuer(), true) {
+			return nil, errorsx.WithStack(ErrInvalidClient.WithHint("Claim 'iss' from 'client_assertion' must match the configured issuer for the OAuth 2.0 Client."))
 		} else if len(f.Config.GetTokenURLs(ctx)) == 0 {
 			return nil, errorsx.WithStack(ErrMisconfiguration.WithHint("The authorization server's token endpoint URL has not been set."))
 		} else if sub, ok := claims["sub"].(string); !ok || sub != clientID {


### PR DESCRIPTION
Allow clients to have a custom client assertion issuer so that a client assertion can be issued by a separate identity provider rather than only self-issued.

BREAKING CHANGES: The `Client` interface defines a new method to return the issuer expected in client assertions. Applications that define their own type must implement `Client.GetJSONWebTokenClientAssertionIssuer`.

<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.

This text will be included in the changelog. If applicable, include links to documentation or pieces of code.
If your change includes breaking changes please add a code block documenting the breaking change:

```
BREAKING CHANGES: This patch changes the behavior of configuration item `foo` to do bar. To keep the existing
behavior please do baz.
```
-->

## Related Issue or Design Document

<!--
If this pull request

1. is a fix for a known bug, link the issue where the bug was reported in the format of `#1234`;
2. is a fix for a previously unknown bug, explain the bug and how to reproduce it in this pull request;
3. implements a new feature, link the issue containing the design document in the format of `#1234`;
4. improves the documentation, no issue reference is required.

Pull requests introducing new features, which do not have a design document linked are more likely to be rejected and take on average 2-8 weeks longer to
get merged.

You can discuss changes with maintainers either in the Github Discussions in this repository or
join the [Ory Chat](https://www.ory.sh/chat).
-->

## Checklist

<!--
Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of
them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.
-->

- [X] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [X] I have read the [security policy](../security/policy).
- [X] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added the necessary documentation within the code base (if appropriate).

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution
you did and what alternatives you considered, etc...
-->
