### PR TITLE
feat: support dynamic port matching for localhost redirect URIs

### DIFF
--- a/authorize_helper.go
+++ b/authorize_helper.go
@@ -141,8 +141,11 @@ func isMatchingAsLoopback(requested *url.URL, registeredURI string) bool {
 	return false
 }
 
-// Check if address is either an IPv4 loopback or an IPv6 loopback.
+// Check if address is either an IPv4 loopback, an IPv6 loopback, or localhost.
 func isLoopbackAddress(hostname string) bool {
+	if hostname == "localhost" {
+		return true
+	}
 	return net.ParseIP(hostname).IsLoopback()
 }
 

--- a/authorize_helper_test.go
+++ b/authorize_helper_test.go
@@ -213,6 +213,28 @@ func TestDoesClientWhiteListRedirect(t *testing.T) {
 			isError:  false,
 			expected: "https://google.com/?foo=bar%20foo+baz",
 		},
+		{
+			client:   &fosite.DefaultClient{RedirectURIs: []string{"http://localhost/callback"}},
+			url:      "http://localhost:9999/callback",
+			expected: "http://localhost:9999/callback",
+			isError:  false,
+		},
+		{
+			client:   &fosite.DefaultClient{RedirectURIs: []string{"http://localhost/callback"}},
+			url:      "http://localhost/callback",
+			expected: "http://localhost/callback",
+			isError:  false,
+		},
+		{
+			client:  &fosite.DefaultClient{RedirectURIs: []string{"http://127.0.0.1/callback"}},
+			url:     "http://localhost:9999/callback",
+			isError: true,
+		},
+		{
+			client:  &fosite.DefaultClient{RedirectURIs: []string{"http://localhost/callback"}},
+			url:     "http://127.0.0.1:9999/callback",
+			isError: true,
+		},
 	} {
 		redir, err := fosite.MatchRedirectURIWithClientRedirectURIs(c.url, c.client)
 		assert.Equal(t, c.isError, err != nil, "%d: %+v", k, c)


### PR DESCRIPTION
Add `localhost` handling to `isLoopbackAddress` so that native OAuth 2.0 clients registering `http://localhost/callback` can use dynamic ports (e.g. `http://localhost:54321/callback`) for loopback redirect URIs.

Previously, `isLoopbackAddress` only used `net.ParseIP` which returns `nil` for the hostname `"localhost"`, preventing port-flexible loopback matching. The existing hostname equality check in `isMatchingAsLoopback` prevents cross-matching between `localhost` and IP literals.

## Related Issue or Design Document

#873

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [x] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [x] I confirm that this pull request does not address a security vulnerability.
      If this pull request addresses a security vulnerability,
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added the necessary documentation within the code base (if appropriate).

## Further comments

RFC 8252 §7.3 strictly defines loopback redirect URIs using IP literals only, and [§8.3](https://tools.ietf.org/html/rfc8252#section-8.3) says `localhost` is NOT RECOMMENDED. However, Fosite already accepts `localhost` as a valid loopback host for transport security purposes via `IsLocalhost`. This one-line change aligns `isLoopbackAddress` (used for port matching) with that existing decision, unblocking real-world MCP/OAuth clients that register `http://localhost/callback` by convention.

**Test cases added:**
- `http://localhost:9999/callback` matches registered `http://localhost/callback` (dynamic port)
- `http://localhost/callback` matches itself (exact match)
- `http://localhost:9999/callback` does NOT match registered `http://127.0.0.1/callback` (hostname mismatch)
- `http://127.0.0.1:9999/callback` does NOT match registered `http://localhost/callback` (hostname mismatch)