### PR TITLE
fix: typo: JKWKSFetcherWithDefaultTTL -> JWKSFetcherWithDefaultTTL

### DIFF
--- a/client_authentication_jwks_strategy.go
+++ b/client_authentication_jwks_strategy.go
@@ -63,8 +63,8 @@ func NewDefaultJWKSFetcherStrategy(opts ...func(*DefaultJWKSFetcherStrategy)) JW
 	return s
 }
 
-// JKWKSFetcherWithDefaultTTL sets the default TTL for the cache.
-func JKWKSFetcherWithDefaultTTL(ttl time.Duration) func(*DefaultJWKSFetcherStrategy) {
+// JWKSFetcherWithDefaultTTL sets the default TTL for the cache.
+func JWKSFetcherWithDefaultTTL(ttl time.Duration) func(*DefaultJWKSFetcherStrategy) {
 	return func(s *DefaultJWKSFetcherStrategy) {
 		s.ttl = ttl
 	}

--- a/client_authentication_jwks_strategy_test.go
+++ b/client_authentication_jwks_strategy_test.go
@@ -118,7 +118,7 @@ func TestDefaultJWKSFetcherStrategy(t *testing.T) {
 	t.Run("JWKSFetcherWithTTL", func(t *testing.T) {
 		ts := initServerWithKey(t)
 
-		s := NewDefaultJWKSFetcherStrategy(JKWKSFetcherWithDefaultTTL(time.Nanosecond))
+		s := NewDefaultJWKSFetcherStrategy(JWKSFetcherWithDefaultTTL(time.Nanosecond))
 		_, err := s.Resolve(ctx, ts.URL, false)
 		require.NoError(t, err)
 		s.(*DefaultJWKSFetcherStrategy).cache.Wait()


### PR DESCRIPTION
This looks like a minor typo - but I suppose it could potentially be a breaking change, if anyone's using this function.
