### PR TITLE
chore: slightly reduce session JSON size

### DIFF
--- a/handler/oauth2/strategy_jwt.go
+++ b/handler/oauth2/strategy_jwt.go
@@ -111,10 +111,10 @@ func toRFCErr(v *jwt.ValidationError) *fosite.RFC6749Error {
 func (h *DefaultJWTStrategy) generate(ctx context.Context, tokenType fosite.TokenType, requester fosite.Requester) (string, string, error) {
 	if jwtSession, ok := requester.GetSession().(JWTSessionContainer); !ok {
 		return "", "", errors.Errorf("Session must be of type JWTSessionContainer but got type: %T", requester.GetSession())
-	} else if jwtSession.GetJWTClaims() == nil {
+	} else if claims := jwtSession.GetJWTClaims(); claims == nil {
 		return "", "", errors.New("GetTokenClaims() must not be nil")
 	} else {
-		claims := jwtSession.GetJWTClaims().
+		claims.
 			With(
 				jwtSession.GetExpiresAt(tokenType),
 				requester.GetGrantedScopes(),

--- a/handler/openid/strategy_jwt.go
+++ b/handler/openid/strategy_jwt.go
@@ -36,8 +36,8 @@ type DefaultSession struct {
 	Claims    *jwt.IDTokenClaims             `json:"id_token_claims"`
 	Headers   *jwt.Headers                   `json:"headers"`
 	ExpiresAt map[fosite.TokenType]time.Time `json:"expires_at"`
-	Username  string                         `json:"username"`
-	Subject   string                         `json:"subject"`
+	Username  string                         `json:"username,omitempty"`
+	Subject   string                         `json:"subject,omitempty"`
 }
 
 func NewDefaultSession() *DefaultSession {


### PR DESCRIPTION
If someone stores the session as JSON (as we do in Hydra), omitting empty keys can slightly reduce the storage size, while resulting in the exact same behavior.