### PR TITLE
fix: reject jwt-bearer assertions with future iat claim

### DIFF
--- a/handler/rfc7523/handler.go
+++ b/handler/rfc7523/handler.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Ory Corp
+// Copyright © 2026 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 package rfc7523
@@ -261,6 +261,15 @@ func (c *Handler) validateTokenClaims(ctx context.Context, claims jwt.Claims, ke
 	if !c.Config.GetGrantTypeJWTBearerIssuedDateOptional(ctx) && claims.IssuedAt == nil {
 		return errorsx.WithStack(fosite.ErrInvalidGrant.
 			WithHint("The JWT in \"assertion\" request parameter MUST contain an \"iat\" (issued at) claim."),
+		)
+	}
+
+	if claims.IssuedAt != nil && claims.IssuedAt.Time().After(time.Now()) {
+		return errorsx.WithStack(fosite.ErrInvalidGrant.
+			WithHintf(
+				"The JWT in \"assertion\" request parameter contains an \"iat\" (issued at) claim with value \"%s\" that is in the future.",
+				claims.IssuedAt.Time().Format(time.RFC3339),
+			),
 		)
 	}
 

--- a/handler/rfc7523/handler_test.go
+++ b/handler/rfc7523/handler_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2025 Ory Corp
+// Copyright © 2026 Ory Corp
 // SPDX-License-Identifier: Apache-2.0
 
 package rfc7523
@@ -432,6 +432,36 @@ func (s *AuthorizeJWTGrantRequestHandlerTestSuite) TestAssertionWithoutRequiredI
 	s.EqualError(err, fosite.ErrInvalidGrant.Error(), "expected error, because of missing iat claim in assertion")
 	s.Equal(
 		"The JWT in \"assertion\" request parameter MUST contain an \"iat\" (issued at) claim.",
+		fosite.ErrorToRFC6749Error(err).HintField,
+	)
+}
+
+func (s *AuthorizeJWTGrantRequestHandlerTestSuite) TestAssertionWithIssueDateInFuture() {
+	// arrange
+	ctx := context.Background()
+	s.accessRequest.GrantTypes = []string{grantTypeJWTBearer}
+	keyID := "my_key"
+	pubKey := s.createJWK(s.privateKey.Public(), keyID)
+	issuedAt := time.Now().Add(time.Hour)
+	cl := s.createStandardClaim()
+	cl.IssuedAt = jwt.NewNumericDate(issuedAt)
+	cl.Expiry = jwt.NewNumericDate(issuedAt.Add(time.Minute))
+	s.handler.Config.(*fosite.Config).GrantTypeJWTBearerIssuedDateOptional = false
+	s.handler.Config.(*fosite.Config).GrantTypeJWTBearerMaxDuration = time.Hour * 24 * 30
+	s.accessRequest.Form.Add("assertion", s.createTestAssertion(cl, keyID))
+	s.mockStore.EXPECT().GetPublicKey(ctx, cl.Issuer, cl.Subject, keyID).Return(&pubKey, nil)
+
+	// act
+	err := s.handler.HandleTokenEndpointRequest(ctx, s.accessRequest)
+
+	// assert
+	s.True(errors.Is(err, fosite.ErrInvalidGrant))
+	s.EqualError(err, fosite.ErrInvalidGrant.Error(), "expected error, because iat claim in assertion is in the future")
+	s.Equal(
+		fmt.Sprintf(
+			"The JWT in \"assertion\" request parameter contains an \"iat\" (issued at) claim with value \"%s\" that is in the future.",
+			cl.IssuedAt.Time().Format(time.RFC3339),
+		),
 		fosite.ErrorToRFC6749Error(err).HintField,
 	)
 }


### PR DESCRIPTION
Rejects `urn:ietf:params:oauth:grant-type:jwt-bearer` assertions whose `iat` claim is in the future. Previously the max-duration check used `exp - iat`, so a token with `iat` set far ahead would always satisfy the bound regardless of `exp`.

## Related Issue or Design Document

Closes #853

## Checklist

- [x] I have read the [contributing guidelines](../blob/master/CONTRIBUTING.md) and signed the CLA.
- [ ] I have referenced an issue containing the design document if my change introduces a new feature.
- [x] I have read the [security policy](../security/policy).
- [ ] I confirm that this pull request does not address a security vulnerability. 
      If this pull request addresses a security vulnerability, 
      I confirm that I got approval (please contact [security@ory.sh](mailto:security@ory.sh)) from the maintainers to push the changes.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added the necessary documentation within the code base (if appropriate).

## Further comments

The bug is described in the public issue #853 (open since April 2025); the reporter notes the implications are minor (long-lived JTIs accumulating in storage). The fix mirrors the existing `nbf` validation pattern in the same function.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * JWT validation now rejects assertions whose "issued-at" (iat) claim is set in the future, preventing acceptance of improperly timestamped tokens and improving authentication correctness.

* **Tests**
  * Added test coverage to verify JWT assertions with future-dated "iat" claims are correctly rejected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ory/fosite/pull/877)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->