### PR TITLE
fix: parse aud claim from []interface{} in JWTClaims.FromMap

### DIFF
--- a/token/jwt/claims_jwt.go
+++ b/token/jwt/claims_jwt.go
@@ -159,10 +159,18 @@ func (c *JWTClaims) FromMap(m map[string]interface{}) {
 				c.Issuer = s
 			}
 		case "aud":
-			if s, ok := v.(string); ok {
-				c.Audience = []string{s}
-			} else if s, ok := v.([]string); ok {
-				c.Audience = s
+			switch aud := v.(type) {
+			case string:
+				c.Audience = []string{aud}
+			case []string:
+				c.Audience = aud
+			case []interface{}:
+				c.Audience = make([]string, 0, len(aud))
+				for _, a := range aud {
+					if s, ok := a.(string); ok {
+						c.Audience = append(c.Audience, s)
+					}
+				}
 			}
 		case "iat":
 			c.IssuedAt = toTime(v, c.IssuedAt)

--- a/token/jwt/claims_jwt_test.go
+++ b/token/jwt/claims_jwt_test.go
@@ -73,6 +73,26 @@ func TestClaimsFromMap(t *testing.T) {
 	assert.Equal(t, jwtClaims, &claims)
 }
 
+func TestClaimsFromMapAudienceInterfaceSlice(t *testing.T) {
+	// A JWT decoded into MapClaims carries a multi-value aud as []interface{}
+	// (JSON arrays never decode to []string), which is what introspection feeds
+	// back through FromMap. The audience must survive that round-trip.
+	var claims JWTClaims
+	claims.FromMap(map[string]interface{}{
+		"aud": []interface{}{"aud-1", "aud-2"},
+	})
+	assert.Equal(t, []string{"aud-1", "aud-2"}, claims.Audience)
+}
+
+func TestClaimsFromMapAudienceString(t *testing.T) {
+	// A single-valued aud may be encoded as a bare string per RFC 7519.
+	var claims JWTClaims
+	claims.FromMap(map[string]interface{}{
+		"aud": "aud-1",
+	})
+	assert.Equal(t, []string{"aud-1"}, claims.Audience)
+}
+
 func TestScopeFieldString(t *testing.T) {
 	jwtClaimsWithString := jwtClaims.WithScopeField(JWTScopeFieldString)
 	// Making a copy of jwtClaimsMap.


### PR DESCRIPTION
## Summary

`JWTClaims.FromMap` drops the `aud` claim when it is encoded as a JSON array, leaving `JWTClaims.Audience` empty.

## Details

When a JWT is decoded into `MapClaims` (`map[string]interface{}`) — which is what `DefaultSigner.Decode` produces and what stateless JWT introspection (`AccessTokenJWTToRequest` → `FromMapClaims` → `FromMap`) feeds back in — a multi-value `aud` claim arrives as `[]interface{}`, because JSON arrays never unmarshal to `[]string`. The current `case "aud"` only handles `string` and `[]string`:

```go
case "aud":
    if s, ok := v.(string); ok {
        c.Audience = []string{s}
    } else if s, ok := v.([]string); ok {
        c.Audience = s
    }
```

So a token issued with `aud: ["foo"]` round-trips through introspection with an **empty** `Audience` (and, via `AccessTokenJWTToRequest`, an empty `GrantedAudience`/`RequestedAudience`). Any resource server that classifies or authorizes a token by reading the introspected session's audience silently sees no audience.

Note `ToMap` always emits `aud` as an array (`ret["aud"] = c.Audience`), so the array form is the common case on the wire — this isn't an edge case.

## Fix

Handle `[]interface{}` in the `aud` case, exactly as the neighbouring `scp` case already does:

```go
case "aud":
    switch aud := v.(type) {
    case string:
        c.Audience = []string{aud}
    case []string:
        c.Audience = aud
    case []interface{}:
        c.Audience = make([]string, 0, len(aud))
        for _, a := range aud {
            if s, ok := a.(string); ok {
                c.Audience = append(c.Audience, s)
            }
        }
    }
```

## Tests

Added `TestClaimsFromMapAudienceInterfaceSlice` (the `[]interface{}` round-trip) and `TestClaimsFromMapAudienceString` (bare-string `aud` per RFC 7519) in `token/jwt/claims_jwt_test.go`. Existing tests still cover the `[]string` path.

No behaviour change for `string` or `[]string` inputs; this only recovers audiences that were previously dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT audience claim handling when values are provided as multiple entries or a single string.
  * Non-string audience entries are safely ignored during conversion.

* **Tests**
  * Added coverage for single-value and multi-value audience claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->